### PR TITLE
Fix picolibc C++ test with meson 1.4

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -369,11 +369,14 @@ if(C_LIBRARY STREQUAL picolibc)
     # and flags e.g. 'path/to/clang', '--target=armv6m-none-eabi',
     # '-march=armv6m'
     set(picolibc_flags "${LLVM_BINARY_DIR}/bin/clang${CMAKE_EXECUTABLE_SUFFIX} ${lib_compile_flags}")
+    set(picolibcpp_flags "${LLVM_BINARY_DIR}/bin/clang++${CMAKE_EXECUTABLE_SUFFIX} ${lib_compile_flags}")
     if(CMAKE_C_COMPILER_LAUNCHER)
         set(picolibc_flags "${CMAKE_C_COMPILER_LAUNCHER} ${picolibc_flags}")
     endif()
     separate_arguments(picolibc_flags)
+    separate_arguments(picolibcpp_flags)
     to_meson_list("${picolibc_flags}" picolibc_meson_flags)
+    to_meson_list("${picolibcpp_flags}" picolibcpp_meson_flags)
 
     if(ENABLE_LIBC_TESTS)
         set(picolibc_test_executor_bin ${CMAKE_CURRENT_SOURCE_DIR}/test-support/picolibc-test-wrapper.py)

--- a/arm-software/embedded/arm-runtimes/meson-cross-build.txt.in
+++ b/arm-software/embedded/arm-runtimes/meson-cross-build.txt.in
@@ -1,5 +1,6 @@
 [binaries]
 c = [@picolibc_meson_flags@, '-nostdlib']
+cpp = [@picolibcpp_meson_flags@, '-nostdlib']
 ar = '@LLVM_BINARY_DIR@/bin/llvm-ar@CMAKE_EXECUTABLE_SUFFIX@'
 strip = '@LLVM_BINARY_DIR@/bin/llvm-strip@CMAKE_EXECUTABLE_SUFFIX@'
 # only needed to run tests


### PR DESCRIPTION
Picolibc contains one C++ test, which is failing for me when building with meson 1.4.1, but not 1.3.1. In the failing case, the test is being compiled and linked using clang++ from my PATH, not the freshly built one. With meson 1.3.1, the same compiler is being used for both C and C++, so this test works correctly. I don't see anything in the meson changelog which could cause this, but setting the c++ compiler in the same way we do for C makes this test work for both meson versions.