### PR TITLE
Ensure variant names are unique and match filenames

### DIFF
--- a/arm-software/embedded/arm-multilib/json/variants/armv6m_soft_nofp_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv6m_soft_nofp_exn_rtti_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv6m",
-            "VARIANT": "armv6m_soft_nofp_exn_rtti",
+            "VARIANT": "armv6m_soft_nofp_exn_rtti_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv6m -mfpu=none",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",

--- a/arm-software/embedded/arm-multilib/json/variants/armv6m_soft_nofp_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv6m_soft_nofp_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv6m",
-            "VARIANT": "armv6m_soft_nofp",
+            "VARIANT": "armv6m_soft_nofp_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv6m -mfpu=none",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_hard_vfpv3_d16_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_hard_vfpv3_d16_exn_rtti_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7a",
-            "VARIANT": "armv7a_hard_vfpv3_d16_exn_rtti",
+            "VARIANT": "armv7a_hard_vfpv3_d16_exn_rtti_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv7a -mfpu=vfpv3-d16",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_hard_vfpv3_d16_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_hard_vfpv3_d16_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7a",
-            "VARIANT": "armv7a_hard_vfpv3_d16",
+            "VARIANT": "armv7a_hard_vfpv3_d16_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv7a -mfpu=vfpv3-d16",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_nofp_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_nofp_exn_rtti_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7a",
-            "VARIANT": "armv7a_soft_nofp_exn_rtti",
+            "VARIANT": "armv7a_soft_nofp_exn_rtti_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv7a -mfpu=none",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_nofp_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_nofp_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7a",
-            "VARIANT": "armv7a_soft_nofp",
+            "VARIANT": "armv7a_soft_nofp_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv7a -mfpu=none",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_vfpv3_d16_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_vfpv3_d16_exn_rtti_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7a",
-            "VARIANT": "armv7a_soft_vfpv3_d16_exn_rtti",
+            "VARIANT": "armv7a_soft_vfpv3_d16_exn_rtti_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=softfp -march=armv7a -mfpu=vfpv3-d16",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_vfpv3_d16_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_vfpv3_d16_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7a",
-            "VARIANT": "armv7a_soft_vfpv3_d16",
+            "VARIANT": "armv7a_soft_vfpv3_d16_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=softfp -march=armv7a -mfpu=vfpv3-d16",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv7m_hard_fpv4_sp_d16_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7m_hard_fpv4_sp_d16_exn_rtti_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7m",
-            "VARIANT": "armv7m_hard_fpv4_sp_d16_exn_rtti",
+            "VARIANT": "armv7m_hard_fpv4_sp_d16_exn_rtti_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv7m -mfpu=fpv4-sp-d16",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",

--- a/arm-software/embedded/arm-multilib/json/variants/armv7m_hard_fpv4_sp_d16_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7m_hard_fpv4_sp_d16_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7m",
-            "VARIANT": "armv7m_hard_fpv4_sp_d16",
+            "VARIANT": "armv7m_hard_fpv4_sp_d16_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv7m -mfpu=fpv4-sp-d16",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_fpv4_sp_d16_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_fpv4_sp_d16_exn_rtti_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7m",
-            "VARIANT": "armv7m_soft_fpv4_sp_d16_exn_rtti",
+            "VARIANT": "armv7m_soft_fpv4_sp_d16_exn_rtti_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=softfp -march=armv7m -mfpu=fpv4-sp-d16",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",

--- a/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_fpv4_sp_d16_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_fpv4_sp_d16_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7m",
-            "VARIANT": "armv7m_soft_fpv4_sp_d16",
+            "VARIANT": "armv7m_soft_fpv4_sp_d16_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=softfp -march=armv7m -mfpu=fpv4-sp-d16",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_nofp_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_nofp_exn_rtti_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7m",
-            "VARIANT": "armv7m_soft_nofp_exn_rtti",
+            "VARIANT": "armv7m_soft_nofp_exn_rtti_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv7m -mfpu=none",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",

--- a/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_nofp_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_nofp_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7m",
-            "VARIANT": "armv7m_soft_nofp",
+            "VARIANT": "armv7m_soft_nofp_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv7m -mfpu=none",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3_d16_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3_d16_exn_rtti_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7r",
-            "VARIANT": "armv7r_hard_vfpv3_d16_exn_rtti",
+            "VARIANT": "armv7r_hard_vfpv3_d16_exn_rtti_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv7r -mfpu=vfpv3-d16",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3_d16_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3_d16_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7r",
-            "VARIANT": "armv7r_hard_vfpv3_d16",
+            "VARIANT": "armv7r_hard_vfpv3_d16_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv7r -mfpu=vfpv3-d16",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3xd_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3xd_exn_rtti_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7r",
-            "VARIANT": "armv7r_hard_vfpv3xd_exn_rtti",
+            "VARIANT": "armv7r_hard_vfpv3xd_exn_rtti_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv7r -mfpu=vfpv3xd",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3xd_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3xd_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7r",
-            "VARIANT": "armv7r_hard_vfpv3xd",
+            "VARIANT": "armv7r_hard_vfpv3xd_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv7r -mfpu=vfpv3xd",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_nofp_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_nofp_exn_rtti_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7r",
-            "VARIANT": "armv7r_soft_nofp_exn_rtti",
+            "VARIANT": "armv7r_soft_nofp_exn_rtti_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv7r -mfpu=none",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_nofp_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_nofp_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7r",
-            "VARIANT": "armv7r_soft_nofp",
+            "VARIANT": "armv7r_soft_nofp_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv7r -mfpu=none",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_vfpv3xd_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_vfpv3xd_exn_rtti_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7r",
-            "VARIANT": "armv7r_soft_vfpv3xd_exn_rtti",
+            "VARIANT": "armv7r_soft_vfpv3xd_exn_rtti_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=softfp -march=armv7r -mfpu=vfpv3xd",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_vfpv3xd_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_vfpv3xd_unaligned.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "armv7r",
-            "VARIANT": "armv7r_soft_vfpv3xd",
+            "VARIANT": "armv7r_soft_vfpv3xd_unaligned",
             "COMPILE_FLAGS": "-mfloat-abi=softfp -march=armv7r -mfpu=vfpv3xd",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",


### PR DESCRIPTION
Each variant has a name property which should match the filename, however there are a number of variants where differences have crept in. In particular, the "unaligned" suffix appears missing in many cases.