### PR TITLE
[ATfL] Do not use libzstd.a when building shared runtime libs

### DIFF
--- a/arm-software/linux/build.sh
+++ b/arm-software/linux/build.sh
@@ -350,7 +350,7 @@ shared_lib_build() {
     run_command cmake ${CMAKE_ARGS} -G Ninja "${SOURCES_DIR}/llvm" \
         -DBUILD_SHARED_LIBS=True \
         -DLIBOMP_ENABLE_SHARED=False \
-        "${COMMON_CMAKE_FLAGS[@]}" "${PRODUCT_CMAKE_FLAGS[@]}" "${COMPILER_CMAKE_FLAGS[@]}" "${LIBUNWIND_SHARED_CMAKE_FLAGS[@]}" ${extra_flags} 2>&1 |
+        "${COMMON_CMAKE_FLAGS[@]}" -DLLVM_ENABLE_ZSTD=OFF "${PRODUCT_CMAKE_FLAGS[@]}" "${COMPILER_CMAKE_FLAGS[@]}" "${LIBUNWIND_SHARED_CMAKE_FLAGS[@]}" ${extra_flags} 2>&1 |
         tee "${LOGS_DIR}/shared_lib.txt"
     run_command cmake --build . ${CMAKE_BUILD_ARGS} 2>&1 | tee -a "${LOGS_DIR}/shared_lib.txt"
     rm -rf "${ATFL_DIR}.keep" "${ATFL_DIR}.libs"


### PR DESCRIPTION
At the shared_lib_build stage we do not need ZSTD as the main goal of this stage is to provide shared runtime libraries, while ZSTD is being used at compile time. Sadly, there is no way (yet) to eliminate remaining attempts to build other things at this stage, and some of this stuff is linked against libzstd. Unfortunately, on some Linux distributions, those static variants of libraries that we are using to build ATfL were not built with -fPIC, resulting in linker failures. The only way to prevent this is to override one of the COMMON_CMAKE_FLAGS and disable the use of ZSTD at this stage.