### PR TITLE
Add Arm copyright notices to samples

### DIFF
--- a/arm-software/embedded/newlib-samples/src/baremetal-semihosting-newlib/hello.c
+++ b/arm-software/embedded/newlib-samples/src/baremetal-semihosting-newlib/hello.c
@@ -1,3 +1,9 @@
+/* Copyright (c) 2025, Arm Limited and affiliates.
+ *
+ * Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */
+ 
 #include <stdio.h>
 
 int main(void) {

--- a/arm-software/embedded/newlib-samples/src/cpp-baremetal-semihosting-newlib/hello.cpp
+++ b/arm-software/embedded/newlib-samples/src/cpp-baremetal-semihosting-newlib/hello.cpp
@@ -1,3 +1,9 @@
+/* Copyright (c) 2025, Arm Limited and affiliates.
+ *
+ * Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */
+
 // Include as many C++17 headers as possible.
 // Unsupported headers are commented out.
 #include <algorithm>

--- a/arm-software/embedded/samples/src/baremetal-semihosting-aarch64/hello.c
+++ b/arm-software/embedded/samples/src/baremetal-semihosting-aarch64/hello.c
@@ -1,3 +1,9 @@
+/* Copyright (c) 2020-2025, Arm Limited and affiliates. 
+ *
+ * Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */
+
 #include <stdio.h>
 
 int main(void) {

--- a/arm-software/embedded/samples/src/baremetal-semihosting/hello.c
+++ b/arm-software/embedded/samples/src/baremetal-semihosting/hello.c
@@ -1,3 +1,9 @@
+/* Copyright (c) 2020-2025, Arm Limited and affiliates. 
+ *
+ * Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */
+
 #include <stdio.h>
 
 int main(void) {

--- a/arm-software/embedded/samples/src/baremetal-uart/hello.c
+++ b/arm-software/embedded/samples/src/baremetal-uart/hello.c
@@ -1,3 +1,9 @@
+/* Copyright (c) 2020-2025, Arm Limited and affiliates. 
+ *
+ * Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */
+
 #include <stdio.h>
 
 // https://infocenter.nordicsemi.com/pdf/nRF51_RM_v3.0.pdf sections 14.2 and 29.10

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-cfi/hello.cpp
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-cfi/hello.cpp
@@ -1,3 +1,9 @@
+/* Copyright (c) 2023-2025, Arm Limited and affiliates. 
+ *
+ * Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */
+
 #include <iostream>
 
 class Base {

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-exceptions/hello-exn.cpp
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-exceptions/hello-exn.cpp
@@ -1,3 +1,9 @@
+/* Copyright (c) 2024-2025, Arm Limited and affiliates. 
+ *
+ * Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */
+
 #include <iostream>
 
 int main(void) {

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-exceptions/hello.cpp
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-exceptions/hello.cpp
@@ -1,3 +1,9 @@
+/* Copyright (c) 2024-2025, Arm Limited and affiliates. 
+ *
+ * Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */
+
 #include <iostream>
 
 int main(void) {

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-prof/hello.cpp
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-prof/hello.cpp
@@ -1,3 +1,9 @@
+/* Copyright (c) 2023-2025, Arm Limited and affiliates. 
+ *
+ * Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */
+
 #include <iostream>
 #include <vector>
 

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-prof/proflib.c
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-prof/proflib.c
@@ -6,6 +6,8 @@
 |*
 \*===----------------------------------------------------------------------===*/
 
+// Copyright (c) 2023-2025, Arm Limited and affiliates.
+
 // This file is derived from various files in compiler-rt of the llvm-project,
 // see https://github.com/llvm/llvm-project/tree/main/compiler-rt/lib/profile
 

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-ubsan/hello.cpp
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-ubsan/hello.cpp
@@ -1,3 +1,9 @@
+/* Copyright (c) 2023-2025, Arm Limited and affiliates. 
+ *
+ * Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */
+
 #include <iostream>
 #include <limits>
 

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-ubsan/libubsan.cpp
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-ubsan/libubsan.cpp
@@ -1,3 +1,9 @@
+/* Copyright (c) 2023-2025, Arm Limited and affiliates. 
+ *
+ * Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting/hello.cpp
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting/hello.cpp
@@ -1,3 +1,9 @@
+/* Copyright (c) 2021-2025, Arm Limited and affiliates. 
+ *
+ * Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */
+
 #include <vector>
 #include <iostream>
 


### PR DESCRIPTION
Add missing Arm copyright notices to C and C++ files under the samples folders.