### PR TITLE
automerge: make error-message formatting less amusing.

### DIFF
--- a/arm-software/ci/automerge.py
+++ b/arm-software/ci/automerge.py
@@ -8,6 +8,7 @@ in upstream LLVM into a downstream branch.
 import argparse
 import json
 import logging
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -206,7 +207,7 @@ def main():
     except subprocess.CalledProcessError as error:
         logger.error(
             'Failed to run command: "%s"\nstdout:\n%s\nstderr:\n%s',
-            " ".join(str(error.cmd)),
+            shlex.join(error.cmd),
             error.stdout,
             error.stderr,
         )


### PR DESCRIPTION
The automerge script failed just now (for a benign transient reason), and printed this:

ERROR: Failed to run command: "[ ' g i t ' ,   ' - C ' ,   ' / h o m e / r u n n e r / w o r k / a r m - t o o l c h a i n / a r m - t o o l c h a i n ' ,   ' p u s h ' ,   ' o r i g i n ' ,   ' a r m - s o f t w a r e ' ]"

because `error.cmd` was a list of strings, and the error message tried to format it using `" ".join(str(error.cmd))`, which first converted the list into a single string the same way `__repr__` would have done it (displaying the list in Python syntax with strings quoted), and then applied `" ".join` to the resulting string, which caused it to be treated as a list of characters, and each pair of characters separated with a space.

The sensible way to format a shell command in list-of-strings format is `shlex.join`. Funny as the above is, let's use that instead :-)