### PR TITLE
Cherry-pick: Integrating Changes from PR #126277 and #127096

### DIFF
--- a/compiler-rt/lib/builtins/arm/negdf2vfp.S
+++ b/compiler-rt/lib/builtins/arm/negdf2vfp.S
@@ -20,7 +20,11 @@ DEFINE_COMPILERRT_FUNCTION(__negdf2vfp)
 #if defined(COMPILER_RT_ARMHF_TARGET)
 	vneg.f64 d0, d0
 #else
-	eor	r1, r1, #-2147483648	// flip sign bit on double in r0/r1 pair
+#if _YUGA_BIG_ENDIAN
+	eor	r0, r0, #0x80000000	// flip sign bit on double in r0/r1 pair
+#else
+	eor	r1, r1, #0x80000000	// flip sign bit on double in r0/r1 pair
+#endif
 #endif
 	bx	lr
 END_COMPILERRT_FUNCTION(__negdf2vfp)

--- a/compiler-rt/test/builtins/Unit/arm/aeabi_idivmod_test.c
+++ b/compiler-rt/test/builtins/Unit/arm/aeabi_idivmod_test.c
@@ -14,8 +14,19 @@ int test__aeabi_idivmod(si_int a, si_int b,
 {
 	  si_int rem;
     du_int ret = __aeabi_idivmod(a, b);
+    // __aeabi_idivmod actually returns a struct { quotient; remainder; } using
+    // value_in_regs calling convention. Due to the ABI rules, struct fields
+    // come in the same order regardless of endianness. However since the
+    // result is received here as a 64-bit integer, in which endianness does
+    // matter, the position of each component (quotient and remainder) varies
+    // depending on endianness.
+#  if _YUGA_BIG_ENDIAN
+    rem = ret & 0xFFFFFFFF;
+    si_int result = ret >> 32;
+#  else
     rem = ret >> 32;
     si_int result = ret & 0xFFFFFFFF;
+#  endif
     if (result != expected_result) {
         printf("error in __aeabi_idivmod: %d / %d = %d, expected %d\n",
                a, b, result, expected_result);

--- a/compiler-rt/test/builtins/Unit/arm/aeabi_uidivmod_test.c
+++ b/compiler-rt/test/builtins/Unit/arm/aeabi_uidivmod_test.c
@@ -13,8 +13,19 @@ int test__aeabi_uidivmod(su_int a, su_int b,
 						su_int expected_result, su_int expected_rem)
 {
     du_int ret = __aeabi_uidivmod(a, b);
+    // __aeabi_uidivmod actually returns a struct { quotient; remainder; }
+    // using value_in_regs calling convention. Due to the ABI rules, struct
+    // fields come in the same order regardless of endianness. However since
+    // the result is received here as a 64-bit integer, in which endianness
+    // does matter, the position of each component (quotient and remainder)
+    // varies depending on endianness.
+#  if _YUGA_BIG_ENDIAN
+    su_int rem = ret & 0xFFFFFFFF;
+    si_int result = ret >> 32;
+#  else
     su_int rem = ret >> 32;
     si_int result = ret & 0xFFFFFFFF;
+#  endif
 
     if (result != expected_result) {
         printf("error in __aeabi_uidivmod: %u / %u = %u, expected %u\n",


### PR DESCRIPTION
[compiler-rt] Add support for big endian for Arm's __negdf2vfp (cherry picked from https://github.com/llvm/llvm-project/pull/127096)

[compiler-rt] Fix tests of __aeabi_(idivmod|uidivmod|uldivmod) to support big endian (cherry picked from https://github.com/llvm/llvm-project/pull/126277)