### PR TITLE
Ensure workflows only run on arm/arm-toolchain and not on forks

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   Run-Automerge:
     runs-on: ubuntu-latest
+    if: github.repository == 'arm/arm-toolchain'
     strategy:
       matrix:
         branches:

--- a/.github/workflows/sync_from_upstream.yml
+++ b/.github/workflows/sync_from_upstream.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   Fetch-Upstream:
     runs-on: ubuntu-latest
+    if: github.repository == 'arm/arm-toolchain'
     strategy:
       matrix:
         branch: [main, release/20.x]


### PR DESCRIPTION
Currently workflows that exist under `.github/workflows` are executed
not only on arm/arm-toolchain, but on all forks of this repo, including
personal forks used for development and submitting PRs.
To prevent that from happening, this change adds a condition to the
existing workflows, checking if the current repo is arm/arm-toolchain
before running.
