### PR TITLE
Add logic to multilib.yaml to handle cases of armebv7a_soft_nofp and armebv7a_hard_vfpv3_d16 variants

### DIFF
--- a/arm-software/embedded/arm-multilib/multilib.yaml.in
+++ b/arm-software/embedded/arm-multilib/multilib.yaml.in
@@ -119,6 +119,9 @@ Mappings:
 - Match: --target=thumbv7-unknown-none-eabihf
   Flags:
   - --target=armv7-unknown-none-eabihf
+- Match: --target=thumbebv7-unknown-none-eabihf
+  Flags:
+  - --target=armebv7-unknown-none-eabihf
 - Match: --target=thumbv4t-unknown-none-eabi
   Flags:
   - --target=armv4t-unknown-none-eabi
@@ -140,6 +143,9 @@ Mappings:
 - Match: --target=(arm|thumb)v7ve-unknown-none-eabihf
   Flags:
   - --target=armv7-unknown-none-eabihf
+- Match: --target=(arm|thumb)ebv7ve-unknown-none-eabihf
+  Flags:
+  - --target=armebv7-unknown-none-eabihf
 
 # Higher versions of the architecture such as v8-A and v9-A are a superset of
 # v7-A.

--- a/arm-software/embedded/test/multilib/armv7a.test
+++ b/arm-software/embedded/test/multilib/armv7a.test
@@ -16,6 +16,15 @@
 # NOFP-EXN-RTTI: arm-none-eabi/armv7a_soft_nofp_exn_rtti{{$}}
 # NOFP-EXN-RTTI-EMPTY:
 
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=none -mno-unaligned-access | FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=none -mno-unaligned-access -marm | FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=none -mno-unaligned-access -mthumb| FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -mno-unaligned-access | FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -mno-unaligned-access -marm  | FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -mno-unaligned-access -mthumb| FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
+# NOFP-EXN-RTTI-BE: arm-none-eabi/armebv7a_soft_nofp_exn_rtti{{$}}
+# NOFP-EXN-RTTI-BE-EMPTY:
+
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mfpu=none -fno-exceptions -fno-rtti | FileCheck %s --check-prefix=NOFP-UNALIGNED
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mfpu=none -marm  -fno-exceptions -fno-rtti | FileCheck %s --check-prefix=NOFP-UNALIGNED
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mfpu=none -mthumb -fno-exceptions -fno-rtti | FileCheck %s --check-prefix=NOFP-UNALIGNED
@@ -33,6 +42,15 @@
 # RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mfpu=none -fno-exceptions -fno-rtti -mno-unaligned-access -mthumb| FileCheck --check-prefix=NOFP %s
 # NOFP: arm-none-eabi/armv7a_soft_nofp{{$}}
 # NOFP-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=NOFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti -mno-unaligned-access -marm | FileCheck --check-prefix=NOFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti -mno-unaligned-access -mthumb| FileCheck --check-prefix=NOFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=NOFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti -mno-unaligned-access -marm  | FileCheck --check-prefix=NOFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti -mno-unaligned-access -mthumb| FileCheck --check-prefix=NOFP-BE %s
+# NOFP-BE: arm-none-eabi/armebv7a_soft_nofp{{$}}
+# NOFP-BE-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=vfpv3-d16 | FileCheck --check-prefix=VFPV3-EXN-RTTI-UNALIGNED %s
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=neon-vfpv3 | FileCheck --check-prefix=VFPV3-EXN-RTTI-UNALIGNED %s
@@ -66,6 +84,22 @@
 # VFPV3-EXN-RTTI: arm-none-eabi/armv7a_hard_vfpv3_d16_exn_rtti{{$}}
 # VFPV3-EXN-RTTI-EMPTY:
 
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=neon-vfpv3 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16-fp16 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-fp16 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv4-d16 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv4 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=neon-fp16 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=neon-vfpv4 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -marm -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -mthumb -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -mthumb -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# VFPV3-EXN-RTTI-BE: arm-none-eabi/armebv7a_hard_vfpv3_d16_exn_rtti{{$}}
+# VFPV3-EXN-RTTI-BE-EMPTY:
+
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=vfpv3-d16 -fno-exceptions -fno-rtti | FileCheck --check-prefix=VFPV3-UNALIGNED %s
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=neon-vfpv3 -fno-exceptions -fno-rtti| FileCheck --check-prefix=VFPV3-UNALIGNED %s
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=vfpv3 -fno-exceptions -fno-rtti| FileCheck --check-prefix=VFPV3-UNALIGNED %s
@@ -97,6 +131,22 @@
 # RUN: %clang -print-multi-directory --target=armv7ve-none-eabihf -mfpu=vfpv3-d16 -fno-exceptions -fno-rtti -mthumb -mno-unaligned-access | FileCheck --check-prefix=VFPV3 %s
 # VFPV3: arm-none-eabi/armv7a_hard_vfpv3_d16{{$}}
 # VFPV3-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=neon-vfpv3 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16-fp16 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-fp16 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv4-d16 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv4 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=neon-fp16 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=neon-vfpv4 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -marm -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -mthumb -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -fno-exceptions -fno-rtti -mthumb -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# VFPV3-BE: arm-none-eabi/armebv7a_hard_vfpv3_d16{{$}}
+# VFPV3-BE-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mfpu=vfpv3-d16 -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-VFPV3-EXN-RTTI-UNALIGNED %s
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mfpu=neon-vfpv3 -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-VFPV3-EXN-RTTI-UNALIGNED %s


### PR DESCRIPTION
These variants were missing some logic in multilib.yaml: some of the flag matching rules existed only for little endian. Thus they had to be copied for big endian as well.

Besides the changes to multilib.yaml, tests have been added to properly test the library selection of the variants.