### PR TITLE
Use variant id in stamp and binary dirs for llvmlibc-support

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -660,8 +660,8 @@ if(C_LIBRARY STREQUAL llvmlibc)
 
     ExternalProject_Add(
         llvmlibc-support
-        STAMP_DIR ${PROJECT_PREFIX}/llvmlibc-support-stamp
-        BINARY_DIR ${PROJECT_PREFIX}/llvmlibc-support-build
+        STAMP_DIR ${PROJECT_PREFIX}/llvmlibc-support/${VARIANT_BUILD_ID}/stamp
+        BINARY_DIR ${PROJECT_PREFIX}/llvmlibc-support/${VARIANT_BUILD_ID}/build
         DOWNLOAD_DIR ${PROJECT_PREFIX}/llvmlibc-support/${VARIANT_BUILD_ID}/dl
         TMP_DIR ${PROJECT_PREFIX}/llvmlibc-support/${VARIANT_BUILD_ID}/tmp
         SOURCE_DIR ${TOOLCHAIN_SOURCE_DIR}/llvmlibc-support


### PR DESCRIPTION
Like the other directories, the stamp and build directories for llvmlibc-support project need to use a unique identifier for each variant build, otherwise multiple versions of the same project may attempt to use them. The download and temp directories are already set properly.