### PR TITLE
[ATfE] Use python executable path for picolibc tests

### DIFF
--- a/arm-software/embedded/arm-runtimes/meson-cross-build.txt.in
+++ b/arm-software/embedded/arm-runtimes/meson-cross-build.txt.in
@@ -8,7 +8,7 @@ strip = '@LLVM_BINARY_DIR@/bin/llvm-strip@CMAKE_EXECUTABLE_SUFFIX@'
 exe_wrapper = [
     'sh',
     '-c',
-    'test -z "$PICOLIBC_TEST" || @picolibc_test_executor_bin@ "$@" < /dev/null',
+    'test -z "$PICOLIBC_TEST" || @Python_EXECUTABLE@ @picolibc_test_executor_bin@ "$@" < /dev/null',
     '@picolibc_test_executor_bin@',
     @meson_test_executor_params@]
 


### PR DESCRIPTION
Currently, the wrapper command for running picolibc tests in ATfE
includes a direct call to the `picolibc-test-wrapper.py` script, relying
on the script's shebang line to invoke the python interpreter. This is a
problem for invoking tests on Windows platofrms, as the naming of the
Python 3 executable is not consistent with the one used on Unix - i.e.
python vs python3.
To fix this problem, this change adds the path for the python executable
to that call. The path used is the one discovered by CMake as part of
the `find_package(Python3 ...)` command.
