### PR TITLE
[ATfE] Enable FVP testing in build script if available

### DIFF
--- a/arm-software/embedded/scripts/build.sh
+++ b/arm-software/embedded/scripts/build.sh
@@ -10,6 +10,9 @@
 # The script creates a build of the toolchain in the 'build' directory, inside
 # the repository tree.
 
+# If FVPs have been installed, the environment variable `FVP_INSTALL_DIR`
+# should be set to their install location to enable their use in tests.
+
 set -ex
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
@@ -20,8 +23,13 @@ clang --version
 export CC=clang
 export CXX=clang++
 
+EXTRA_CMAKE_ARGS=""
+if [[ ! -z "${FVP_INSTALL_DIR}" ]]; then
+    EXTRA_CMAKE_ARGS="${EXTRA_CMAKE_ARGS} -DENABLE_FVP_TESTING=ON -DFVP_INSTALL_DIR=${FVP_INSTALL_DIR}"
+fi
+
 mkdir -p ${REPO_ROOT}/build
 cd ${REPO_ROOT}/build
 
-cmake ../arm-software/embedded -GNinja -DFETCHCONTENT_QUIET=OFF
+cmake ../arm-software/embedded -GNinja -DFETCHCONTENT_QUIET=OFF ${EXTRA_CMAKE_ARGS}
 ninja package-llvm-toolchain


### PR DESCRIPTION
If FVPs have been installed using the `get_fvps.sh` script, then this patch allows them to be used in the `build.sh` script by setting the `FVP_INSTALL_DIR` environment variable to the install location.