### PR TITLE
[ATfL] According to rpmfind, libzstd-static is available for RHEL9, so we should use it

### DIFF
--- a/arm-software/linux/build.sh-HOWTO.md
+++ b/arm-software/linux/build.sh-HOWTO.md
@@ -45,6 +45,7 @@ The following packages need to be installed (using `apt`):
 - `zlib-devel`
 - `zlib-static`
 - `zstd`
+- `libzstd-static` (since RHEL9)
 - `wget`
 - `mpfr`
 - `mpfr-devel`


### PR DESCRIPTION
This is to add support for compressed binaries. If this library is not
present, such support is silently disabled. We already have it enabled
in Ubuntu builds.