### PR TITLE
(release 20.x non-upstream patch) [clang] Lower non-builtin sincos[f|l] calls to llvm.sincos.* when -fno-math-errno is set

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -3253,9 +3253,11 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
       return RValue::get(emitUnaryMaybeConstrainedFPBuiltin(
           *this, E, Intrinsic::sinh, Intrinsic::experimental_constrained_sinh));
 
+      /* Downstream change: #87 (sincos vectorization)*/
     case Builtin::BIsincos:
     case Builtin::BIsincosf:
     case Builtin::BIsincosl:
+      /* End downstream change: #87 */
     case Builtin::BI__builtin_sincos:
     case Builtin::BI__builtin_sincosf:
     case Builtin::BI__builtin_sincosf16:

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -3253,6 +3253,9 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
       return RValue::get(emitUnaryMaybeConstrainedFPBuiltin(
           *this, E, Intrinsic::sinh, Intrinsic::experimental_constrained_sinh));
 
+    case Builtin::BIsincos:
+    case Builtin::BIsincosf:
+    case Builtin::BIsincosl:
     case Builtin::BI__builtin_sincos:
     case Builtin::BI__builtin_sincosf:
     case Builtin::BI__builtin_sincosf16:

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -3263,6 +3263,10 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     case Builtin::BI__builtin_sincosf16:
     case Builtin::BI__builtin_sincosl:
     case Builtin::BI__builtin_sincosf128:
+      /* Downstream change: #87 (sincos vectorization)*/
+      if (Builder.getIsFPConstrained())
+        break; // TODO: Emit constrained sincos intrinsic once one exists.
+      /* Downstream change: #87 (sincos vectorization)*/
       emitSincosBuiltin(*this, E, Intrinsic::sincos);
       return RValue::get(nullptr);
 

--- a/clang/test/CodeGen/AArch64/sincos.c
+++ b/clang/test/CodeGen/AArch64/sincos.c
@@ -1,6 +1,10 @@
 // RUN: %clang_cc1 -triple=aarch64-gnu-linux -emit-llvm -O1 %s -o - | FileCheck --check-prefix=NO-MATH-ERRNO %s
 // RUN: %clang_cc1 -triple=aarch64-gnu-linux -emit-llvm -fmath-errno %s -o - | FileCheck --check-prefix=MATH-ERRNO %s
 
+void sincos(double, double*, double*);
+void sincosf(float, float*, float*);
+void sincosl(long double, long double*, long double*);
+
 // NO-MATH-ERRNO-LABEL: @sincos_f32
 //      NO-MATH-ERRNO:    [[SINCOS:%.*]] = tail call { float, float } @llvm.sincos.f32(float {{.*}})
 // NO-MATH-ERRNO-NEXT:    [[SIN:%.*]] = extractvalue { float, float } [[SINCOS]], 0
@@ -12,6 +16,20 @@
 //      MATH-ERRNO:    call void @sincosf(
 //
 void sincos_f32(float x, float* fp0, float* fp1) {
+  sincosf(x, fp0, fp1);
+}
+
+// NO-MATH-ERRNO-LABEL: @sincos_builtin_f32
+//      NO-MATH-ERRNO:    [[SINCOS:%.*]] = tail call { float, float } @llvm.sincos.f32(float {{.*}})
+// NO-MATH-ERRNO-NEXT:    [[SIN:%.*]] = extractvalue { float, float } [[SINCOS]], 0
+// NO-MATH-ERRNO-NEXT:    [[COS:%.*]] = extractvalue { float, float } [[SINCOS]], 1
+// NO-MATH-ERRNO-NEXT:    store float [[SIN]], ptr {{.*}}, align 4, !alias.scope [[SINCOS_ALIAS_SCOPE:![0-9]+]]
+// NO-MATH-ERRNO-NEXT:    store float [[COS]], ptr {{.*}}, align 4, !noalias [[SINCOS_ALIAS_SCOPE]]
+//
+// MATH-ERRNO-LABEL: @sincos_builtin_f32
+//      MATH-ERRNO:    call void @sincosf(
+//
+void sincos_builtin_f32(float x, float* fp0, float* fp1) {
   __builtin_sincosf(x, fp0, fp1);
 }
 
@@ -26,6 +44,20 @@ void sincos_f32(float x, float* fp0, float* fp1) {
 //      MATH-ERRNO:    call void @sincos(
 //
 void sincos_f64(double x, double* dp0, double* dp1) {
+  sincos(x, dp0, dp1);
+}
+
+// NO-MATH-ERRNO-LABEL: @sincos_builtin_f64
+//      NO-MATH-ERRNO:    [[SINCOS:%.*]] = tail call { double, double } @llvm.sincos.f64(double {{.*}})
+// NO-MATH-ERRNO-NEXT:    [[SIN:%.*]] = extractvalue { double, double } [[SINCOS]], 0
+// NO-MATH-ERRNO-NEXT:    [[COS:%.*]] = extractvalue { double, double } [[SINCOS]], 1
+// NO-MATH-ERRNO-NEXT:    store double [[SIN]], ptr {{.*}}, align 8, !alias.scope [[SINCOS_ALIAS_SCOPE:![0-9]+]]
+// NO-MATH-ERRNO-NEXT:    store double [[COS]], ptr {{.*}}, align 8, !noalias [[SINCOS_ALIAS_SCOPE]]
+//
+// MATH-ERRNO-LABEL: @sincos_builtin_f64
+//      MATH-ERRNO:    call void @sincos(
+//
+void sincos_builtin_f64(double x, double* dp0, double* dp1) {
   __builtin_sincos(x, dp0, dp1);
 }
 
@@ -40,5 +72,19 @@ void sincos_f64(double x, double* dp0, double* dp1) {
 //      MATH-ERRNO:    call void @sincosl(
 //
 void sincos_f128(long double x, long double* ldp0, long double* ldp1) {
+  sincosl(x, ldp0, ldp1);
+}
+
+// NO-MATH-ERRNO-LABEL: @sincos_builtin_f128
+//      NO-MATH-ERRNO:    [[SINCOS:%.*]] = tail call { fp128, fp128 } @llvm.sincos.f128(fp128 {{.*}})
+// NO-MATH-ERRNO-NEXT:    [[SIN:%.*]] = extractvalue { fp128, fp128 } [[SINCOS]], 0
+// NO-MATH-ERRNO-NEXT:    [[COS:%.*]] = extractvalue { fp128, fp128 } [[SINCOS]], 1
+// NO-MATH-ERRNO-NEXT:    store fp128 [[SIN]], ptr {{.*}}, align 16, !alias.scope [[SINCOS_ALIAS_SCOPE:![0-9]+]]
+// NO-MATH-ERRNO-NEXT:    store fp128 [[COS]], ptr {{.*}}, align 16, !noalias [[SINCOS_ALIAS_SCOPE]]
+//
+// MATH-ERRNO-LABEL: @sincos_builtin_f128
+//      MATH-ERRNO:    call void @sincosl(
+//
+void sincos_builtin_f128(long double x, long double* ldp0, long double* ldp1) {
   __builtin_sincosl(x, ldp0, ldp1);
 }

--- a/clang/test/CodeGen/AArch64/sincos.c
+++ b/clang/test/CodeGen/AArch64/sincos.c
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 -triple=aarch64-gnu-linux -emit-llvm -O1 %s -o - | FileCheck --check-prefix=NO-MATH-ERRNO %s
 // RUN: %clang_cc1 -triple=aarch64-gnu-linux -emit-llvm -fmath-errno %s -o - | FileCheck --check-prefix=MATH-ERRNO %s
+// RUN: %clang_cc1 -triple=aarch64-gnu-linux -emit-llvm -ffp-exception-behavior=strict %s -o - | FileCheck --check-prefix=STRICT-FP %s
 
 void sincos(double, double*, double*);
 void sincosf(float, float*, float*);
@@ -14,6 +15,9 @@ void sincosl(long double, long double*, long double*);
 //
 // MATH-ERRNO-LABEL: @sincos_f32
 //      MATH-ERRNO:    call void @sincosf(
+//
+// STRICT-FP-LABEL: @sincos_f32
+//      STRICT-FP:    call void @sincosf(
 //
 void sincos_f32(float x, float* fp0, float* fp1) {
   sincosf(x, fp0, fp1);
@@ -43,6 +47,9 @@ void sincos_builtin_f32(float x, float* fp0, float* fp1) {
 // MATH-ERRNO-LABEL: @sincos_f64
 //      MATH-ERRNO:    call void @sincos(
 //
+// STRICT-FP-LABEL: @sincos_f64
+//      STRICT-FP:    call void @sincos(
+//
 void sincos_f64(double x, double* dp0, double* dp1) {
   sincos(x, dp0, dp1);
 }
@@ -70,6 +77,9 @@ void sincos_builtin_f64(double x, double* dp0, double* dp1) {
 //
 // MATH-ERRNO-LABEL: @sincos_f128
 //      MATH-ERRNO:    call void @sincosl(
+//
+// STRICT-FP-LABEL: @sincos_f128
+//      STRICT-FP:    call void @sincosl(
 //
 void sincos_f128(long double x, long double* ldp0, long double* ldp1) {
   sincosl(x, ldp0, ldp1);

--- a/clang/test/CodeGen/math-libcalls.c
+++ b/clang/test/CodeGen/math-libcalls.c
@@ -660,6 +660,17 @@ void foo(double *d, float f, float *fp, long double *l, int *i, const char *c) {
 // HAS_MAYTRAP: declare float @llvm.experimental.constrained.sinh.f32(
 // HAS_MAYTRAP: declare x86_fp80 @llvm.experimental.constrained.sinh.f80(
 
+sincos(f, d, d);       sincosf(f, fp, fp);        sincosl(f, l, l);
+
+// NO__ERRNO: declare { double, double } @llvm.sincos.f64(double) [[READNONE_INTRINSIC]]
+// NO__ERRNO: declare { float, float } @llvm.sincos.f32(float) [[READNONE_INTRINSIC]]
+// NO__ERRNO: declare { x86_fp80, x86_fp80 } @llvm.sincos.f80(x86_fp80) [[READNONE_INTRINSIC]]
+// HAS_ERRNO: declare void @sincos(double noundef, ptr noundef, ptr noundef) [[NOT_READNONE]]
+// HAS_ERRNO: declare void @sincosf(float noundef, ptr noundef, ptr noundef) [[NOT_READNONE]]
+// HAS_ERRNO: declare void @sincosl(x86_fp80 noundef, ptr noundef, ptr noundef) [[NOT_READNONE]]
+// HAS_MAYTRAP: declare void @sincos(double noundef, ptr noundef, ptr noundef) [[NOT_READNONE]]
+// HAS_MAYTRAP: declare void @sincosf(float noundef, ptr noundef, ptr noundef) [[NOT_READNONE]]
+// HAS_MAYTRAP: declare void @sincosl(x86_fp80 noundef, ptr noundef, ptr noundef) [[NOT_READNONE]]
 
   sqrt(f);       sqrtf(f);      sqrtl(f);
 


### PR DESCRIPTION
This will allow vectorizing these calls (after a few more patches). This should not change the codegen for targets that enable the use of AA during the codegen (in `TargetSubtargetInfo::useAA()`). This includes targets such as AArch64. This notably does not include x86 but can be worked around by passing `-mllvm -combiner-global-alias-analysis=true` to clang.

---

Downstream issue: #87