### PR TITLE
[ATfE] Fix typo on python executable reference for picolibc tests

### DIFF
--- a/arm-software/embedded/arm-runtimes/meson-cross-build.txt.in
+++ b/arm-software/embedded/arm-runtimes/meson-cross-build.txt.in
@@ -8,7 +8,7 @@ strip = '@LLVM_BINARY_DIR@/bin/llvm-strip@CMAKE_EXECUTABLE_SUFFIX@'
 exe_wrapper = [
     'sh',
     '-c',
-    'test -z "$PICOLIBC_TEST" || @Python_EXECUTABLE@ @picolibc_test_executor_bin@ "$@" < /dev/null',
+    'test -z "$PICOLIBC_TEST" || @Python3_EXECUTABLE@ @picolibc_test_executor_bin@ "$@" < /dev/null',
     '@picolibc_test_executor_bin@',
     @meson_test_executor_params@]
 


### PR DESCRIPTION
This cherry-picks the commit de779493b0fb (#89)
