### PR TITLE
[ATfE] Cherry-pick libcxx change in wchar inclusion guarding into 20.x

### DIFF
--- a/arm-software/embedded/patches/llvm-project/0012-libc-Do-not-guard-inclusion-of-wchar.h-with-_LIBCPP_.patch
+++ b/arm-software/embedded/patches/llvm-project/0012-libc-Do-not-guard-inclusion-of-wchar.h-with-_LIBCPP_.patch
@@ -1,4 +1,4 @@
-From 55004e55d9c29408500c1362fbf86a689d7ac2ee Mon Sep 17 00:00:00 2001
+From 9c2048aa841cafd80e0c6752cf6872a9d42e6eb3 Mon Sep 17 00:00:00 2001
 From: Steven Cooreman <steven.cooreman@gmail.com>
 Date: Tue, 18 Feb 2025 12:12:23 +0100
 Subject: [libc++] Do not guard inclusion of wchar.h with
@@ -25,6 +25,8 @@ top
 of a C library which doesn't provide `<wchar.h>` (since it would then
 still
 go look for `<uchar.h>` or error out).
+
+(cherry picked from commit 762001118c068317ec67274221497be2e6499c6a)
 ---
  libcxx/include/__mbstate_t.h | 8 ++++----
  1 file changed, 4 insertions(+), 4 deletions(-)

--- a/arm-software/embedded/patches/llvm-project/0012-libc-Do-not-guard-inclusion-of-wchar.h-with-_LIBCPP_.patch
+++ b/arm-software/embedded/patches/llvm-project/0012-libc-Do-not-guard-inclusion-of-wchar.h-with-_LIBCPP_.patch
@@ -1,0 +1,55 @@
+From 55004e55d9c29408500c1362fbf86a689d7ac2ee Mon Sep 17 00:00:00 2001
+From: Steven Cooreman <steven.cooreman@gmail.com>
+Date: Tue, 18 Feb 2025 12:12:23 +0100
+Subject: [libc++] Do not guard inclusion of wchar.h with
+ _LIBCPP_HAS_WIDE_CHARACTERS (#126924)
+
+`mbstate_t` needs to be visible to libcpp, even when it is not providing
+wide
+character functionality (i.e. `_LIBCPP_HAS_WIDE_CHARACTERS` is turned
+off)
+and thus not using any of the C library's wide character functions.
+
+There are C libraries (such as newlib-nano/nanolib/picolibc) which do
+provide their definition of `mbstate_t` in `<wchar.h>` even though they
+do not
+come with wide character functions.
+
+Since there is a way to conditionally include the C library's
+`<wchar.h>`
+only if it exists, we should rely on the fact that if it exists, it will
+provide `mbstate_t`. Removing this guard will allow using libc++ on top
+of
+newlib-nano/picolibc while not breaking the cases where it is used on
+top
+of a C library which doesn't provide `<wchar.h>` (since it would then
+still
+go look for `<uchar.h>` or error out).
+---
+ libcxx/include/__mbstate_t.h | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/libcxx/include/__mbstate_t.h b/libcxx/include/__mbstate_t.h
+index e013384454b4..c23ea7113ca7 100644
+--- a/libcxx/include/__mbstate_t.h
++++ b/libcxx/include/__mbstate_t.h
+@@ -43,12 +43,12 @@
+ #  include <bits/types/mbstate_t.h> // works on most Unixes
+ #elif __has_include(<sys/_types/_mbstate_t.h>)
+ #  include <sys/_types/_mbstate_t.h> // works on Darwin
+-#elif _LIBCPP_HAS_WIDE_CHARACTERS && __has_include_next(<wchar.h>)
+-#  include_next <wchar.h> // fall back to the C standard provider of mbstate_t
++#elif __has_include_next(<wchar.h>)
++#  include_next <wchar.h> // use the C standard provider of mbstate_t if present
+ #elif __has_include_next(<uchar.h>)
+-#  include_next <uchar.h> // <uchar.h> is also required to make mbstate_t visible
++#  include_next <uchar.h> // Try <uchar.h> in absence of <wchar.h> for mbstate_t
+ #else
+-#  error "We don't know how to get the definition of mbstate_t without <wchar.h> on your platform."
++#  error "We don't know how to get the definition of mbstate_t on your platform."
+ #endif
+ 
+ #endif // _LIBCPP___MBSTATE_T_H
+-- 
+2.47.1
+


### PR DESCRIPTION
This change is required for the newlib-nano library overlay
implementation to work correctly, as it provides the definition
`mbstate_t` despite not providing wide-character support.