### PR TITLE
[ATfE] Set Arm Toolchain ID

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -334,6 +334,12 @@ install(
     COMPONENT llvm-toolchain-config-files
 )
 
+# Generate a toolchain ID.
+# Product code 'E' for Embedded.
+set(LLVM_TOOLCHAIN_PROJECT_CODE "E")
+set(LLVM_TOOLCHAIN_VERSION_SUFFIX "pre")
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/generate_toolchain_id.cmake)
+
 set(llvmproject_src_dir ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 add_subdirectory(
     ${llvmproject_src_dir}/llvm llvm

--- a/arm-software/embedded/cmake/generate_toolchain_id.cmake
+++ b/arm-software/embedded/cmake/generate_toolchain_id.cmake
@@ -1,0 +1,37 @@
+# Generate a toolchain ID.
+# This should identify the product, and where the build came from.
+
+# The ID begins with a product code (e.g. E for Embedded), followed
+# by build identifier. The build identifier will depend on the
+# build environment: for Jenkins builds, the pipeline and build
+# number will be sufficient.
+
+if(NOT DEFINED LLVM_TOOLCHAIN_PROJECT_CODE)
+    message(FATAL_ERROR "LLVM_TOOLCHAIN_PROJECT_CODE must be set before including generate_toolchain_id.cmake")
+endif()
+
+# JENKINS_URL, BUILD_URL and BUILD_NUMBER will be set in a Jenkins environment.
+if(DEFINED ENV{JENKINS_URL} AND DEFINED ENV{BUILD_URL} AND DEFINED ENV{BUILD_NUMBER})
+    set(builder_name $ENV{BUILD_URL})
+    set(build_number $ENV{BUILD_NUMBER})
+    # BUILD_URL also contains the build number, which is not needed.
+    string(REGEX REPLACE "/${build_number}/$" "/" builder_name ${builder_name})
+else()
+    # Use HOSTNAME if nothing else is available.
+    cmake_host_system_information(RESULT builder_name QUERY HOSTNAME)
+    set(build_number 0)
+endif()
+
+# Version suffix should be optional.
+if(DEFINED LLVM_TOOLCHAIN_VERSION_SUFFIX)
+    set(ID_SUFFIX "-${LLVM_TOOLCHAIN_VERSION_SUFFIX}")
+else()
+    set(ID_SUFFIX "")
+endif()
+
+string(SHA256 builder_name_hash ${builder_name})
+string(SUBSTRING ${builder_name_hash} 0 8 builder_name_hash)
+set(ARM_TOOLCHAIN_ID
+    "${LLVM_TOOLCHAIN_PROJECT_CODE}${build_number}${ID_SUFFIX} (${builder_name_hash})" CACHE STRING
+    "Toolchain ID to identify product."
+)


### PR DESCRIPTION
In order to uniquely identify ATfE builds, this patch populates the new Arm Toolchain ID with an auto-generated tag.

This tag contains both the product code (E for Embedded), as well as a unique identifier for the build. In a Jenkins environment, this will be based on the build URL and build number.