### PR TITLE
Add scripts to run builds and tests for ATfE

### DIFF
--- a/arm-software/embedded/scripts/build.bat
+++ b/arm-software/embedded/scripts/build.bat
@@ -1,0 +1,13 @@
+
+REM A bat script to build the Arm Toolchain for Embedded
+
+set SCRIPT_DIR=%~dp0
+for /f %%i in ('git -C %SCRIPT_DIR% rev-parse --show-toplevel') do set REPO_ROOT=%%i
+
+vcvars64.bat
+
+mkdir build
+cd build
+
+cmake %REPO_ROOT%\arm-software\embedded -GNinja -DFETCHCONTENT_QUIET=OFF
+ninja package-llvm-toolchain

--- a/arm-software/embedded/scripts/build.sh
+++ b/arm-software/embedded/scripts/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# A bash script to build the Arm Toolchain for Embedded
+
+set -ex
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( git -C ${SCRIPT_DIR} rev-parse --show-toplevel )
+
+clang --version
+
+export CC=clang
+export CXX=clang++
+
+mkdir build
+cd build
+
+cmake ${REPO_ROOT}/arm-software/embedded -GNinja -DFETCHCONTENT_QUIET=OFF
+ninja package-llvm-toolchain

--- a/arm-software/embedded/scripts/test.bat
+++ b/arm-software/embedded/scripts/test.bat
@@ -1,0 +1,7 @@
+
+REM A bat script to run the tests from the Arm Toolchain for Embedded
+
+vcvars64.bat
+
+cd arm-toolchain\build
+ninja check-llvm-toolchain

--- a/arm-software/embedded/scripts/test.sh
+++ b/arm-software/embedded/scripts/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# A bash script to run the tests from the Arm Toolchain for Embedded
+
+cd arm-toolchain/build
+ninja check-llvm-toolchain


### PR DESCRIPTION
This introduces a set of bash and batch scripts to run builds and tests
for the Arm Toolchain For Embedded. These scripts can be used for
building the toolchain from source, and will be used by CI in the
future.
