### PR TITLE
[ATfE] Add scripts to build newlib and llvmlibc overlay packages

### DIFF
--- a/arm-software/embedded/scripts/build_llvmlibc_overlay.sh
+++ b/arm-software/embedded/scripts/build_llvmlibc_overlay.sh
@@ -7,14 +7,12 @@
 
 set -ex
 
+export CC=clang
+export CXX=clang++
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$( git -C ${SCRIPT_DIR} rev-parse --show-toplevel )
 BUILD_DIR=${REPO_ROOT}/build_llvmlibc_overlay
-
-clang --version
-
-export CC=clang
-export CXX=clang++
 
 mkdir -p ${BUILD_DIR}
 cd ${BUILD_DIR}

--- a/arm-software/embedded/scripts/build_llvmlibc_overlay.sh
+++ b/arm-software/embedded/scripts/build_llvmlibc_overlay.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# A bash script to build the llvmlibc overlay for the Arm Toolchain for Embedded
+
+# The script creates a build of the toolchain in the 'build_llvmlibc_overlay'
+# directory, inside the repository tree.
+
+set -ex
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( git -C ${SCRIPT_DIR} rev-parse --show-toplevel )
+BUILD_DIR=${REPO_ROOT}/build_llvmlibc_overlay
+
+clang --version
+
+export CC=clang
+export CXX=clang++
+
+mkdir -p ${BUILD_DIR}
+cd ${BUILD_DIR}
+
+cmake ../arm-software/embedded -GNinja -DFETCHCONTENT_QUIET=OFF -DLLVM_TOOLCHAIN_C_LIBRARY=llvmlibc -DLLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL=on
+ninja package-llvm-toolchain
+
+# The package-llvm-toolchain target will produce a .tar.xz package, but we also
+# a zip version for Windows users
+cpack -G ZIP

--- a/arm-software/embedded/scripts/build_newlib_overlay.sh
+++ b/arm-software/embedded/scripts/build_newlib_overlay.sh
@@ -7,14 +7,12 @@
 
 set -ex
 
+export CC=clang
+export CXX=clang++
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$( git -C ${SCRIPT_DIR} rev-parse --show-toplevel )
 BUILD_DIR=${REPO_ROOT}/build_newlib_overlay
-
-clang --version
-
-export CC=clang
-export CXX=clang++
 
 mkdir -p ${BUILD_DIR}
 cd ${BUILD_DIR}

--- a/arm-software/embedded/scripts/build_newlib_overlay.sh
+++ b/arm-software/embedded/scripts/build_newlib_overlay.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# A bash script to build the newlib overlay for the Arm Toolchain for Embedded
+
+# The script creates a build of the toolchain in the 'build_newlib_overlay'
+# directory, inside the repository tree.
+
+set -ex
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( git -C ${SCRIPT_DIR} rev-parse --show-toplevel )
+BUILD_DIR=${REPO_ROOT}/build_newlib_overlay
+
+clang --version
+
+export CC=clang
+export CXX=clang++
+
+mkdir -p ${BUILD_DIR}
+cd ${BUILD_DIR}
+
+cmake ../arm-software/embedded -GNinja -DFETCHCONTENT_QUIET=OFF -DLLVM_TOOLCHAIN_C_LIBRARY=newlib -DLLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL=on
+ninja package-llvm-toolchain
+
+# The package-llvm-toolchain target will produce a .tar.xz package, but we also
+# a zip version for Windows users
+cpack -G ZIP


### PR DESCRIPTION
This introduces two new scripts for building ovelay library packages for
the Arm Toolchain for Embedded, one for the newlib overlay and one for
the llvmlibc overlay.
The scripts follow the same approach as the existing `build.sh` script,
but using different build directories and providing the corresponding
CMake options for each overlay package.
