### PR TITLE
Filter Corstone's stdout

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
+++ b/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
@@ -92,6 +92,19 @@ def run_fvp(
         cwd=working_directory,
         check=False,
     )
-    sys.stdout.buffer.write(result.stdout)
+
+    # Corstone-310 prints out boilerplate text on stdout alongside the actual
+    # output of the image. Some tests, for instance in libcxx, check the
+    # contents of stdout, and may treat the unexpected text as a condition for
+    # failure. To work around this, we cut out the model's boilerplate output.
+    if fvp_model == "corstone-310":
+        decoded_stdout = result.stdout.decode()
+        relevant_lines = decoded_stdout.splitlines()[5:-2]
+        reencoded_stdout = '\n'.join(relevant_lines).encode()
+        result_stdout = reencoded_stdout
+    else:
+        result_stdout = result.stdout
+
+    sys.stdout.buffer.write(result_stdout)
     return result.returncode
 

--- a/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
+++ b/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
@@ -101,8 +101,8 @@ def run_fvp(
     if fvp_model == "corstone-310":
         decoded_stdout = result.stdout.decode()
         expected_stdout_format = r"""
-    Ethos-U rev 136b7d75 --- Apr 12 2023 13:44:01
-    \(C\) COPYRIGHT 2019-2023 Arm Limited
+    Ethos-U rev [0-9a-z]+ --- \w{3} \d{2} \d{4} \d{2}:\d{2}:\d{2}
+    \(C\) COPYRIGHT (?:\d{4}|\d{4}-\d{4})(?:,\s?(?:\d{4}|\d{4}-\d{4}))* Arm Limited
     ALL RIGHTS RESERVED
 
 (.*)


### PR DESCRIPTION
Corstone prints out some informational text to stdout, but this text conflicts with expectations from tests about the contents of stdout.

This patch filters out this text to send to stdout only what matters.