### PR TITLE
[ATfE] Disable audio device in FVP tests

### DIFF
--- a/arm-software/embedded/fvp/config/v8a-aarch32.cfg
+++ b/arm-software/embedded/fvp/config/v8a-aarch32.cfg
@@ -18,3 +18,6 @@ bp.secure_memory=0
 
 # Boot in AArch32 mode
 cluster0.cpu0.CONFIG64=0
+
+# Disable audio interface
+bp.pl041_aaci.enabled=0

--- a/arm-software/embedded/fvp/config/v8a-aarch64.cfg
+++ b/arm-software/embedded/fvp/config/v8a-aarch64.cfg
@@ -18,3 +18,6 @@ bp.secure_memory=0
 
 # Boot in AArch64 mode
 cluster0.cpu0.CONFIG64=1
+
+# Disable audio interface
+bp.pl041_aaci.enabled=0

--- a/arm-software/embedded/fvp/config/v8r-aarch32.cfg
+++ b/arm-software/embedded/fvp/config/v8r-aarch32.cfg
@@ -14,3 +14,6 @@ cluster0.NUM_CORES=1
 
 # AArch32 mode
 cluster0.has_aarch64=0
+
+# Disable audio interface
+bp.pl041_aaci.enabled=0

--- a/arm-software/embedded/fvp/config/v8r-aarch64.cfg
+++ b/arm-software/embedded/fvp/config/v8r-aarch64.cfg
@@ -21,3 +21,6 @@ cluster0.gicv3.cpuintf-mmap-access-level=2
 cluster0.gicv3.SRE-enable-action-on-mmap=2
 cluster0.gicv3.SRE-EL2-enable-RAO=1
 cluster0.gicv3.extended-interrupt-range-support=1
+
+# Disable audio interface
+bp.pl041_aaci.enabled=0


### PR DESCRIPTION
The FVP models include an implementation of a sound device, however when running a large number of tests concurrently this can cause errors with the sound driver.

Since we do not need audio output for our tests, this patch disables the audio device.