### PR TITLE
Run GitHub Actions on ARM processors

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 jobs:
   Run-Automerge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     env:
       FROM_BRANCH: main
       TO_BRANCH: arm-software

--- a/.github/workflows/sync_from_upstream.yml
+++ b/.github/workflows/sync_from_upstream.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   Fetch-Upstream:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         branch: [main, release/19.x]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Welcome to the Arm Toolchain project!
 This repository contains the source code for the Arm Toolchain
 project, a fork of the LLVM project containing build scripts and
 auxiliary material for building LLVM based toolchains targeting
-Arm for bare-metal or native AArch64 Linux environments. 
+Arm for bare-metal or native AArch64 Linux environments.
 
 ## Goal
 


### PR DESCRIPTION
[Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) --> `ubuntu-24.04-arm`