### PR TITLE
Read Git repository URL from versions.json

### DIFF
--- a/arm-software/embedded/cmake/fetch_newlib.cmake
+++ b/arm-software/embedded/cmake/fetch_newlib.cmake
@@ -14,7 +14,7 @@ read_repo_version(newlib newlib)
 get_patch_command(${CMAKE_CURRENT_LIST_DIR}/.. newlib newlib_patch_command)
 
 FetchContent_Declare(newlib
-    GIT_REPOSITORY https://sourceware.org/git/newlib-cygwin.git
+    GIT_REPOSITORY "${newlib_URL}"
     GIT_TAG "${newlib_TAG}"
     GIT_SHALLOW "${newlib_SHALLOW}"
     GIT_PROGRESS TRUE

--- a/arm-software/embedded/cmake/fetch_picolibc.cmake
+++ b/arm-software/embedded/cmake/fetch_picolibc.cmake
@@ -14,7 +14,7 @@ read_repo_version(picolibc picolibc)
 get_patch_command(${CMAKE_CURRENT_LIST_DIR}/.. picolibc picolibc_patch_command)
 
 FetchContent_Declare(picolibc
-    GIT_REPOSITORY https://github.com/picolibc/picolibc.git
+    GIT_REPOSITORY "${picolibc_URL}"
     GIT_TAG "${picolibc_TAG}"
     GIT_SHALLOW "${picolibc_SHALLOW}"
     GIT_PROGRESS TRUE

--- a/arm-software/embedded/cmake/read_versions.cmake
+++ b/arm-software/embedded/cmake/read_versions.cmake
@@ -1,6 +1,7 @@
 # Read which revisions of the repos to use.
 file(READ ${CMAKE_CURRENT_LIST_DIR}/../versions.json VERSIONS_JSON)
 function(read_repo_version output_variable_prefix repo)
+    string(JSON url GET ${VERSIONS_JSON} "repos" "${repo}" "url")
     string(JSON tag GET ${VERSIONS_JSON} "repos" "${repo}" "tag")
     string(JSON tagType GET ${VERSIONS_JSON} "repos" "${repo}" "tagType")
     if(tagType STREQUAL "commithash")
@@ -17,6 +18,7 @@ function(read_repo_version output_variable_prefix repo)
         message(FATAL_ERROR "Unrecognised tagType ${tagType}")
     endif()
 
+    set(${output_variable_prefix}_URL "${url}" PARENT_SCOPE)
     set(${output_variable_prefix}_TAG "${tag}" PARENT_SCOPE)
     set(${output_variable_prefix}_SHALLOW "${shallow}" PARENT_SCOPE)
 endfunction()

--- a/arm-software/embedded/versions.json
+++ b/arm-software/embedded/versions.json
@@ -1,16 +1,18 @@
 {
   "comment": [
-    "Release branches of Arm Toolchain for Embedded for Arm will use",
+    "Release branches of Arm Toolchain for Embedded will use",
     "specific revisions of the repos it depends on. This file provides",
     "a single source of truth for which revisions to use that can be",
     "queried by CMake and other automation software."
   ],
   "repos": {
     "picolibc": {
+      "url": "https://github.com/picolibc/picolibc.git",
       "tagType": "branch",
       "tag": "main"
     },
     "newlib": {
+      "url": "https://sourceware.org/git/newlib-cygwin.git",
       "tagType": "tag",
       "tag": "newlib-4.5.0"
     }


### PR DESCRIPTION
Currently, the location of the Git repository for dependencies is hard-codedinto the FetchContent. This patch instead reads it from the existing versions.json file, if a different location is desired - for example, using a mirror of the repo.