### PR TITLE
[ATfE] Cherry-pick PRs #113, #116 and #151

### DIFF
--- a/arm-software/embedded/fvp/config/v8a-aarch32.cfg
+++ b/arm-software/embedded/fvp/config/v8a-aarch32.cfg
@@ -18,3 +18,6 @@ bp.secure_memory=0
 
 # Boot in AArch32 mode
 cluster0.cpu0.CONFIG64=0
+
+# Disable audio interface
+bp.pl041_aaci.enabled=0

--- a/arm-software/embedded/fvp/config/v8a-aarch64.cfg
+++ b/arm-software/embedded/fvp/config/v8a-aarch64.cfg
@@ -18,3 +18,6 @@ bp.secure_memory=0
 
 # Boot in AArch64 mode
 cluster0.cpu0.CONFIG64=1
+
+# Disable audio interface
+bp.pl041_aaci.enabled=0

--- a/arm-software/embedded/fvp/config/v8r-aarch32.cfg
+++ b/arm-software/embedded/fvp/config/v8r-aarch32.cfg
@@ -14,3 +14,6 @@ cluster0.NUM_CORES=1
 
 # AArch32 mode
 cluster0.has_aarch64=0
+
+# Disable audio interface
+bp.pl041_aaci.enabled=0

--- a/arm-software/embedded/fvp/config/v8r-aarch64.cfg
+++ b/arm-software/embedded/fvp/config/v8r-aarch64.cfg
@@ -21,3 +21,6 @@ cluster0.gicv3.cpuintf-mmap-access-level=2
 cluster0.gicv3.SRE-enable-action-on-mmap=2
 cluster0.gicv3.SRE-EL2-enable-RAO=1
 cluster0.gicv3.extended-interrupt-range-support=1
+
+# Disable audio interface
+bp.pl041_aaci.enabled=0

--- a/arm-software/embedded/scripts/test.sh
+++ b/arm-software/embedded/scripts/test.sh
@@ -15,5 +15,10 @@ set -ex
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$( git -C ${SCRIPT_DIR} rev-parse --show-toplevel )
 
+# In order to get results for all variants, ignore any failures
+# in the individual library tests. --ignore-fail only works with
+# lit based tests.
+export LIT_OPTS="--ignore-fail"
+
 cd ${REPO_ROOT}/build
-ninja check-llvm-toolchain
+ninja check-all check-llvm-toolchain check-cxxabi check-unwind check-package-llvm-toolchain

--- a/arm-software/embedded/scripts/test.sh
+++ b/arm-software/embedded/scripts/test.sh
@@ -15,10 +15,21 @@ set -ex
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$( git -C ${SCRIPT_DIR} rev-parse --show-toplevel )
 
-# In order to get results for all variants, ignore any failures
-# in the individual library tests. --ignore-fail only works with
-# lit based tests.
-export LIT_OPTS="--ignore-fail"
-
 cd ${REPO_ROOT}/build
-ninja check-all check-llvm-toolchain check-cxxabi check-unwind check-package-llvm-toolchain
+
+# If a test fails, lit will ordinarily return a non-zero result,
+# which prevents further testing. Setting the --ignore-fail option
+# will cause testing to continue, so that CI systems can get a
+# full set of results.
+# The check-all target runs the upstream clang and LLVM tests,
+# which do not generate an junit xml results file by default.
+# Additionally setting the --xunit-xml-output option store the
+# results.
+export LIT_OPTS="--ignore-fail --xunit-xml-output=results.xml"
+ninja check-all
+
+# The llvm-toolchain targets already set --xunit-xml-output so
+# only the --ignore-fail option is needed.
+# The picolibc tests do not use lit so do not support this option.
+export LIT_OPTS="--ignore-fail"
+ninja check-llvm-toolchain check-cxxabi check-unwind check-package-llvm-toolchain

--- a/arm-software/embedded/scripts/test_libcxx.sh
+++ b/arm-software/embedded/scripts/test_libcxx.sh
@@ -18,5 +18,11 @@ set -ex
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$( git -C ${SCRIPT_DIR} rev-parse --show-toplevel )
 
+# If a test fails, lit will ordinarily return a non-zero result,
+# which prevents further testing. Setting the --ignore-fail flag
+# will cause testing to continue, so that CI systems can get a
+# full set of results.
+export LIT_OPTS="--ignore-fail"
+
 cd ${REPO_ROOT}/build
 ninja check-cxx


### PR DESCRIPTION
Cherry pick of three changes to the release branch with no modification:

- Disable audio device in FVP tests (#113) (77958d290d811601f41d0ee9f581980e156ab63e)
- Add additional test targets to test script (#116) (9c425650b0f36b1bd00cf93701e3445a840c2067)
- Store check-all results and continue libcxx tests on failure (#151) (3428e354dd3724bb015deb3bc18e31e7e0396d08)