### PR TITLE
Use fixed picolibc version on 20.x release branch

### DIFF
--- a/arm-software/embedded/versions.json
+++ b/arm-software/embedded/versions.json
@@ -8,8 +8,8 @@
   "repos": {
     "picolibc": {
       "url": "https://github.com/picolibc/picolibc.git",
-      "tagType": "branch",
-      "tag": "main"
+      "tagType": "commithash",
+      "tag": "be1b69f5f5910d216c16f9fca927c1bdb4d38a51"
     },
     "newlib": {
       "url": "https://sourceware.org/git/newlib-cygwin.git",


### PR DESCRIPTION
To reduce the need to cherry pick additional changes due to any continuing upstream changes in picolibc, this patch sets the build to use a specific commit of picolibc, instead of fetching the latest.