### PR TITLE
Resolve time formatting issue in ATFE 20.x by updating Picolibc version.

### DIFF
--- a/arm-software/embedded/versions.json
+++ b/arm-software/embedded/versions.json
@@ -9,7 +9,7 @@
     "picolibc": {
       "url": "https://github.com/picolibc/picolibc.git",
       "tagType": "commithash",
-      "tag": "be1b69f5f5910d216c16f9fca927c1bdb4d38a51"
+      "tag": "d0dba7fa5cbe947d10836d119ee7ec73cf7f4444"
     },
     "newlib": {
       "url": "https://sourceware.org/git/newlib-cygwin.git",


### PR DESCRIPTION
This commit hash (be1b69f5f5910d216c16f9fca927c1bdb4d38a51) corresponds to a commit from February 10, 2025. However, the fix for the 'X' specifier issue was
introduced in a later commit on February 12, 2025. Therefore, the current picolibc version in the ATFE 20.x branch does not include this fix. To resolve the current libcxx test failure locale_time_put_members.put2.pass.cpp, update the versions.json file in the ATFE 20.x branch to reference a picolibc commit that includes the necessary fix.