### PR TITLE
[ATfE] Update downstream performance patches

### DIFF
--- a/arm-software/embedded/patches/llvm-project-perf/0001-Pipelines-Additional-unrolling-in-LTO.patch
+++ b/arm-software/embedded/patches/llvm-project-perf/0001-Pipelines-Additional-unrolling-in-LTO.patch
@@ -1,14 +1,14 @@
-From 4adfc5231d2c0182d6278b4aa75eec57648e5dd4 Mon Sep 17 00:00:00 2001
+From 47dd90545df09ec7f74a9a617cf3b63e9cf8f26b Mon Sep 17 00:00:00 2001
 From: Vladi Krapp <vladi.krapp@arm.com>
 Date: Tue, 3 Sep 2024 14:12:48 +0100
-Subject: [Pipelines] Additional unrolling  in LTO 
+Subject: [Pipelines] Additional unrolling  in LTO
 
 Some workloads require specific sequences of events to happen
 to fully simplify. This adds an extra full unrolling pass to help these
 cases on the cores with branch predictors. It helps produce simplified
 loops, which can then be SROA'd allowing further simplification, which
 can be important for performance.
-Feature adds extra compile time to get extra performance and 
+Feature adds extra compile time to get extra performance and
 is enabled by the opt flag 'extra-LTO-loop-unroll' (off by default).
 
 Original patch by David Green (david.green@arm.com)
@@ -17,7 +17,7 @@ Original patch by David Green (david.green@arm.com)
  1 file changed, 16 insertions(+)
 
 diff --git a/llvm/lib/Passes/PassBuilderPipelines.cpp b/llvm/lib/Passes/PassBuilderPipelines.cpp
-index 1184123c7710..6dc45d85927a 100644
+index 4632a0e46908..c625e2424f8b 100644
 --- a/llvm/lib/Passes/PassBuilderPipelines.cpp
 +++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
 @@ -332,6 +332,10 @@ namespace llvm {
@@ -31,8 +31,8 @@ index 1184123c7710..6dc45d85927a 100644
  void PassBuilder::invokePeepholeEPCallbacks(FunctionPassManager &FPM,
                                              OptimizationLevel Level) {
    for (auto &C : PeepholeEPCallbacks)
-@@ -1940,6 +1944,18 @@ PassBuilder::buildLTODefaultPipeline(OptimizationLevel Level,
-   MPM.addPass(createModuleToPostOrderCGSCCPassAdaptor(ArgumentPromotionPass()));
+@@ -2018,6 +2022,18 @@ PassBuilder::buildLTODefaultPipeline(OptimizationLevel Level,
+   MPM.addPass(createModuleToPostOrderCGSCCPassAdaptor(std::move(CGPM)));
  
    FunctionPassManager FPM;
 +
@@ -51,5 +51,5 @@ index 1184123c7710..6dc45d85927a 100644
    FPM.addPass(InstCombinePass());
    invokePeepholeEPCallbacks(FPM, Level);
 -- 
-2.34.1
+2.43.0
 

--- a/arm-software/embedded/patches/llvm-project-perf/0002-ARM-CodeGen-Prefer-MEMCPY-LDM-STM-inlining-for-v7-m.patch
+++ b/arm-software/embedded/patches/llvm-project-perf/0002-ARM-CodeGen-Prefer-MEMCPY-LDM-STM-inlining-for-v7-m.patch
@@ -1,8 +1,14 @@
-From 411bab1ff439215c060127b6a5188ed0c9ed5d65 Mon Sep 17 00:00:00 2001
-From: Vrukesh V Panse <vrukesh.panse@arm.com>
-Date: Thu, 2 Jan 2025 10:29:56 +0000
-Subject: [NFC]: Update the patch file with upstream changes of SelectionDAG
+From 56b1d9becf044649a759129b986de71cc43b4c29 Mon Sep 17 00:00:00 2001
+From: Scott Douglass <scott.douglass@arm.com>
+Date: Tue, 13 Aug 2024 10:55:51 +0100
+Subject: [ARM][CodeGen]Prefer MEMCPY LDM/STM inlining for v7-m
 
+This patch changes the behaviour of memcpy inlining on v7m targets.
+The old behaviour was to inline memcpys with LDM/STM instructions.
+Alternatively, using LD/ST instructions for memcpy inlining allowed
+for performance gains of 1% to 2% on selected benchmarks.
+
+Co-authored-by: Nashe Mncube <nashe.mncube@arm.com>
 ---
  llvm/lib/Target/ARM/ARMSelectionDAGInfo.cpp | 120 +++++++++++++++
  llvm/lib/Target/ARM/ARMSelectionDAGInfo.h   |   6 +
@@ -340,5 +346,5 @@ index 000000000000..e549958494dc
 +  ret void
 +}
 -- 
-2.34.1
+2.43.0
 


### PR DESCRIPTION
The `Additional unrolling in LTO` patch has been rebased against an upstream change, while `Prefer MEMCPY LDM/STM inlining for v7-m` has had the original commit message restored in order to provide context for the change.

The filenames now also match the subject of the commit message, as they have been regenerated using git format-patch.