### PR TITLE
Add LLVM Exception to license notices

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -1,18 +1,9 @@
 #
-# Copyright (c) 2022, Arm Limited and affiliates.
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2022-2025, Arm Limited and affiliates.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 

--- a/arm-software/embedded/README.md
+++ b/arm-software/embedded/README.md
@@ -54,7 +54,7 @@ picolibc   | https://github.com/picolibc/picolibc
 
 ## License
 
-Content of this repository is licensed under Apache-2.0, see
+Content of this repository is licensed under Apache-2.0 with LLVM Exceptions, see
 [LICENSE.txt](LICENSE.txt). Individual patch files under the
 [patches](https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/tree/main/patches)
 folder may contain code under the upstream project license, if they are

--- a/arm-software/embedded/arm-multilib/CMakeLists.txt
+++ b/arm-software/embedded/arm-multilib/CMakeLists.txt
@@ -1,18 +1,9 @@
 #
-# Copyright (c) 2024, Arm Limited and affiliates.
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025, Arm Limited and affiliates.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 # CMake build for a multilib layout of library variants, with each

--- a/arm-software/embedded/arm-multilib/multilib.yaml.in
+++ b/arm-software/embedded/arm-multilib/multilib.yaml.in
@@ -1,18 +1,9 @@
 #
-# Copyright (c) 2023, Arm Limited and affiliates.
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023-2025, Arm Limited and affiliates.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 # If you're reading this file under the name 'multilib.yaml.in' in the

--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -1,18 +1,9 @@
 #
-# Copyright (c) 2024, Arm Limited and affiliates.
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2024-2025, Arm Limited and affiliates.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 # CMake build for a library variant, combining a chosen C library

--- a/arm-software/embedded/llvmlibc-samples/src/llvmlibc/baremetal-semihosting/Makefile
+++ b/arm-software/embedded/llvmlibc-samples/src/llvmlibc/baremetal-semihosting/Makefile
@@ -1,18 +1,8 @@
 #
-# Copyright (c) 2020-2024, Arm Limited and affiliates.
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright (c) 2020-2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 include ../../../Makefile.conf

--- a/arm-software/embedded/llvmlibc-samples/src/llvmlibc/baremetal-semihosting/crt0llvmlibc.c
+++ b/arm-software/embedded/llvmlibc-samples/src/llvmlibc/baremetal-semihosting/crt0llvmlibc.c
@@ -1,17 +1,8 @@
-// Copyright (c) 2024, Arm Limited and affiliates.
-// SPDX-License-Identifier: Apache-2.0
-
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-
-//    http://www.apache.org/licenses/LICENSE-2.0
-
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright (c) 2024-2025, Arm Limited and affiliates.
+//
+// Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <stddef.h>
 #include <stdlib.h>

--- a/arm-software/embedded/llvmlibc-samples/src/llvmlibc/baremetal-semihosting/hello.c
+++ b/arm-software/embedded/llvmlibc-samples/src/llvmlibc/baremetal-semihosting/hello.c
@@ -1,17 +1,8 @@
-// Copyright (c) 2024, Arm Limited and affiliates.
-// SPDX-License-Identifier: Apache-2.0
-
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-
-//    http://www.apache.org/licenses/LICENSE-2.0
-
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright (c) 2024-2025, Arm Limited and affiliates.
+//
+// Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <assert.h>
 #include <stdio.h>

--- a/arm-software/embedded/llvmlibc-samples/src/llvmlibc/baremetal-semihosting/vector.c
+++ b/arm-software/embedded/llvmlibc-samples/src/llvmlibc/baremetal-semihosting/vector.c
@@ -1,17 +1,8 @@
-// Copyright (c) 2024, Arm Limited and affiliates.
-// SPDX-License-Identifier: Apache-2.0
-
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-
-//    http://www.apache.org/licenses/LICENSE-2.0
-
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright (c) 2024-2025, Arm Limited and affiliates.
+//
+// Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <stdlib.h>
 #include <stdint.h>

--- a/arm-software/embedded/llvmlibc-support/CMakeLists.txt
+++ b/arm-software/embedded/llvmlibc-support/CMakeLists.txt
@@ -1,18 +1,8 @@
 #
-# Copyright (c) 2022, Arm Limited and affiliates.
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright (c) 2022-2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 # This directory builds two additional library files to go with llvm-libc:

--- a/arm-software/embedded/llvmlibc-support/crt0.c
+++ b/arm-software/embedded/llvmlibc-support/crt0.c
@@ -1,18 +1,9 @@
 //
-// Copyright (c) 2022, Arm Limited and affiliates.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2022-2025, Arm Limited and affiliates.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 
 #include <stddef.h>

--- a/arm-software/embedded/llvmlibc-support/exit.c
+++ b/arm-software/embedded/llvmlibc-support/exit.c
@@ -1,18 +1,9 @@
 //
-// Copyright (c) 2022, Arm Limited and affiliates.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2022-2025, Arm Limited and affiliates.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 
 #include <stddef.h>

--- a/arm-software/embedded/llvmlibc-support/init.c
+++ b/arm-software/embedded/llvmlibc-support/init.c
@@ -1,18 +1,9 @@
 //
-// Copyright (c) 2022, Arm Limited and affiliates.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2022-2025, Arm Limited and affiliates.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 
 #include <stddef.h>

--- a/arm-software/embedded/llvmlibc-support/platform.h
+++ b/arm-software/embedded/llvmlibc-support/platform.h
@@ -1,18 +1,9 @@
 //
-// Copyright (c) 2022, Arm Limited and affiliates.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2022-2025, Arm Limited and affiliates.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 
 // This header file defines the interface between libcrt0.a, which defines

--- a/arm-software/embedded/llvmlibc-support/semihost.h
+++ b/arm-software/embedded/llvmlibc-support/semihost.h
@@ -1,18 +1,9 @@
 //
-// Copyright (c) 2022, Arm Limited and affiliates.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2022-2025, Arm Limited and affiliates.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 
 // This header file provides internal definitions for libsemihost.a,

--- a/arm-software/embedded/llvmlibc-support/stdio_read.c
+++ b/arm-software/embedded/llvmlibc-support/stdio_read.c
@@ -1,18 +1,9 @@
 //
-// Copyright (c) 2022, Arm Limited and affiliates.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2022-2025, Arm Limited and affiliates.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 
 #include <stddef.h>

--- a/arm-software/embedded/llvmlibc-support/stdio_write.c
+++ b/arm-software/embedded/llvmlibc-support/stdio_write.c
@@ -1,18 +1,9 @@
 //
-// Copyright (c) 2022, Arm Limited and affiliates.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2022-2025, Arm Limited and affiliates.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 
 #include <stddef.h>

--- a/arm-software/embedded/newlib-samples/src/baremetal-semihosting-newlib/Makefile
+++ b/arm-software/embedded/newlib-samples/src/baremetal-semihosting-newlib/Makefile
@@ -1,18 +1,8 @@
 #
 # Copyright (c) 2025, Arm Limited and affiliates.
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 include ../../Makefile.conf

--- a/arm-software/embedded/newlib-samples/src/cpp-baremetal-semihosting-newlib/Makefile
+++ b/arm-software/embedded/newlib-samples/src/cpp-baremetal-semihosting-newlib/Makefile
@@ -1,18 +1,8 @@
 #
 # Copyright (c) 2025, Arm Limited and affiliates.
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 include ../../Makefile.conf

--- a/arm-software/embedded/samples/Makefile.conf
+++ b/arm-software/embedded/samples/Makefile.conf
@@ -1,18 +1,8 @@
 #
-# Copyright (c) 2020-2023, Arm Limited and affiliates.
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright (c) 2020-2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 ifndef BIN_PATH

--- a/arm-software/embedded/samples/src/baremetal-semihosting-aarch64/Makefile
+++ b/arm-software/embedded/samples/src/baremetal-semihosting-aarch64/Makefile
@@ -1,18 +1,8 @@
 #
-# Copyright (c) 2020-2023, Arm Limited and affiliates.
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright (c) 2020-2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 include ../../Makefile.conf

--- a/arm-software/embedded/samples/src/baremetal-semihosting-aarch64/make.bat
+++ b/arm-software/embedded/samples/src/baremetal-semihosting-aarch64/make.bat
@@ -1,17 +1,8 @@
-@REM Copyright (c) 2023, Arm Limited and affiliates.
-@REM SPDX-License-Identifier: Apache-2.0
+@REM Copyright (c) 2023-2025, Arm Limited and affiliates.
 @REM
-@REM Licensed under the Apache License, Version 2.0 (the "License");
-@REM you may not use this file except in compliance with the License.
-@REM You may obtain a copy of the License at
-@REM
-@REM     http://www.apache.org/licenses/LICENSE-2.0
-@REM
-@REM Unless required by applicable law or agreed to in writing, software
-@REM distributed under the License is distributed on an "AS IS" BASIS,
-@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-@REM See the License for the specific language governing permissions and
-@REM limitations under the License.
+@REM Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+@REM See https://llvm.org/LICENSE.txt for license information.
+@REM SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 @if [%1]==[] goto :target_empty
 @set target=%1

--- a/arm-software/embedded/samples/src/baremetal-semihosting/Makefile
+++ b/arm-software/embedded/samples/src/baremetal-semihosting/Makefile
@@ -1,18 +1,8 @@
 #
-# Copyright (c) 2020-2023, Arm Limited and affiliates.
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright (c) 2020-2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 include ../../Makefile.conf

--- a/arm-software/embedded/samples/src/baremetal-semihosting/make.bat
+++ b/arm-software/embedded/samples/src/baremetal-semihosting/make.bat
@@ -1,17 +1,8 @@
-@REM Copyright (c) 2021-2023, Arm Limited and affiliates.
-@REM SPDX-License-Identifier: Apache-2.0
+@REM Copyright (c) 2021-2025, Arm Limited and affiliates.
 @REM
-@REM Licensed under the Apache License, Version 2.0 (the "License");
-@REM you may not use this file except in compliance with the License.
-@REM You may obtain a copy of the License at
-@REM
-@REM     http://www.apache.org/licenses/LICENSE-2.0
-@REM
-@REM Unless required by applicable law or agreed to in writing, software
-@REM distributed under the License is distributed on an "AS IS" BASIS,
-@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-@REM See the License for the specific language governing permissions and
-@REM limitations under the License.
+@REM Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+@REM See https://llvm.org/LICENSE.txt for license information.
+@REM SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 @if [%1]==[] goto :target_empty
 @set target=%1

--- a/arm-software/embedded/samples/src/baremetal-uart/Makefile
+++ b/arm-software/embedded/samples/src/baremetal-uart/Makefile
@@ -1,18 +1,8 @@
 #
-# Copyright (c) 2020-2023, Arm Limited and affiliates.
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright (c) 2020-2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 include ../../Makefile.conf

--- a/arm-software/embedded/samples/src/baremetal-uart/make.bat
+++ b/arm-software/embedded/samples/src/baremetal-uart/make.bat
@@ -1,17 +1,8 @@
-@REM Copyright (c) 2021-2023, Arm Limited and affiliates.
-@REM SPDX-License-Identifier: Apache-2.0
+@REM Copyright (c) 2021-2025, Arm Limited and affiliates.
 @REM
-@REM Licensed under the Apache License, Version 2.0 (the "License");
-@REM you may not use this file except in compliance with the License.
-@REM You may obtain a copy of the License at
-@REM
-@REM     http://www.apache.org/licenses/LICENSE-2.0
-@REM
-@REM Unless required by applicable law or agreed to in writing, software
-@REM distributed under the License is distributed on an "AS IS" BASIS,
-@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-@REM See the License for the specific language governing permissions and
-@REM limitations under the License.
+@REM Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+@REM See https://llvm.org/LICENSE.txt for license information.
+@REM SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 @if [%1]==[] goto :target_empty
 @set target=%1

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-cfi/Makefile
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-cfi/Makefile
@@ -1,18 +1,8 @@
 #
-# Copyright (c) 2023, Arm Limited and affiliates.
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright (c) 2023-2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 include ../../Makefile.conf

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-cfi/make.bat
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-cfi/make.bat
@@ -1,17 +1,8 @@
-@REM Copyright (c) 2023, Arm Limited and affiliates.
-@REM SPDX-License-Identifier: Apache-2.0
+@REM Copyright (c) 2023-2025, Arm Limited and affiliates.
 @REM
-@REM Licensed under the Apache License, Version 2.0 (the "License");
-@REM you may not use this file except in compliance with the License.
-@REM You may obtain a copy of the License at
-@REM
-@REM     http://www.apache.org/licenses/LICENSE-2.0
-@REM
-@REM Unless required by applicable law or agreed to in writing, software
-@REM distributed under the License is distributed on an "AS IS" BASIS,
-@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-@REM See the License for the specific language governing permissions and
-@REM limitations under the License.
+@REM Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+@REM See https://llvm.org/LICENSE.txt for license information.
+@REM SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 @if [%1]==[] goto :target_empty
 @set target=%1

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-exceptions/Makefile
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-exceptions/Makefile
@@ -1,18 +1,8 @@
 #
-# Copyright (c) 2024, Arm Limited and affiliates.
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright (c) 2024-2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 include ../../Makefile.conf

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-exceptions/make.bat
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-exceptions/make.bat
@@ -1,17 +1,8 @@
-@REM Copyright (c) 2024, Arm Limited and affiliates.
-@REM SPDX-License-Identifier: Apache-2.0
+@REM Copyright (c) 2024-2025, Arm Limited and affiliates.
 @REM
-@REM Licensed under the Apache License, Version 2.0 (the "License");
-@REM you may not use this file except in compliance with the License.
-@REM You may obtain a copy of the License at
-@REM
-@REM     http://www.apache.org/licenses/LICENSE-2.0
-@REM
-@REM Unless required by applicable law or agreed to in writing, software
-@REM distributed under the License is distributed on an "AS IS" BASIS,
-@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-@REM See the License for the specific language governing permissions and
-@REM limitations under the License.
+@REM Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+@REM See https://llvm.org/LICENSE.txt for license information.
+@REM SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 @if [%1]==[] goto :target_empty
 @set target=%1

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-prof/Makefile
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-prof/Makefile
@@ -1,18 +1,8 @@
 #
-# Copyright (c) 2023, Arm Limited and affiliates.
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright (c) 2023-2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 include ../../Makefile.conf

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-prof/make.bat
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-prof/make.bat
@@ -1,17 +1,8 @@
-@REM Copyright (c) 2023, Arm Limited and affiliates.
-@REM SPDX-License-Identifier: Apache-2.0
+@REM Copyright (c) 2023-2025, Arm Limited and affiliates.
 @REM
-@REM Licensed under the Apache License, Version 2.0 (the "License");
-@REM you may not use this file except in compliance with the License.
-@REM You may obtain a copy of the License at
-@REM
-@REM     http://www.apache.org/licenses/LICENSE-2.0
-@REM
-@REM Unless required by applicable law or agreed to in writing, software
-@REM distributed under the License is distributed on an "AS IS" BASIS,
-@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-@REM See the License for the specific language governing permissions and
-@REM limitations under the License.
+@REM Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+@REM See https://llvm.org/LICENSE.txt for license information.
+@REM SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 @if [%1]==[] goto :target_empty
 @set target=%1

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-ubsan/Makefile
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-ubsan/Makefile
@@ -1,18 +1,8 @@
 #
-# Copyright (c) 2023, Arm Limited and affiliates.
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright (c) 2023-2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 include ../../Makefile.conf

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-ubsan/make.bat
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-ubsan/make.bat
@@ -1,17 +1,8 @@
-@REM Copyright (c) 2023, Arm Limited and affiliates.
-@REM SPDX-License-Identifier: Apache-2.0
+@REM Copyright (c) 2023-2025, Arm Limited and affiliates.
 @REM
-@REM Licensed under the Apache License, Version 2.0 (the "License");
-@REM you may not use this file except in compliance with the License.
-@REM You may obtain a copy of the License at
-@REM
-@REM     http://www.apache.org/licenses/LICENSE-2.0
-@REM
-@REM Unless required by applicable law or agreed to in writing, software
-@REM distributed under the License is distributed on an "AS IS" BASIS,
-@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-@REM See the License for the specific language governing permissions and
-@REM limitations under the License.
+@REM Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+@REM See https://llvm.org/LICENSE.txt for license information.
+@REM SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 @if [%1]==[] goto :target_empty
 @set target=%1

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting/Makefile
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting/Makefile
@@ -1,18 +1,8 @@
 #
-# Copyright (c) 2021-2023, Arm Limited and affiliates.
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright (c) 2021-2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
 include ../../Makefile.conf

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting/make.bat
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting/make.bat
@@ -1,17 +1,8 @@
-@REM Copyright (c) 2021-2023, Arm Limited and affiliates.
-@REM SPDX-License-Identifier: Apache-2.0
+@REM Copyright (c) 2021-2025, Arm Limited and affiliates.
 @REM
-@REM Licensed under the Apache License, Version 2.0 (the "License");
-@REM you may not use this file except in compliance with the License.
-@REM You may obtain a copy of the License at
-@REM
-@REM     http://www.apache.org/licenses/LICENSE-2.0
-@REM
-@REM Unless required by applicable law or agreed to in writing, software
-@REM distributed under the License is distributed on an "AS IS" BASIS,
-@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-@REM See the License for the specific language governing permissions and
-@REM limitations under the License.
+@REM Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+@REM See https://llvm.org/LICENSE.txt for license information.
+@REM SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 @if [%1]==[] goto :target_empty
 @set target=%1


### PR DESCRIPTION
Add LLVM Exception to Apache 2.0 license notices in samples and auxiliary files.