### PR TITLE
Update scripts and config for Corstone-310 v11.27

### DIFF
--- a/arm-software/embedded/fvp/config/m-pacbti.cfg
+++ b/arm-software/embedded/fvp/config/m-pacbti.cfg
@@ -2,4 +2,3 @@
 
 # Enable M-profile PAC and BTI
 cpu0.CFGPACBTI=1
-cpu0.ID_ISAR5.PACBTI=1


### PR DESCRIPTION
The new version of Corstone-310 FVP model has a few differences compared to v11.24 which require changes:

* The `ID_ISAR5.PACBTI` parameter has been deprecated and removed.
* The install now includes its own copy of pythonlib and fmtplib, the paths to which need to be set as environment variables before starting the model. `PYTHONHOME` should be set to `<install>/python`, and `LD_LIBRARY_PATH` to `<install>/fmtplib:<install>/python/lib`.
* The boilerplate message printed to stdout has a different date, and the Info message on stop is no longer present. The regex has been updated to still match.