### PR TITLE
Update Automerge workflow to use App Access Token

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -20,10 +20,17 @@ jobs:
           - from_branch: release/20.x
             to_branch: release/arm-software/20.x
     steps:
+      - name: Configure Access Token
+        uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app-id: ${{ secrets.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v4
         with:
-            ref: ${{ matrix.branches.to_branch }}
+          ref: ${{ matrix.branches.to_branch }}
+          token: ${{ steps.generate-token.outputs.token }}
       - name: Configure Git Identity
         run: |
           git config --local user.name "github-actions[bot]"


### PR DESCRIPTION
This updates the "Automerge" workflow to use the same App Access Token
used by the "Sync from Upstream LLVM" workflow. This is necessary to
allow the aotumerge script to bypass the branch protection rules of the
repo, once PR approvals are required for merges.
