### PR TITLE
[ATfE] Store check-all results and continue libcxx tests on failure

### DIFF
--- a/arm-software/embedded/scripts/test.sh
+++ b/arm-software/embedded/scripts/test.sh
@@ -15,10 +15,21 @@ set -ex
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$( git -C ${SCRIPT_DIR} rev-parse --show-toplevel )
 
-# In order to get results for all variants, ignore any failures
-# in the individual library tests. --ignore-fail only works with
-# lit based tests.
-export LIT_OPTS="--ignore-fail"
-
 cd ${REPO_ROOT}/build
-ninja check-all check-llvm-toolchain check-cxxabi check-unwind check-package-llvm-toolchain
+
+# If a test fails, lit will ordinarily return a non-zero result,
+# which prevents further testing. Setting the --ignore-fail option
+# will cause testing to continue, so that CI systems can get a
+# full set of results.
+# The check-all target runs the upstream clang and LLVM tests,
+# which do not generate an junit xml results file by default.
+# Additionally setting the --xunit-xml-output option store the
+# results.
+export LIT_OPTS="--ignore-fail --xunit-xml-output=results.xml"
+ninja check-all
+
+# The llvm-toolchain targets already set --xunit-xml-output so
+# only the --ignore-fail option is needed.
+# The picolibc tests do not use lit so do not support this option.
+export LIT_OPTS="--ignore-fail"
+ninja check-llvm-toolchain check-cxxabi check-unwind check-package-llvm-toolchain

--- a/arm-software/embedded/scripts/test_libcxx.sh
+++ b/arm-software/embedded/scripts/test_libcxx.sh
@@ -18,5 +18,11 @@ set -ex
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$( git -C ${SCRIPT_DIR} rev-parse --show-toplevel )
 
+# If a test fails, lit will ordinarily return a non-zero result,
+# which prevents further testing. Setting the --ignore-fail flag
+# will cause testing to continue, so that CI systems can get a
+# full set of results.
+export LIT_OPTS="--ignore-fail"
+
 cd ${REPO_ROOT}/build
 ninja check-cxx


### PR DESCRIPTION
The `check-all` target runs upstream tests, which by default do not generate an XML results file. This can be done through a lit option.

The `--ignore-fail` option should also be set for the libcxx test script, in the same way as the main test script.