### PR TITLE
[ATfE] Add additional test targets to test script

### DIFF
--- a/arm-software/embedded/scripts/test.sh
+++ b/arm-software/embedded/scripts/test.sh
@@ -15,5 +15,10 @@ set -ex
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$( git -C ${SCRIPT_DIR} rev-parse --show-toplevel )
 
+# In order to get results for all variants, ignore any failures
+# in the individual library tests. --ignore-fail only works with
+# lit based tests.
+export LIT_OPTS="--ignore-fail"
+
 cd ${REPO_ROOT}/build
-ninja check-llvm-toolchain
+ninja check-all check-llvm-toolchain check-cxxabi check-unwind check-package-llvm-toolchain


### PR DESCRIPTION
The `check-llvm-toolchain` target misses some available tests, however the `check-all-llvm-toolchain` target would include libcxx tests which we do not want to run from `test.sh` due to the long duration.

This patch instead adds the following targets:
* `check-all` to run the upstream clang/llvm tests, to ensure we get the same results after any downstream changes.
* `check-cxxabi` and `check-unwind` since these are much quicker to run compared to `check-cxx`.
* `check-package-llvm-toolchain` to check the package and run samples

The lit option `--ignore-fail` also allows the tests to continue after a failure, so that a failure in one variant does not prevent testing of another.