### PR TITLE
Adjust sync_to_upstream to use App Token for authentication

### DIFF
--- a/.github/workflows/sync_from_upstream.yml
+++ b/.github/workflows/sync_from_upstream.yml
@@ -14,10 +14,17 @@ jobs:
     env:
       UPSTREAM_REMOTE: https://github.com/llvm/llvm-project.git
     steps:
+      - name: Configure Access Token
+        uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app-id: ${{ secrets.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
+          token: ${{ steps.generate-token.outputs.token }}
       - name: Configure Upstream Remote
         run: git remote add upstream ${{ env.UPSTREAM_REMOTE }}
       - name: Fetch Upstream Changes


### PR DESCRIPTION
Incoming commits from upstream may contain changes to the `.github`
directory, but GitHub workflows are not allowed to modify these contents
by default.
To allow such commits to be fetched from upstream successfully, this
adjusts the sync_from_upstream.yml workflow to use a GitHub App token
for authentication when checking out the repo.
