### PR TITLE
[ATfL] Introduce the ability to set the default target triple (#131)

### DIFF
--- a/arm-software/linux/build.sh-HOWTO.md
+++ b/arm-software/linux/build.sh-HOWTO.md
@@ -152,6 +152,8 @@ The `build.sh` script reads the following environment variables:
   (default: number of the available CPU cores)
 - `ATFL_ASSERTIONS` - Enable assertions in the build ON/OFF
   (default: ON), set this to `OFF` when doing a proper release (not nightly) build
+- `ATFL_TARGET_TRIPLE` - Specify the default target triple
+  (default: aarch64-unknown-linux-gnu), Set it to aarch64-amazon-linux when building for Amazon Linux
 - `TAR_NAME` - The name of the tarball to be created
   (default: atfl-0.0-linux-aarch64.tar.gz)
 - `ZLIB_STATIC_PATH` - Specifies the location of the static zlib library (libz.a)


### PR DESCRIPTION
It's a cherry-pick from the arm-software branch.

Amazon Linux uses different target triple than other distributions. An attempt to accomodate it in Clang's frontend driver has been rejected already [1], so the only way to handle it is to set the default target triple explicitly when building LLVM. This will affect the name of the runtimes library which LLVM creates.

[1] https://github.com/llvm/llvm-project/pull/109263