### PR TITLE
Disable libcxx tests on armebv6m_soft_nofp variants (#66)

### DIFF
--- a/arm-software/embedded/arm-multilib/json/variants/armebv6m_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armebv6m_soft_nofp.json
@@ -22,7 +22,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "ON"
+            "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {
             "ENABLE_CXX_LIBS": "ON",

--- a/arm-software/embedded/arm-multilib/json/variants/armebv6m_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armebv6m_soft_nofp_exn_rtti.json
@@ -22,7 +22,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "ON"
+            "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {
             "ENABLE_CXX_LIBS": "ON",


### PR DESCRIPTION
Some libcxx tests are failing on this variant, despite whether any of the failures are exclusive to this variant is unknown.

For now the libcxx tests will remain disabled while we focus on having C library tests passing for new variants we add.

(cherry picked from https://github.com/arm/arm-toolchain/pull/66)