### PR TITLE
llvm-libc build fixes

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -361,25 +361,6 @@ if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL llvmlibc)
       COMPONENT llvm-toolchain-llvmlibc-configs
     )
 
-    # We need to build libc-hdrgen
-    ExternalProject_Add(
-        libc_hdrgen
-        SOURCE_DIR ${llvmproject_src_dir}/llvm
-        DEPENDS ${lib_tool_dependencies}
-        CMAKE_ARGS
-            -DLLVM_ENABLE_RUNTIMES=libc
-            -DLLVM_LIBC_FULL_BUILD=ON
-            -DCMAKE_BUILD_TYPE=Debug
-        STEP_TARGETS build install
-        BUILD_COMMAND ${CMAKE_COMMAND} --build . --target libc-hdrgen
-        INSTALL_COMMAND ${CMAKE_COMMAND} -E true
-        # Always run the build command so that incremental builds are correct.
-        BUILD_ALWAYS TRUE
-        CONFIGURE_HANDLED_BY_BUILD TRUE
-    )
-    ExternalProject_Get_property(libc_hdrgen BINARY_DIR)
-    set(LIBC_HDRGEN ${BINARY_DIR}/bin/libc-hdrgen${CMAKE_EXECUTABLE_SUFFIX})
-
     # LLVM libc lacks a configuration for AArch64, but the AArch32 one works
     # fine. However, setting the configuration for both architectures to the
     # arm config directory means the baremetal config.json is never loaded,
@@ -628,7 +609,6 @@ if(NOT PREBUILT_TARGET_LIBRARIES)
         -DENABLE_PARALLEL_LIB_CONFIG=${ENABLE_PARALLEL_LIB_CONFIG}
         -DENABLE_PARALLEL_LIB_BUILD=${ENABLE_PARALLEL_LIB_BUILD}
         -DPARALLEL_LIB_BUILD_LEVELS=${PARALLEL_LIB_BUILD_LEVELS}
-        -DLIBC_HDRGEN=${LIBC_HDRGEN}
         -DFVP_INSTALL_DIR=${FVP_INSTALL_DIR}
         -DENABLE_QEMU_TESTING=${ENABLE_QEMU_TESTING}
         -DENABLE_FVP_TESTING=${ENABLE_FVP_TESTING}

--- a/arm-software/embedded/arm-multilib/CMakeLists.txt
+++ b/arm-software/embedded/arm-multilib/CMakeLists.txt
@@ -40,7 +40,6 @@ option(
     OFF
 )
 set(LLVM_BINARY_DIR "" CACHE PATH "Path to LLVM toolchain build or install root.")
-set(LIBC_HDRGEN "" CACHE PATH "Path to prebuilt lbc-hdrgen if not included in LLVM binaries set by LLVM_BINARY_DIR")
 option(
     ENABLE_QEMU_TESTING
     "Enable tests that use QEMU. This option is ON by default."
@@ -91,7 +90,6 @@ endif()
 # Arguments to pass down to the library projects.
 foreach(arg
     LLVM_BINARY_DIR
-    LIBC_HDRGEN
     FVP_INSTALL_DIR
     FVP_CONFIG_DIR
 )
@@ -113,31 +111,6 @@ endif()
 
 # Target for any dependencies to build the runtimes project.
 add_custom_target(runtimes-depends)
-
-# If building llvm-libc, ensure libc-hdrgen is available.
-if(C_LIBRARY STREQUAL llvmlibc)
-    if(NOT LIBC_HDRGEN)
-        if(EXISTS ${LLVM_BINARY_DIR}/bin/libc-hdrgen${CMAKE_EXECUTABLE_SUFFIX})
-            set(LIBC_HDRGEN ${LLVM_BINARY_DIR}/bin/libc-hdrgen${CMAKE_EXECUTABLE_SUFFIX})
-        else()
-            ExternalProject_Add(
-                libc_hdrgen
-                SOURCE_DIR ${llvmproject_src_dir}/llvm
-                CMAKE_ARGS
-                    -DLLVM_ENABLE_RUNTIMES=libc
-                    -DLLVM_LIBC_FULL_BUILD=ON
-                    -DCMAKE_BUILD_TYPE=Debug
-                BUILD_COMMAND ${CMAKE_COMMAND} --build . --target libc-hdrgen
-                INSTALL_COMMAND ${CMAKE_COMMAND} -E true
-                CONFIGURE_HANDLED_BY_BUILD TRUE
-            )
-            ExternalProject_Get_property(libc_hdrgen BINARY_DIR)
-            set(LIBC_HDRGEN ${BINARY_DIR}/bin/libc-hdrgen${CMAKE_EXECUTABLE_SUFFIX})
-            add_dependencies(runtimes-depends libc_hdrgen)
-        endif()
-    endif()
-    list(APPEND passthrough_dirs "-DLIBC_HDRGEN=${LIBC_HDRGEN}")
-endif()
 
 # Create one target to run all the tests.
 add_custom_target(check-${C_LIBRARY})

--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -98,7 +98,6 @@ set(ENABLE_LIBC_TESTS ${ENABLE_LIBC_TESTS_def} CACHE BOOL "Enable libc tests (pi
 set(ENABLE_COMPILER_RT_TESTS ${ENABLE_COMPILER_RT_TESTS_def} CACHE BOOL "Enable compiler-rt tests.")
 set(ENABLE_LIBCXX_TESTS ${ENABLE_LIBCXX_TESTS_def} CACHE BOOL "Enable libcxx tests.")
 set(LLVM_BINARY_DIR "" CACHE PATH "Path to LLVM toolchain root to build libraries with")
-set(LIBC_HDRGEN "" CACHE PATH "Path to prebuilt lbc-hdrgen if not included in LLVM binaries set by LLVM_BINARY_DIR")
 
 set(PROJECT_PREFIX "subproj" CACHE STRING "Directory to build subprojects in.")
 set(VARIANT_BUILD_ID "${VARIANT}" CACHE STRING "Name to use to identify build directories." )
@@ -601,29 +600,6 @@ if(C_LIBRARY STREQUAL llvmlibc)
         -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY
     )
 
-    if(LIBC_HDRGEN)
-        # If libc-hdrgen is provided, there is no need to build it,
-        # but a target is still needed to satisfy the dependency.
-        add_custom_target(libc_hdrgen)
-    elseif(EXISTS ${LLVM_BINARY_DIR}/bin/libc-hdrgen${CMAKE_EXECUTABLE_SUFFIX})
-        set(LIBC_HDRGEN ${LLVM_BINARY_DIR}/bin/libc-hdrgen${CMAKE_EXECUTABLE_SUFFIX})
-        add_custom_target(libc_hdrgen)
-    else()
-        ExternalProject_Add(
-            libc_hdrgen
-            SOURCE_DIR ${llvmproject_src_dir}/llvm
-            CMAKE_ARGS
-                -DLLVM_ENABLE_RUNTIMES=libc
-                -DLLVM_LIBC_FULL_BUILD=ON
-                -DCMAKE_BUILD_TYPE=Debug
-            BUILD_COMMAND ${CMAKE_COMMAND} --build . --target libc-hdrgen
-            INSTALL_COMMAND ${CMAKE_COMMAND} -E true
-            CONFIGURE_HANDLED_BY_BUILD TRUE
-        )
-        ExternalProject_Get_property(libc_hdrgen BINARY_DIR)
-        set(LIBC_HDRGEN ${BINARY_DIR}/bin/libc-hdrgen${CMAKE_EXECUTABLE_SUFFIX})
-    endif()
-
     ExternalProject_Add(
         llvmlibc
         STAMP_DIR ${PROJECT_PREFIX}/llvmlibc/${VARIANT_BUILD_ID}/stamp
@@ -632,12 +608,10 @@ if(C_LIBRARY STREQUAL llvmlibc)
         TMP_DIR ${PROJECT_PREFIX}/llvmlibc/${VARIANT_BUILD_ID}/tmp
         SOURCE_DIR ${llvmproject_src_dir}/runtimes
         INSTALL_DIR llvmlibc/install
-        DEPENDS libc_hdrgen
         CMAKE_ARGS
         ${compiler_launcher_cmake_args}
         ${common_llvmlibc_cmake_args}
         -DLIBC_TARGET_TRIPLE=${target_triple}
-        -DLIBC_HDRGEN_EXE=${LIBC_HDRGEN}
         -DLIBC_CONFIG_PATH=${LIBC_CFG_DIR}
         -DLIBC_CONF_TIME_64BIT=ON
         -DLLVM_CMAKE_DIR=${LLVM_BINARY_DIR}/lib/cmake/llvm

--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -802,6 +802,14 @@ if(ENABLE_CXX_LIBS)
         endforeach()
     endif()
 
+else() # if not ENABLE_CXX_LIBS
+
+    # The parent arm-multilib cmake script will still want to invoke
+    # build targets like 'cxxlibs-configure', whether we actually have
+    # C++ libraries or not. So we should define them, even if they
+    # don't do anything.
+    add_custom_target(cxxlibs-configure)
+    add_custom_target(cxxlibs-build)
 endif()
 
 install(


### PR DESCRIPTION
Two patches here, both aimed at making the embedded build have fewer failures in the llvmlibc variant.

I'm not confident that this fixes _all_ the problems in the llvm-libc build. In a clean attempt with this change and the previous one, I had a mysterious failure, which went away when I just ran `ninja` again. That suggests some kind of intermittent issue related to build parallelism, maybe a missing dependency of some kind.

But even so, I think each of these changes removes _a_ problem, even if there's still another one yet to be found.
