### PR TITLE
Use https instead of ssh to fetch from upstream LLVM in workflow

### DIFF
--- a/.github/workflows/sync_from_upstream.yml
+++ b/.github/workflows/sync_from_upstream.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         branch: [main, release/19.x]
     env:
-      UPSTREAM_REMOTE: git@github.com:llvm/llvm-project.git
+      UPSTREAM_REMOTE: https://github.com/llvm/llvm-project.git
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This updates the sync_from_upstream.yml workflow to use HTTPS instead of
SSH to fetch changes from upstream LLVM, as the workflow runner doesn't
have access to the external repository via ssh.
