### PR TITLE
Reduce nesting of subproject build folders

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -181,6 +181,14 @@ set(LLVM_TOOLCHAIN_C_LIBRARY
 set_property(CACHE LLVM_TOOLCHAIN_C_LIBRARY
     PROPERTY STRINGS picolibc newlib llvmlibc)
 
+option(
+    SHORT_BUILD_PATHS
+    "Shorten the lengths of internal build paths, which may help with OS path
+    length limits. This replaces the variant suffixes in build directories with
+    index numbers, which is shorter but less descriptive."
+    OFF
+)
+
 # Previously, the LLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL option was
 # called LLVM_TOOLCHAIN_NEWLIB_OVERLAY_INSTALL. Detect a setting of
 # that name, in case it's in an existing CMakeCache.txt or command
@@ -600,10 +608,15 @@ if(NOT PREBUILT_TARGET_LIBRARIES)
     # LIST_SEPARATOR option will handle switching it back.
     string(REPLACE ";" "," ENABLE_VARIANTS_PASSTHROUGH "${LLVM_TOOLCHAIN_LIBRARY_VARIANTS}")
 
+    set(multilib_prefix ${CMAKE_BINARY_DIR}/multilib-builds)
+
     ExternalProject_Add(
         multilib-${LLVM_TOOLCHAIN_C_LIBRARY}
-        PREFIX ${CMAKE_BINARY_DIR}/multilib-builds
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/arm-multilib
+        STAMP_DIR ${multilib_prefix}/multilib/${LLVM_TOOLCHAIN_C_LIBRARY}-stamp
+        BINARY_DIR ${multilib_prefix}/multilib/${LLVM_TOOLCHAIN_C_LIBRARY}-build
+        DOWNLOAD_DIR ${multilib_prefix}/multilib/${LLVM_TOOLCHAIN_C_LIBRARY}-dl
+        TMP_DIR ${multilib_prefix}/multilib/${LLVM_TOOLCHAIN_C_LIBRARY}-tmp
         INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/llvm/${TARGET_LIBRARIES_DIR}${library_subdir}
         DEPENDS ${lib_tool_dependencies}
         CMAKE_ARGS
@@ -623,6 +636,8 @@ if(NOT PREBUILT_TARGET_LIBRARIES)
         -DFETCHCONTENT_SOURCE_DIR_PICOLIBC=${FETCHCONTENT_SOURCE_DIR_PICOLIBC}
         -DFETCHCONTENT_SOURCE_DIR_NEWLIB=${FETCHCONTENT_SOURCE_DIR_NEWLIB}
         -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        -DPROJECT_PREFIX=${multilib_prefix}
+        -DNUMERICAL_BUILD_NAMES=${SHORT_BUILD_PATHS}
         USES_TERMINAL_CONFIGURE TRUE
         USES_TERMINAL_BUILD TRUE
         LIST_SEPARATOR ,

--- a/arm-software/embedded/arm-multilib/CMakeLists.txt
+++ b/arm-software/embedded/arm-multilib/CMakeLists.txt
@@ -33,6 +33,12 @@ set(MULTILIB_JSON "" CACHE STRING "JSON file to load library definitions from.")
 set(ENABLE_VARIANTS "all" CACHE STRING "Semicolon separated list of variants to build, or \"all\". Must match entries in the json.")
 set(C_LIBRARY "picolibc" CACHE STRING "Which C library to use.")
 set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc newlib llvmlibc)
+set(PROJECT_PREFIX "${CMAKE_BINARY_DIR}/lib-builds" CACHE STRING "Directory to build subprojects in.")
+option(
+    NUMERICAL_BUILD_NAMES
+    "Instead of using the full variant name to label build directories, use an index number. This may help shorten paths."
+    OFF
+)
 set(LLVM_BINARY_DIR "" CACHE PATH "Path to LLVM toolchain build or install root.")
 set(LIBC_HDRGEN "" CACHE PATH "Path to prebuilt lbc-hdrgen if not included in LLVM binaries set by LLVM_BINARY_DIR")
 option(
@@ -249,9 +255,19 @@ foreach(lib_idx RANGE ${lib_count_dec})
                 endforeach()
             endif()
 
+            if(NUMERICAL_BUILD_NAMES)
+                set(runtimes_id ${lib_idx})
+                list(APPEND additional_cmake_args "-DVARIANT_BUILD_ID=${lib_idx}")
+            else()
+                set(runtimes_id ${variant})
+            endif()
+
             ExternalProject_Add(
                 runtimes-${variant}
-                PREFIX ${CMAKE_BINARY_DIR}/lib-builds
+                STAMP_DIR ${PROJECT_PREFIX}/runtimes/${runtimes_id}/stamp
+                BINARY_DIR ${PROJECT_PREFIX}/runtimes/${runtimes_id}/build
+                DOWNLOAD_DIR ${PROJECT_PREFIX}/runtimes/${runtimes_id}/dl
+                TMP_DIR ${PROJECT_PREFIX}/runtimes/${runtimes_id}/tmp
                 SOURCE_DIR ${TOOLCHAIN_SOURCE_DIR}/arm-runtimes
                 INSTALL_DIR ${destination_directory}
                 DEPENDS runtimes-depends
@@ -262,6 +278,7 @@ foreach(lib_idx RANGE ${lib_count_dec})
                 -DVARIANT_JSON=${variant_json_file}
                 -DC_LIBRARY=${C_LIBRARY}
                 -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                -DPROJECT_PREFIX=${PROJECT_PREFIX}
                 STEP_TARGETS build install
                 USES_TERMINAL_CONFIGURE FALSE
                 USES_TERMINAL_BUILD TRUE

--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -100,6 +100,9 @@ set(ENABLE_LIBCXX_TESTS ${ENABLE_LIBCXX_TESTS_def} CACHE BOOL "Enable libcxx tes
 set(LLVM_BINARY_DIR "" CACHE PATH "Path to LLVM toolchain root to build libraries with")
 set(LIBC_HDRGEN "" CACHE PATH "Path to prebuilt lbc-hdrgen if not included in LLVM binaries set by LLVM_BINARY_DIR")
 
+set(PROJECT_PREFIX "subproj" CACHE STRING "Directory to build subprojects in.")
+set(VARIANT_BUILD_ID "${VARIANT}" CACHE STRING "Name to use to identify build directories." )
+
 # Temporary location to collect the libraries as they are built.
 set(TEMP_LIB_DIR "${CMAKE_CURRENT_BINARY_DIR}/tmp_install")
 
@@ -264,6 +267,10 @@ endif()
 ExternalProject_Add(
     compiler_rt
     SOURCE_DIR ${llvmproject_src_dir}/compiler-rt
+    STAMP_DIR ${PROJECT_PREFIX}/compiler_rt/${VARIANT_BUILD_ID}/stamp
+    BINARY_DIR ${PROJECT_PREFIX}/compiler_rt/${VARIANT_BUILD_ID}/build
+    DOWNLOAD_DIR ${PROJECT_PREFIX}/compiler_rt/${VARIANT_BUILD_ID}/dl
+    TMP_DIR ${PROJECT_PREFIX}/compiler_rt/${VARIANT_BUILD_ID}/tmp
     INSTALL_DIR compiler-rt/install
     CMAKE_ARGS
     ${compiler_launcher_cmake_args}
@@ -382,6 +389,10 @@ if(C_LIBRARY STREQUAL picolibc)
 
     ExternalProject_Add(
         picolibc
+        STAMP_DIR ${PROJECT_PREFIX}/picolibc/${VARIANT_BUILD_ID}/stamp
+        BINARY_DIR ${PROJECT_PREFIX}/picolibc/${VARIANT_BUILD_ID}/build
+        DOWNLOAD_DIR ${PROJECT_PREFIX}/picolibc/${VARIANT_BUILD_ID}/dl
+        TMP_DIR ${PROJECT_PREFIX}/picolibc/${VARIANT_BUILD_ID}/tmp
         SOURCE_DIR ${picolibc_SOURCE_DIR}
         INSTALL_DIR ${TEMP_LIB_DIR}
         DEPENDS compiler_rt-install
@@ -486,6 +497,10 @@ if(C_LIBRARY STREQUAL newlib)
 
     ExternalProject_Add(
         newlib
+        STAMP_DIR ${PROJECT_PREFIX}/newlib/${VARIANT_BUILD_ID}/stamp
+        BINARY_DIR ${PROJECT_PREFIX}/newlib/${VARIANT_BUILD_ID}/build
+        DOWNLOAD_DIR ${PROJECT_PREFIX}/newlib/${VARIANT_BUILD_ID}/dl
+        TMP_DIR ${PROJECT_PREFIX}/newlib/${VARIANT_BUILD_ID}/tmp
         SOURCE_DIR ${newlib_SOURCE_DIR}
         INSTALL_DIR ${TEMP_LIB_DIR}
         CONFIGURE_COMMAND
@@ -611,6 +626,10 @@ if(C_LIBRARY STREQUAL llvmlibc)
 
     ExternalProject_Add(
         llvmlibc
+        STAMP_DIR ${PROJECT_PREFIX}/llvmlibc/${VARIANT_BUILD_ID}/stamp
+        BINARY_DIR ${PROJECT_PREFIX}/llvmlibc/${VARIANT_BUILD_ID}/build
+        DOWNLOAD_DIR ${PROJECT_PREFIX}/llvmlibc/${VARIANT_BUILD_ID}/dl
+        TMP_DIR ${PROJECT_PREFIX}/llvmlibc/${VARIANT_BUILD_ID}/tmp
         SOURCE_DIR ${llvmproject_src_dir}/runtimes
         INSTALL_DIR llvmlibc/install
         DEPENDS libc_hdrgen
@@ -650,6 +669,10 @@ if(C_LIBRARY STREQUAL llvmlibc)
 
     ExternalProject_Add(
         llvmlibc-support
+        STAMP_DIR ${PROJECT_PREFIX}/llvmlibc-support-stamp
+        BINARY_DIR ${PROJECT_PREFIX}/llvmlibc-support-build
+        DOWNLOAD_DIR ${PROJECT_PREFIX}/llvmlibc-support/${VARIANT_BUILD_ID}/dl
+        TMP_DIR ${PROJECT_PREFIX}/llvmlibc-support/${VARIANT_BUILD_ID}/tmp
         SOURCE_DIR ${TOOLCHAIN_SOURCE_DIR}/llvmlibc-support
         INSTALL_DIR ${TEMP_LIB_DIR}
         DEPENDS ${lib_tool_dependencies} llvmlibc-install
@@ -719,6 +742,10 @@ if(ENABLE_CXX_LIBS)
 
     ExternalProject_Add(
         cxxlibs
+        STAMP_DIR ${PROJECT_PREFIX}/cxxlibs/${VARIANT_BUILD_ID}/stamp
+        BINARY_DIR ${PROJECT_PREFIX}/cxxlibs/${VARIANT_BUILD_ID}/build
+        DOWNLOAD_DIR ${PROJECT_PREFIX}/cxxlibs/${VARIANT_BUILD_ID}/dl
+        TMP_DIR ${PROJECT_PREFIX}/cxxlibs/${VARIANT_BUILD_ID}/tmp
         SOURCE_DIR ${llvmproject_src_dir}/runtimes
         INSTALL_DIR ${TEMP_LIB_DIR}
         DEPENDS compiler_rt-install clib-install


### PR DESCRIPTION
Currently, each library library variant is built as a subproject, which in turn generate more subprojects within its build folder.

This patch instead uses a shared location for all subproject builds, to slightly reduce path lengths and make the structure more organized.

It also adds an option to avoid using the full variant name to label build folders, since this can make paths too long on systems with path length limits.