### PR TITLE
Cherry-pick: Integrating Changes from PR #99, #102 and #115

### DIFF
--- a/arm-software/embedded/arm-multilib/json/multilib.json
+++ b/arm-software/embedded/arm-multilib/json/multilib.json
@@ -187,12 +187,12 @@
         {
             "variant": "armebv7a_soft_nofp_exn_rtti",
             "json": "armebv7a_soft_nofp_exn_rtti.json",
-            "flags": "--target=armebv7-unknown-none-eabi -mfpu=none -mno-unaligned-access"
+            "flags": "--target=armebv7-unknown-none-eabi -mfpu=none"
         },
         {
             "variant": "armebv7a_soft_nofp",
             "json": "armebv7a_soft_nofp.json",
-            "flags": "--target=armebv7-unknown-none-eabi -mfpu=none -fno-exceptions -fno-rtti -mno-unaligned-access"
+            "flags": "--target=armebv7-unknown-none-eabi -mfpu=none -fno-exceptions -fno-rtti"
         },
         {
             "variant": "armv7a_hard_vfpv3_d16_exn_rtti_unaligned",
@@ -217,12 +217,12 @@
         {
             "variant": "armebv7a_hard_vfpv3_d16_exn_rtti",
             "json": "armebv7a_hard_vfpv3_d16_exn_rtti.json",
-            "flags": "--target=armebv7-unknown-none-eabihf -mfpu=vfpv3-d16 -mno-unaligned-access"
+            "flags": "--target=armebv7-unknown-none-eabihf -mfpu=vfpv3-d16"
         },
         {
             "variant": "armebv7a_hard_vfpv3_d16",
             "json": "armebv7a_hard_vfpv3_d16.json",
-            "flags": "--target=armebv7-unknown-none-eabihf -mfpu=vfpv3-d16 -fno-exceptions -fno-rtti -mno-unaligned-access"
+            "flags": "--target=armebv7-unknown-none-eabihf -mfpu=vfpv3-d16 -fno-exceptions -fno-rtti"
         },
         {
             "variant": "armv7a_soft_vfpv3_d16_exn_rtti_unaligned",
@@ -247,12 +247,12 @@
         {
             "variant": "armebv7a_soft_vfpv3_d16_exn_rtti",
             "json": "armebv7a_soft_vfpv3_d16_exn_rtti.json",
-            "flags": "--target=armebv7-unknown-none-eabi -mfpu=vfpv3-d16 -mno-unaligned-access"
+            "flags": "--target=armebv7-unknown-none-eabi -mfpu=vfpv3-d16"
         },
         {
             "variant": "armebv7a_soft_vfpv3_d16",
             "json": "armebv7a_soft_vfpv3_d16.json",
-            "flags": "--target=armebv7-unknown-none-eabi -mfpu=vfpv3-d16 -fno-exceptions -fno-rtti -mno-unaligned-access"
+            "flags": "--target=armebv7-unknown-none-eabi -mfpu=vfpv3-d16 -fno-exceptions -fno-rtti"
         },
         {
             "variant": "armv7r_soft_nofp_exn_rtti_unaligned",

--- a/arm-software/embedded/arm-multilib/json/multilib.json
+++ b/arm-software/embedded/arm-multilib/json/multilib.json
@@ -85,6 +85,36 @@
             "flags": "--target=aarch64-unknown-none-elf -march=armv8-r -fno-exceptions -fno-rtti -mno-unaligned-access"
         },
         {
+            "variant": "aarch64r_soft_nofp_exn_rtti_unaligned",
+            "json": "aarch64r_soft_nofp_exn_rtti_unaligned.json",
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8-r -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft"
+        },
+        {
+            "variant": "aarch64r_soft_nofp_unaligned",
+            "json": "aarch64r_soft_nofp_unaligned.json",
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8-r -march=armvX+nofp -march=armvX+nosimd -fno-exceptions -fno-rtti -mabi=aapcs-soft"
+        },
+        {
+            "variant": "aarch64r_soft_nofp_exn_rtti",
+            "json": "aarch64r_soft_nofp_exn_rtti.json",
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8-r -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft -mno-unaligned-access"
+        },
+        {
+            "variant": "aarch64r_soft_nofp",
+            "json": "aarch64r_soft_nofp.json",
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8-r -march=armvX+nofp -march=armvX+nosimd -fno-exceptions -fno-rtti -mabi=aapcs-soft -mno-unaligned-access"
+        },
+        {
+            "variant": "aarch64r_be_soft_nofp_exn_rtti",
+            "json": "aarch64r_be_soft_nofp_exn_rtti.json",
+            "flags": "--target=aarch64_be-unknown-none-elf -march=armv8-r -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft"
+        },
+        {
+            "variant": "aarch64r_be_soft_nofp",
+            "json": "aarch64r_be_soft_nofp.json",
+            "flags": "--target=aarch64_be-unknown-none-elf -march=armv8-r -march=armvX+nofp -march=armvX+nosimd -fno-exceptions -fno-rtti -mabi=aapcs-soft"
+        },
+        {
             "variant": "armv4t_exn_rtti",
             "json": "armv4t_exn_rtti.json",
             "flags": "--target=armv4t-unknown-none-eabi -mfpu=none"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_soft_nofp.json
@@ -1,0 +1,40 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "aarch64r",
+            "VARIANT": "aarch64r_be_soft_nofp",
+            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mbig-endian -mabi=aapcs-soft -mno-unaligned-access",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "fvp",
+            "FVP_MODEL": "aem-r",
+            "FVP_CONFIG": "v8r-aarch64 big-endian",
+            "BOOT_FLASH_ADDRESS": "0x0",
+            "BOOT_FLASH_SIZE": "0x1000",
+            "FLASH_ADDRESS": "0x1000",
+            "FLASH_SIZE": "0xfff000",
+            "RAM_ADDRESS": "0x1000000",
+            "RAM_SIZE": "0x1000000",
+            "STACK_SIZE": "8K"
+        },
+        "picolibc": {
+            "PICOLIBC_BUILD_TYPE": "release",
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "newlib": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "llvmlibc": {
+            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_soft_nofp_exn_rtti.json
@@ -1,0 +1,40 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "aarch64r",
+            "VARIANT": "aarch64r_be_soft_nofp_exn_rtti",
+            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mbig-endian -mabi=aapcs-soft -mno-unaligned-access",
+            "ENABLE_EXCEPTIONS": "ON",
+            "ENABLE_RTTI": "ON",
+            "TEST_EXECUTOR": "fvp",
+            "FVP_MODEL": "aem-r",
+            "FVP_CONFIG": "v8r-aarch64 big-endian",
+            "BOOT_FLASH_ADDRESS": "0x0",
+            "BOOT_FLASH_SIZE": "0x1000",
+            "FLASH_ADDRESS": "0x1000",
+            "FLASH_SIZE": "0xfff000",
+            "RAM_ADDRESS": "0x1000000",
+            "RAM_SIZE": "0x1000000",
+            "STACK_SIZE": "8K"
+        },
+        "picolibc": {
+            "PICOLIBC_BUILD_TYPE": "release",
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "newlib": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "llvmlibc": {
+            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp.json
@@ -1,0 +1,40 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "aarch64r",
+            "VARIANT": "aarch64r_soft_nofp",
+            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "fvp",
+            "FVP_MODEL": "aem-r",
+            "FVP_CONFIG": "v8r-aarch64",
+            "BOOT_FLASH_ADDRESS": "0x0",
+            "BOOT_FLASH_SIZE": "0x1000",
+            "FLASH_ADDRESS": "0x1000",
+            "FLASH_SIZE": "0xfff000",
+            "RAM_ADDRESS": "0x1000000",
+            "RAM_SIZE": "0x1000000",
+            "STACK_SIZE": "8K"
+        },
+        "picolibc": {
+            "PICOLIBC_BUILD_TYPE": "release",
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "newlib": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "llvmlibc": {
+            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_exn_rtti.json
@@ -1,0 +1,40 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "aarch64r",
+            "VARIANT": "aarch64r_soft_nofp_exn_rtti",
+            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access",
+            "ENABLE_EXCEPTIONS": "ON",
+            "ENABLE_RTTI": "ON",
+            "TEST_EXECUTOR": "fvp",
+            "FVP_MODEL": "aem-r",
+            "FVP_CONFIG": "v8r-aarch64",
+            "BOOT_FLASH_ADDRESS": "0x0",
+            "BOOT_FLASH_SIZE": "0x1000",
+            "FLASH_ADDRESS": "0x1000",
+            "FLASH_SIZE": "0xfff000",
+            "RAM_ADDRESS": "0x1000000",
+            "RAM_SIZE": "0x1000000",
+            "STACK_SIZE": "8K"
+        },
+        "picolibc": {
+            "PICOLIBC_BUILD_TYPE": "release",
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "newlib": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "llvmlibc": {
+            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_exn_rtti_unaligned.json
@@ -1,0 +1,40 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "aarch64r",
+            "VARIANT": "aarch64r_soft_nofp_exn_rtti_unaligned",
+            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mabi=aapcs-soft",
+            "ENABLE_EXCEPTIONS": "ON",
+            "ENABLE_RTTI": "ON",
+            "TEST_EXECUTOR": "fvp",
+            "FVP_MODEL": "aem-r",
+            "FVP_CONFIG": "v8r-aarch64",
+            "BOOT_FLASH_ADDRESS": "0x0",
+            "BOOT_FLASH_SIZE": "0x1000",
+            "FLASH_ADDRESS": "0x1000",
+            "FLASH_SIZE": "0xfff000",
+            "RAM_ADDRESS": "0x1000000",
+            "RAM_SIZE": "0x1000000",
+            "STACK_SIZE": "8K"
+        },
+        "picolibc": {
+            "PICOLIBC_BUILD_TYPE": "release",
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "newlib": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "llvmlibc": {
+            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_unaligned.json
@@ -1,0 +1,40 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "aarch64r",
+            "VARIANT": "aarch64r_soft_nofp_unaligned",
+            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mabi=aapcs-soft",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "fvp",
+            "FVP_MODEL": "aem-r",
+            "FVP_CONFIG": "v8r-aarch64",
+            "BOOT_FLASH_ADDRESS": "0x0",
+            "BOOT_FLASH_SIZE": "0x1000",
+            "FLASH_ADDRESS": "0x1000",
+            "FLASH_SIZE": "0xfff000",
+            "RAM_ADDRESS": "0x1000000",
+            "RAM_SIZE": "0x1000000",
+            "STACK_SIZE": "8K"
+        },
+        "picolibc": {
+            "PICOLIBC_BUILD_TYPE": "release",
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "newlib": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "llvmlibc": {
+            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/arm-software/embedded/arm-multilib/multilib.yaml.in
+++ b/arm-software/embedded/arm-multilib/multilib.yaml.in
@@ -122,6 +122,9 @@ Mappings:
 - Match: --target=thumbv7-unknown-none-eabihf
   Flags:
   - --target=armv7-unknown-none-eabihf
+- Match: --target=thumbebv7-unknown-none-eabihf
+  Flags:
+  - --target=armebv7-unknown-none-eabihf
 - Match: --target=thumbv4t-unknown-none-eabi
   Flags:
   - --target=armv4t-unknown-none-eabi
@@ -146,6 +149,9 @@ Mappings:
 - Match: --target=(arm|thumb)v7ve-unknown-none-eabihf
   Flags:
   - --target=armv7-unknown-none-eabihf
+- Match: --target=(arm|thumb)ebv7ve-unknown-none-eabihf
+  Flags:
+  - --target=armebv7-unknown-none-eabihf
 
 # Higher versions of the architecture such as v8-A and v9-A are a superset of
 # v7-A.

--- a/arm-software/embedded/test/multilib/aarch64.test
+++ b/arm-software/embedded/test/multilib/aarch64.test
@@ -32,6 +32,18 @@
 # AARCH64R-UNALIGNED: aarch64-none-elf/aarch64r_unaligned{{$}}
 # AARCH64R-UNALIGNED-EMPTY:
 
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8-r+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=AARCH64R-NOFP-EXNRTTI-UNALIGNED
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-r82+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=AARCH64R-NOFP-EXNRTTI-UNALIGNED
+
+# AARCH64R-NOFP-EXNRTTI-UNALIGNED: aarch64-none-elf/aarch64r_soft_nofp_exn_rtti_unaligned{{$}}
+# AARCH64R-NOFP-EXNRTTI-UNALIGNED-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8-r+nofp+nosimd -fno-exceptions -fno-rtti -mabi=aapcs-soft | FileCheck %s --check-prefix=AARCH64R-NOFP-UNALIGNED
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-r82+nofp+nosimd -fno-exceptions -fno-rtti -mabi=aapcs-soft | FileCheck %s --check-prefix=AARCH64R-NOFP-UNALIGNED
+
+# AARCH64R-NOFP-UNALIGNED: aarch64-none-elf/aarch64r_soft_nofp_unaligned{{$}}
+# AARCH64R-NOFP-UNALIGNED-EMPTY:
+
 
 # Strictalign
 
@@ -69,6 +81,17 @@
 # AARCH64R: aarch64-none-elf/aarch64r{{$}}
 # AARCH64R-EMPTY:
 
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8-r+nofp+nosimd -mno-unaligned-access -mabi=aapcs-soft | FileCheck %s --check-prefix=AARCH64R-NOFP-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-r82+nofp+nosimd -mno-unaligned-access -mabi=aapcs-soft | FileCheck %s --check-prefix=AARCH64R-NOFP-EXNRTTI
+
+# AARCH64R-NOFP-EXNRTTI: aarch64-none-elf/aarch64r_soft_nofp_exn_rtti{{$}}
+# AARCH64R-NOFP-EXNRTTI-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8-r+nofp+nosimd -fno-exceptions -fno-rtti -mno-unaligned-access -mabi=aapcs-soft | FileCheck %s --check-prefix=AARCH64R-NOFP
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-r82+nofp+nosimd -fno-exceptions -fno-rtti -mno-unaligned-access -mabi=aapcs-soft | FileCheck %s --check-prefix=AARCH64R-NOFP
+
+# AARCH64R-NOFP: aarch64-none-elf/aarch64r_soft_nofp{{$}}
+# AARCH64R-NOFP-EMPTY:
 
 # Big endian
 
@@ -123,3 +146,20 @@
 
 # AARCH64R-BE: aarch64-none-elf/aarch64r_be{{$}}
 # AARCH64R-BE-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8-r+nofp+nosimd -mno-unaligned-access -mbig-endian -mabi=aapcs-soft | FileCheck %s --check-prefix=AARCH64R-BE-NOFP-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-r82+nofp+nosimd -mno-unaligned-access -mbig-endian -mabi=aapcs-soft | FileCheck %s --check-prefix=AARCH64R-BE-NOFP-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8-r+nofp+nosimd -mbig-endian -mabi=aapcs-soft | FileCheck %s --check-prefix=AARCH64R-BE-NOFP-EXNRTTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-r82+nofp+nosimd -mbig-endian -mabi=aapcs-soft | FileCheck %s --check-prefix=AARCH64R-BE-NOFP-EXNRTTI
+
+# AARCH64R-BE-NOFP-EXNRTTI: aarch64-none-elf/aarch64r_be_soft_nofp_exn_rtti{{$}}
+# AARCH64R-BE-NOFP-EXNRTTI-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8-r+nofp+nosimd -fno-exceptions -fno-rtti -mno-unaligned-access -mbig-endian -mabi=aapcs-soft | FileCheck %s --check-prefix=AARCH64R-BE-NOFP
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-r82+nofp+nosimd -fno-exceptions -fno-rtti -mno-unaligned-access -mbig-endian -mabi=aapcs-soft | FileCheck %s --check-prefix=AARCH64R-BE-NOFP
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8-r+nofp+nosimd -fno-exceptions -fno-rtti -mbig-endian -mabi=aapcs-soft | FileCheck %s --check-prefix=AARCH64R-BE-NOFP
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-r82+nofp+nosimd -fno-exceptions -fno-rtti -mbig-endian -mabi=aapcs-soft | FileCheck %s --check-prefix=AARCH64R-BE-NOFP
+
+# AARCH64R-BE-NOFP: aarch64-none-elf/aarch64r_be_soft_nofp{{$}}
+# AARCH64R-BE-NOFP-EMPTY:
+

--- a/arm-software/embedded/test/multilib/armv7a.test
+++ b/arm-software/embedded/test/multilib/armv7a.test
@@ -16,6 +16,15 @@
 # NOFP-EXN-RTTI: arm-none-eabi/armv7a_soft_nofp_exn_rtti{{$}}
 # NOFP-EXN-RTTI-EMPTY:
 
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=none -mno-unaligned-access | FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=none -mno-unaligned-access -marm | FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=none -mno-unaligned-access -mthumb| FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -mno-unaligned-access | FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -mno-unaligned-access -marm  | FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -mno-unaligned-access -mthumb| FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
+# NOFP-EXN-RTTI-BE: arm-none-eabi/armebv7a_soft_nofp_exn_rtti{{$}}
+# NOFP-EXN-RTTI-BE-EMPTY:
+
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mfpu=none -fno-exceptions -fno-rtti | FileCheck %s --check-prefix=NOFP-UNALIGNED
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mfpu=none -marm  -fno-exceptions -fno-rtti | FileCheck %s --check-prefix=NOFP-UNALIGNED
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mfpu=none -mthumb -fno-exceptions -fno-rtti | FileCheck %s --check-prefix=NOFP-UNALIGNED
@@ -33,6 +42,15 @@
 # RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mfpu=none -fno-exceptions -fno-rtti -mno-unaligned-access -mthumb| FileCheck --check-prefix=NOFP %s
 # NOFP: arm-none-eabi/armv7a_soft_nofp{{$}}
 # NOFP-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=NOFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti -mno-unaligned-access -marm | FileCheck --check-prefix=NOFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti -mno-unaligned-access -mthumb| FileCheck --check-prefix=NOFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=NOFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti -mno-unaligned-access -marm  | FileCheck --check-prefix=NOFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti -mno-unaligned-access -mthumb| FileCheck --check-prefix=NOFP-BE %s
+# NOFP-BE: arm-none-eabi/armebv7a_soft_nofp{{$}}
+# NOFP-BE-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=vfpv3-d16 | FileCheck --check-prefix=VFPV3-EXN-RTTI-UNALIGNED %s
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=neon-vfpv3 | FileCheck --check-prefix=VFPV3-EXN-RTTI-UNALIGNED %s
@@ -66,6 +84,22 @@
 # VFPV3-EXN-RTTI: arm-none-eabi/armv7a_hard_vfpv3_d16_exn_rtti{{$}}
 # VFPV3-EXN-RTTI-EMPTY:
 
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=neon-vfpv3 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16-fp16 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-fp16 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv4-d16 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv4 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=neon-fp16 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=neon-vfpv4 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -marm -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -mthumb -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -mthumb -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# VFPV3-EXN-RTTI-BE: arm-none-eabi/armebv7a_hard_vfpv3_d16_exn_rtti{{$}}
+# VFPV3-EXN-RTTI-BE-EMPTY:
+
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=vfpv3-d16 -fno-exceptions -fno-rtti | FileCheck --check-prefix=VFPV3-UNALIGNED %s
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=neon-vfpv3 -fno-exceptions -fno-rtti| FileCheck --check-prefix=VFPV3-UNALIGNED %s
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mfpu=vfpv3 -fno-exceptions -fno-rtti| FileCheck --check-prefix=VFPV3-UNALIGNED %s
@@ -97,6 +131,22 @@
 # RUN: %clang -print-multi-directory --target=armv7ve-none-eabihf -mfpu=vfpv3-d16 -fno-exceptions -fno-rtti -mthumb -mno-unaligned-access | FileCheck --check-prefix=VFPV3 %s
 # VFPV3: arm-none-eabi/armv7a_hard_vfpv3_d16{{$}}
 # VFPV3-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=neon-vfpv3 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16-fp16 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-fp16 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv4-d16 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv4 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=neon-fp16 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=neon-vfpv4 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -marm -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -mthumb -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -fno-exceptions -fno-rtti -mthumb -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# VFPV3-BE: arm-none-eabi/armebv7a_hard_vfpv3_d16{{$}}
+# VFPV3-BE-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mfpu=vfpv3-d16 -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-VFPV3-EXN-RTTI-UNALIGNED %s
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mfpu=neon-vfpv3 -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-VFPV3-EXN-RTTI-UNALIGNED %s

--- a/arm-software/embedded/test/multilib/armv7a.test
+++ b/arm-software/embedded/test/multilib/armv7a.test
@@ -22,6 +22,12 @@
 # RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -mno-unaligned-access | FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
 # RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -mno-unaligned-access -marm  | FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
 # RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -mno-unaligned-access -mthumb| FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=none | FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=none -marm | FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=none -mthumb| FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none | FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -marm  | FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -mthumb | FileCheck --check-prefix=NOFP-EXN-RTTI-BE %s
 # NOFP-EXN-RTTI-BE: arm-none-eabi/armebv7a_soft_nofp_exn_rtti{{$}}
 # NOFP-EXN-RTTI-BE-EMPTY:
 
@@ -49,6 +55,12 @@
 # RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=NOFP-BE %s
 # RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti -mno-unaligned-access -marm  | FileCheck --check-prefix=NOFP-BE %s
 # RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti -mno-unaligned-access -mthumb| FileCheck --check-prefix=NOFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti | FileCheck --check-prefix=NOFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti -marm | FileCheck --check-prefix=NOFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti -mthumb| FileCheck --check-prefix=NOFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti | FileCheck --check-prefix=NOFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti -marm  | FileCheck --check-prefix=NOFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabi -mbig-endian -mfpu=none -fno-exceptions -fno-rtti -mthumb | FileCheck --check-prefix=NOFP-BE %s
 # NOFP-BE: arm-none-eabi/armebv7a_soft_nofp{{$}}
 # NOFP-BE-EMPTY:
 
@@ -97,6 +109,19 @@
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -mthumb -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
 # RUN: %clang -print-multi-directory --target=armv7ve-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
 # RUN: %clang -print-multi-directory --target=armv7ve-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -mthumb -mno-unaligned-access | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=neon-vfpv3 | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3 | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16-fp16 | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-fp16 | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv4-d16 | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv4 | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=neon-fp16 | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=neon-vfpv4 | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -mthumb | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabihf -mbig-endian -mfpu=vfpv3-d16 | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -mthumb | FileCheck --check-prefix=VFPV3-EXN-RTTI-BE %s
 # VFPV3-EXN-RTTI-BE: arm-none-eabi/armebv7a_hard_vfpv3_d16_exn_rtti{{$}}
 # VFPV3-EXN-RTTI-BE-EMPTY:
 
@@ -145,6 +170,20 @@
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -mthumb -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
 # RUN: %clang -print-multi-directory --target=armv7ve-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
 # RUN: %clang -print-multi-directory --target=armv7ve-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -fno-exceptions -fno-rtti -mthumb -mno-unaligned-access | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -fno-exceptions -fno-rtti | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -fno-exceptions -fno-rtti | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=neon-vfpv3 -fno-exceptions -fno-rtti | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3 -fno-exceptions -fno-rtti | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16-fp16 -fno-exceptions -fno-rtti | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-fp16 -fno-exceptions -fno-rtti | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv4-d16 -fno-exceptions -fno-rtti | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv4 -fno-exceptions -fno-rtti | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=neon-fp16 -fno-exceptions -fno-rtti | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=neon-vfpv4 -fno-exceptions -fno-rtti | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -marm -fno-exceptions -fno-rtti | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -mthumb -fno-exceptions -fno-rtti | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -fno-exceptions -fno-rtti | FileCheck --check-prefix=VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7ve-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -fno-exceptions -fno-rtti -mthumb | FileCheck --check-prefix=VFPV3-BE %s
 # VFPV3-BE: arm-none-eabi/armebv7a_hard_vfpv3_d16{{$}}
 # VFPV3-BE-EMPTY:
 
@@ -187,6 +226,17 @@
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=neon-vfpv4 -mfloat-abi=softfp -mno-unaligned-access | FileCheck --check-prefix=SOFT-VFPV3-EXN-RTTI-BE %s
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=vfpv3-d16 -marm -mfloat-abi=softfp -mno-unaligned-access | FileCheck --check-prefix=SOFT-VFPV3-EXN-RTTI-BE %s
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=vfpv3-d16 -mthumb -mfloat-abi=softfp -mno-unaligned-access | FileCheck --check-prefix=SOFT-VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=vfpv3-d16 -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=neon-vfpv3 -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=vfpv3 -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=vfpv3-d16-fp16 -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=vfpv3-fp16 -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=vfpv4-d16 -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=vfpv4 -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=neon-fp16 -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=neon-vfpv4 -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=vfpv3-d16 -marm -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-VFPV3-EXN-RTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=vfpv3-d16 -mthumb -mfloat-abi=softfp | FileCheck --check-prefix=SOFT-VFPV3-EXN-RTTI-BE %s
 # SOFT-VFPV3-EXN-RTTI-BE: arm-none-eabi/armebv7a_soft_vfpv3_d16_exn_rtti{{$}}
 # SOFT-VFPV3-EXN-RTTI-BE-EMPTY:
 
@@ -229,6 +279,17 @@
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=neon-vfpv4 -mfloat-abi=softfp -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=SOFT-VFPV3-BE %s
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=vfpv3-d16 -marm -mfloat-abi=softfp -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=SOFT-VFPV3-BE %s
 # RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=vfpv3-d16 -mthumb -mfloat-abi=softfp -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=SOFT-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=vfpv3-d16 -mfloat-abi=softfp -fno-exceptions -fno-rtti | FileCheck --check-prefix=SOFT-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=neon-vfpv3 -mfloat-abi=softfp -fno-exceptions -fno-rtti | FileCheck --check-prefix=SOFT-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=vfpv3 -mfloat-abi=softfp -fno-exceptions -fno-rtti | FileCheck --check-prefix=SOFT-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=vfpv3-d16-fp16 -mfloat-abi=softfp -fno-exceptions -fno-rtti | FileCheck --check-prefix=SOFT-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=vfpv3-fp16 -mfloat-abi=softfp -fno-exceptions -fno-rtti | FileCheck --check-prefix=SOFT-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=vfpv4-d16 -mfloat-abi=softfp -fno-exceptions -fno-rtti | FileCheck --check-prefix=SOFT-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=vfpv4 -mfloat-abi=softfp -fno-exceptions -fno-rtti | FileCheck --check-prefix=SOFT-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=neon-fp16 -mfloat-abi=softfp -fno-exceptions -fno-rtti | FileCheck --check-prefix=SOFT-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=neon-vfpv4 -mfloat-abi=softfp -fno-exceptions -fno-rtti | FileCheck --check-prefix=SOFT-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=vfpv3-d16 -marm -mfloat-abi=softfp -fno-exceptions -fno-rtti | FileCheck --check-prefix=SOFT-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv7a-none-eabi -mbig-endian -mfpu=vfpv3-d16 -mthumb -mfloat-abi=softfp -fno-exceptions -fno-rtti | FileCheck --check-prefix=SOFT-VFPV3-BE %s
 # SOFT-VFPV3-BE: arm-none-eabi/armebv7a_soft_vfpv3_d16{{$}}
 # SOFT-VFPV3-BE-EMPTY:
 


### PR DESCRIPTION
Add AArch64 R-profile soft nofp variants (LE and BE) - (cherry picked from https://github.com/arm/arm-toolchain/pull/102)

Add logic to multilib.yaml to handle cases of armebv7a_soft_nofp and armebv7a_hard_vfpv3_d16 variants- (cherry picked from https://github.com/arm/arm-toolchain/pull/99)

Remove -mno-unaligned-access flag from AArch32 big endian variants -(cherry picked from https://github.com/arm/arm-toolchain/pull/115)