### PR TITLE
Cherry-pick: Integrating Changes from PR #69 and #110

### DIFF
--- a/arm-software/embedded/arm-multilib/json/multilib.json
+++ b/arm-software/embedded/arm-multilib/json/multilib.json
@@ -87,32 +87,38 @@
         {
             "variant": "aarch64r_soft_nofp_exn_rtti_unaligned",
             "json": "aarch64r_soft_nofp_exn_rtti_unaligned.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8-r -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft"
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8-r -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft",
+            "libraries_supported": "picolibc"
         },
         {
             "variant": "aarch64r_soft_nofp_unaligned",
             "json": "aarch64r_soft_nofp_unaligned.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8-r -march=armvX+nofp -march=armvX+nosimd -fno-exceptions -fno-rtti -mabi=aapcs-soft"
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8-r -march=armvX+nofp -march=armvX+nosimd -fno-exceptions -fno-rtti -mabi=aapcs-soft",
+            "libraries_supported": "picolibc"
         },
         {
             "variant": "aarch64r_soft_nofp_exn_rtti",
             "json": "aarch64r_soft_nofp_exn_rtti.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8-r -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft -mno-unaligned-access"
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8-r -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft -mno-unaligned-access",
+            "libraries_supported": "picolibc"
         },
         {
             "variant": "aarch64r_soft_nofp",
             "json": "aarch64r_soft_nofp.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8-r -march=armvX+nofp -march=armvX+nosimd -fno-exceptions -fno-rtti -mabi=aapcs-soft -mno-unaligned-access"
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8-r -march=armvX+nofp -march=armvX+nosimd -fno-exceptions -fno-rtti -mabi=aapcs-soft -mno-unaligned-access",
+            "libraries_supported": "picolibc"
         },
         {
             "variant": "aarch64r_be_soft_nofp_exn_rtti",
             "json": "aarch64r_be_soft_nofp_exn_rtti.json",
-            "flags": "--target=aarch64_be-unknown-none-elf -march=armv8-r -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft"
+            "flags": "--target=aarch64_be-unknown-none-elf -march=armv8-r -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft",
+            "libraries_supported": "picolibc"
         },
         {
             "variant": "aarch64r_be_soft_nofp",
             "json": "aarch64r_be_soft_nofp.json",
-            "flags": "--target=aarch64_be-unknown-none-elf -march=armv8-r -march=armvX+nofp -march=armvX+nosimd -fno-exceptions -fno-rtti -mabi=aapcs-soft"
+            "flags": "--target=aarch64_be-unknown-none-elf -march=armv8-r -march=armvX+nofp -march=armvX+nosimd -fno-exceptions -fno-rtti -mabi=aapcs-soft",
+            "libraries_supported": "picolibc"
         },
         {
             "variant": "armv4t_exn_rtti",

--- a/arm-software/embedded/llvmlibc-samples/src/llvmlibc/baremetal-semihosting/Makefile
+++ b/arm-software/embedded/llvmlibc-samples/src/llvmlibc/baremetal-semihosting/Makefile
@@ -10,7 +10,7 @@ include ../../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.c
-	../$(BIN_PATH)/clang --config=llvmlibc.cfg $(MICROBIT_TARGET) -nostartfiles -lsemihost -g -fno-exceptions -fno-rtti -T microbit-llvmlibc.ld -o hello.elf $^
+	../$(BIN_PATH)/clang --config=llvmlibc.cfg $(MICROBIT_TARGET) -nostartfiles -lsemihost -lm -g -fno-exceptions -fno-rtti -T microbit-llvmlibc.ld -o hello.elf $^
 
 %.hex: %.elf
 	../$(BIN_PATH)/llvm-objcopy -O ihex $< $@


### PR DESCRIPTION
Fix llvmlibc sample, by adding -lm to the link command - Cherry pick from https://github.com/arm/arm-toolchain/pull/69

Do not build aarch64r soft_nofp variants with newlib/llvmlibc - Cherry pick from https://github.com/arm/arm-toolchain/pull/110