### PR TITLE
Fix build directory for ATfE's build and test scripts

### DIFF
--- a/arm-software/embedded/scripts/build.bat
+++ b/arm-software/embedded/scripts/build.bat
@@ -1,13 +1,16 @@
 
 REM A bat script to build the Arm Toolchain for Embedded
 
+REM The script creates a build of the toolchain in the 'build' directory, inside
+REM the repository tree.
+
 set SCRIPT_DIR=%~dp0
 for /f %%i in ('git -C %SCRIPT_DIR% rev-parse --show-toplevel') do set REPO_ROOT=%%i
 
 vcvars64.bat
 
-mkdir build
-cd build
+mkdir %REPO_ROOT%\build
+cd %REPO_ROOT%\build
 
-cmake %REPO_ROOT%\arm-software\embedded -GNinja -DFETCHCONTENT_QUIET=OFF
+cmake ..\arm-software\embedded -GNinja -DFETCHCONTENT_QUIET=OFF
 ninja package-llvm-toolchain

--- a/arm-software/embedded/scripts/build.sh
+++ b/arm-software/embedded/scripts/build.sh
@@ -2,6 +2,9 @@
 
 # A bash script to build the Arm Toolchain for Embedded
 
+# The script creates a build of the toolchain in the 'build' directory, inside
+# the repository tree.
+
 set -ex
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
@@ -12,8 +15,8 @@ clang --version
 export CC=clang
 export CXX=clang++
 
-mkdir build
-cd build
+mkdir -p ${REPO_ROOT}/build
+cd ${REPO_ROOT}/build
 
-cmake ${REPO_ROOT}/arm-software/embedded -GNinja -DFETCHCONTENT_QUIET=OFF
+cmake ../arm-software/embedded -GNinja -DFETCHCONTENT_QUIET=OFF
 ninja package-llvm-toolchain

--- a/arm-software/embedded/scripts/test.bat
+++ b/arm-software/embedded/scripts/test.bat
@@ -1,7 +1,13 @@
 
 REM A bat script to run the tests from the Arm Toolchain for Embedded
 
+REM The script assumes a successful build of the toolchain exists in the 'build'
+REM directory inside the repository tree.
+
+set SCRIPT_DIR=%~dp0
+for /f %%i in ('git -C %SCRIPT_DIR% rev-parse --show-toplevel') do set REPO_ROOT=%%i
+
 vcvars64.bat
 
-cd arm-toolchain\build
+cd %REPO_ROOT%\build
 ninja check-llvm-toolchain

--- a/arm-software/embedded/scripts/test.sh
+++ b/arm-software/embedded/scripts/test.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
-# A bash script to run the tests from the Arm Toolchain for Embedded
+# A bash script to run the tests from the Arm Toolchain for Embedded.
 
-cd arm-toolchain/build
+# The script assumes a successful build of the toolchain exists in the 'build'
+# directory inside the repository tree.
+
+set -ex
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( git -C ${SCRIPT_DIR} rev-parse --show-toplevel )
+
+cd ${REPO_ROOT}/build
 ninja check-llvm-toolchain


### PR DESCRIPTION
This fixes the build directory used by the Arm Toolchain for Embedded's
build and test scripts, ensuring the directory is consistent across
them.
