### PR TITLE
Fix llvmlibc sample, by adding -lm to the link command.

### DIFF
--- a/arm-software/embedded/llvmlibc-samples/src/llvmlibc/baremetal-semihosting/Makefile
+++ b/arm-software/embedded/llvmlibc-samples/src/llvmlibc/baremetal-semihosting/Makefile
@@ -10,7 +10,7 @@ include ../../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.c
-	../$(BIN_PATH)/clang --config=llvmlibc.cfg $(MICROBIT_TARGET) -nostartfiles -lsemihost -g -fno-exceptions -fno-rtti -T microbit-llvmlibc.ld -o hello.elf $^
+	../$(BIN_PATH)/clang --config=llvmlibc.cfg $(MICROBIT_TARGET) -nostartfiles -lsemihost -lm -g -fno-exceptions -fno-rtti -T microbit-llvmlibc.ld -o hello.elf $^
 
 %.hex: %.elf
 	../$(BIN_PATH)/llvm-objcopy -O ihex $< $@


### PR DESCRIPTION
The sample program calls two libm functions (lround and atanf) to turn a floating-point number into decimal digits. But libm.a is built as a separate library from libc.a, so linking the sample program fails because the compile command doesn't use the -lm option. Easily fixed.