### PR TITLE
Ensure sysroot is set when running libcxx tests

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -200,10 +200,10 @@ if(ENABLE_LIBC_TESTS OR ENABLE_COMPILER_RT_TESTS OR ENABLE_LIBCXX_TESTS)
     list(JOIN lit_test_executor " " lit_test_executor)
 endif()
 
-set(compile_arch_flags "--target=${target_triple} ${COMPILE_FLAGS}")
+set(compile_arch_flags "--target=${target_triple} ${COMPILE_FLAGS} --sysroot ${TEMP_LIB_DIR}")
 # Compiling the libraries benefits from some extra optimization
 # flags, and requires a sysroot.
-set(lib_compile_flags "${compile_arch_flags} -ffunction-sections -fdata-sections -fno-ident --sysroot ${TEMP_LIB_DIR}")
+set(lib_compile_flags "${compile_arch_flags} -ffunction-sections -fdata-sections -fno-ident")
 
 # Generic target names for the C library.
 # Declare these now, since compiler-rt requires the 'install' dependency.


### PR DESCRIPTION
The libcxx tests attempt to detect the presence of a -std=c++NN flag, however this does not use the correct multilib flags for the library variants built once they have been installed to the clang runtimes folder. As a result, the tests will likely report an issue with the compiler when only a single library variant is built, as multilib will not be able to find a match.

To fix this, this patch ensures the sysroot is in the compile flags used in the libcxx tests, so that the tests are run using the known library location instead of using multilib..