### PR TITLE
Allow sync and automerge workflows to be triggered manually

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -7,6 +7,7 @@ on:
     workflows: [Sync from Upstream LLVM]
     types:
       - completed
+  workflow_dispatch:
 jobs:
   Run-Automerge:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync_from_upstream.yml
+++ b/.github/workflows/sync_from_upstream.yml
@@ -5,6 +5,7 @@ name: Sync from Upstream LLVM
 on:
   schedule:
     - cron: '0,30 * * * *'
+  workflow_dispatch:
 jobs:
   Fetch-Upstream:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This ads an extra `workflow_dispatch` event to the list of `on` triggers
of the `sync_from_upstream` and `automerge` workflow, giving the option
to run these manually from GitHub's web interface.
