### PR TITLE
Rebase picolibc patches

### DIFF
--- a/arm-software/embedded/patches/picolibc/0001-Enable-libcxx-builds.patch
+++ b/arm-software/embedded/patches/picolibc/0001-Enable-libcxx-builds.patch
@@ -1,4 +1,4 @@
-From bd1dcaa0e3e77260e264cc0c2580bf32f704a0ed Mon Sep 17 00:00:00 2001
+From 253cf7620fe0f935831d5dd4d408ff0b907cd31c Mon Sep 17 00:00:00 2001
 From: Simi Pallipurath <simi.pallipurath@arm.com>
 Date: Thu, 14 Nov 2024 10:07:08 +0000
 Subject: Enable libcxx builds
@@ -11,10 +11,10 @@ libc++ builds.
  2 files changed, 15 insertions(+)
 
 diff --git a/meson.build b/meson.build
-index b8f43c800..9d3f5c672 100644
+index 75dac5275..bc7286442 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -1319,6 +1319,18 @@ if get_option('newlib-retargetable-locking') != get_option('newlib-multithread')
+@@ -1364,6 +1364,18 @@ if get_option('newlib-retargetable-locking') != get_option('newlib-multithread')
    error('newlib-retargetable-locking and newlib-multithread must be set to the same value')
  endif
  
@@ -34,13 +34,13 @@ index b8f43c800..9d3f5c672 100644
  	      cc.has_argument('-fno-tree-loop-distribute-patterns'),
  	      description: 'Compiler flag to prevent detecting memcpy/memset patterns')
 diff --git a/picolibc.ld.in b/picolibc.ld.in
-index 7b63ba172..cda5e1e7e 100644
+index 295131644..0abacadf0 100644
 --- a/picolibc.ld.in
 +++ b/picolibc.ld.in
 @@ -68,6 +68,9 @@ SECTIONS
  		*(.literal.unlikely .text.unlikely .literal.unlikely.* .text.unlikely.*)
  		*(.literal.startup .text.startup .literal.startup.* .text.startup.*)
- 		*(.literal .text .literal.* .text.* .opd .opd.*)
+ 		*(.literal .text .literal.* .text.* .opd .opd.* @EXTRA_TEXT_SECTIONS@)
 +		PROVIDE (__start___lcxx_override = .);
 +		*(__lcxx_override)
 +		PROVIDE (__stop___lcxx_override = .);

--- a/arm-software/embedded/patches/picolibc/0002-Define-picocrt_machines-for-AArch32-builds-as-well-a.patch
+++ b/arm-software/embedded/patches/picolibc/0002-Define-picocrt_machines-for-AArch32-builds-as-well-a.patch
@@ -1,4 +1,4 @@
-From c9a704b1322aec5f699e2962368bbffd286eb010 Mon Sep 17 00:00:00 2001
+From 306f3aac00a63d9cda13be3af8bf4ae8d7d3c9d8 Mon Sep 17 00:00:00 2001
 From: Simi Pallipurath <simi.pallipurath@arm.com>
 Date: Thu, 14 Nov 2024 10:12:33 +0000
 Subject: Define picocrt_machines for AArch32 builds as well as 64.

--- a/arm-software/embedded/patches/picolibc/0003-Add-support-for-strict-align-no-unaligned-access-in-.patch
+++ b/arm-software/embedded/patches/picolibc/0003-Add-support-for-strict-align-no-unaligned-access-in-.patch
@@ -1,4 +1,4 @@
-From ef4378c3f62947b9ce1eac19b717ac44d5aeecb7 Mon Sep 17 00:00:00 2001
+From b3120ec265258f0104bef4a21bc1189de101ab43 Mon Sep 17 00:00:00 2001
 From: Lucas Prates <lucas.prates@arm.com>
 Date: Mon, 11 Nov 2024 16:37:04 +0000
 Subject: Add support for strict-align/no-unaligned-access in AArch64


### PR DESCRIPTION
Commit 0dad9b1 (Add support for target-specific section names in picolibc.ld) in the picolibc repository prevents
0001-Enable-libcxx-builds.patch from being applied cleanly. Only the context around our patches has changed, so a simple rebase is enough to make them apply cleanly again.