### PR TITLE
[ATfL] Update the list of dependencies

### DIFF
--- a/arm-software/linux/build.sh-HOWTO.md
+++ b/arm-software/linux/build.sh-HOWTO.md
@@ -16,7 +16,6 @@ The following packages need to be installed (using `apt`):
 - `binutils-dev`
 - `build-essential`
 - `cmake`
-- `figlet`
 - `git`
 - `libzstd-dev`
 - `ninja-build`
@@ -39,7 +38,6 @@ The following packages need to be installed (using `apt`):
 - `binutils-devel`
 - `make`
 - `cmake`
-- `figlet`
 - `git`
 - `ninja-build`
 - `zlib-devel`
@@ -53,7 +51,14 @@ The following packages need to be installed (using `apt`):
 - `libmpc-devel`
 - `isl`
 - `isl-devel`
+- `perl-FindBin`
+- `perl-Hash-Util`
+- `perl-Hash-Util-FieldHash`
+- `perl-Sys-Hostname`
+- `perl-File-Copy`
 - `cpio`
+- `tar`
+- `gzip`
 
 #### Additionally, on older `.rpm`-based systems (RHEL8, CentOS8):
 


### PR DESCRIPTION
Two things were changed:

- We do not require `figlet` anymore, its installation is optional

- There are packages which are missing in default installations of some of the RPM-based systems