### PR TITLE
Fix cmake syntax in generate_version_txt.cmake.

### DIFF
--- a/arm-software/embedded/cmake/generate_version_txt.cmake
+++ b/arm-software/embedded/cmake/generate_version_txt.cmake
@@ -21,7 +21,7 @@ if(NOT (LLVM_TOOLCHAIN_C_LIBRARY STREQUAL llvmlibc)) # libc in a separate repo?
     if(LLVM_TOOLCHAIN_C_LIBRARY MATCHES "^newlib")
         set(base_library newlib)
     else()
-        set(base_library $(LLVM_TOOLCHAIN_C_LIBRARY))
+        set(base_library ${LLVM_TOOLCHAIN_C_LIBRARY})
     endif()
 
     execute_process(


### PR DESCRIPTION
Commit 23f1d7574e801ca included `$(LLVM_TOOLCHAIN_C_LIBRARY)`, which isn't valid cmake syntax – to interpolate a cmake variable you have to use braces, not parentheses.

This led to a mysterious error from git

fatal: cannot change to 'rev-parse': No such file or directory

because once `${base_library}` is set to something that doesn't make sense, `git -C ${${base_library}_SOURCE_DIR} rev-parse HEAD` substitutes nothing at all for the source directory, and the command collapses to just `git -C rev-parse` which indeed interprets `rev-parse` as the directory to change into.