### PR TITLE
Update llvm-project patch files to integrate changes from #126933.

### DIFF
--- a/arm-software/embedded/patches/llvm-project/0001-libc-tests-with-picolibc-xfail-one-remaining-test.patch
+++ b/arm-software/embedded/patches/llvm-project/0001-libc-tests-with-picolibc-xfail-one-remaining-test.patch
@@ -1,4 +1,4 @@
-From 835b3efcf5a21058dd897700fdab126781493f0d Mon Sep 17 00:00:00 2001
+From e92913eb4c713647e801c2c0c7900480e5051ef8 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Mon, 16 Oct 2023 11:35:48 +0200
 Subject: [libc++] tests with picolibc: xfail one remaining test

--- a/arm-software/embedded/patches/llvm-project/0002-libc-tests-with-picolibc-disable-large-tests.patch
+++ b/arm-software/embedded/patches/llvm-project/0002-libc-tests-with-picolibc-disable-large-tests.patch
@@ -1,4 +1,4 @@
-From d26509789db1ef12299a530cda51357fcb020b44 Mon Sep 17 00:00:00 2001
+From eb7ea5ea8c9eb3c8755ff047903aa512ef6c907c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Wed, 15 Nov 2023 12:18:35 +0100
 Subject: [libc++] tests with picolibc: disable large tests

--- a/arm-software/embedded/patches/llvm-project/0003-Disable-failing-compiler-rt-test.patch
+++ b/arm-software/embedded/patches/llvm-project/0003-Disable-failing-compiler-rt-test.patch
@@ -1,4 +1,4 @@
-From 758eaf3c1f4d4fa3b0dc1f823133635e920fade1 Mon Sep 17 00:00:00 2001
+From d2874b0df484e6e9a31b8876eb8f8c0f47411d03 Mon Sep 17 00:00:00 2001
 From: Piotr Przybyla <piotr.przybyla@arm.com>
 Date: Wed, 15 Nov 2023 16:04:24 +0000
 Subject: Disable failing compiler-rt test

--- a/arm-software/embedded/patches/llvm-project/0004-libc-tests-with-picolibc-XFAIL-uses-of-atomics.patch
+++ b/arm-software/embedded/patches/llvm-project/0004-libc-tests-with-picolibc-XFAIL-uses-of-atomics.patch
@@ -1,4 +1,4 @@
-From 295e2d01e88d3979aaae65214303d0a84243a4eb Mon Sep 17 00:00:00 2001
+From 8b5771b3e32d9d371b5286853ae15439bc13b660 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Thu, 9 Nov 2023 15:25:14 +0100
 Subject: [libc++] tests with picolibc: XFAIL uses of atomics

--- a/arm-software/embedded/patches/llvm-project/0005-libc-tests-with-picolibc-mark-two-more-large-tests.patch
+++ b/arm-software/embedded/patches/llvm-project/0005-libc-tests-with-picolibc-mark-two-more-large-tests.patch
@@ -1,4 +1,4 @@
-From 061b8165660a9e3f9d7b28f9a89edf9a5a7ac57a Mon Sep 17 00:00:00 2001
+From c67e5240e358a2a11068d9ecb1f1ee2608b04cca Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Wed, 22 Nov 2023 16:12:39 +0100
 Subject: [libc++] tests with picolibc: mark two more large tests

--- a/arm-software/embedded/patches/llvm-project/0006-Define-_LIBCPP_HAS_C8RTOMB_MBRTOC8.patch
+++ b/arm-software/embedded/patches/llvm-project/0006-Define-_LIBCPP_HAS_C8RTOMB_MBRTOC8.patch
@@ -1,4 +1,4 @@
-From fac938223fca26f2cbdff7fa0208c8c58decb8e8 Mon Sep 17 00:00:00 2001
+From 4bcc2556dfeae6acad38a3cf8326d91483a170eb Mon Sep 17 00:00:00 2001
 From: Victor Campos <victor.campos@arm.com>
 Date: Thu, 31 Oct 2024 09:58:34 +0000
 Subject: Define _LIBCPP_HAS_C8RTOMB_MBRTOC8

--- a/arm-software/embedded/patches/llvm-project/0007-libcxx-Remove-xfails-due-to-picolibc-s-support-for-c.patch
+++ b/arm-software/embedded/patches/llvm-project/0007-libcxx-Remove-xfails-due-to-picolibc-s-support-for-c.patch
@@ -1,4 +1,4 @@
-From 119f253eb9c95c208cd55df4f2025e3d3904525b Mon Sep 17 00:00:00 2001
+From 73748307742ad7c866b45723eeecb8061514b57d Mon Sep 17 00:00:00 2001
 From: Victor Campos <victor.campos@arm.com>
 Date: Thu, 31 Oct 2024 14:03:58 +0000
 Subject: [libcxx] Remove xfails due to picolibc's support for char16_t and

--- a/arm-software/embedded/patches/llvm-project/0008-PATCH-Revert-order-of-libraries-and-update-tests.patch
+++ b/arm-software/embedded/patches/llvm-project/0008-PATCH-Revert-order-of-libraries-and-update-tests.patch
@@ -1,4 +1,4 @@
-From aa109995a14c1f83b47fc0999c90539112cc471e Mon Sep 17 00:00:00 2001
+From 33c02bbbce37db0f1a6445c35951f20203c23c05 Mon Sep 17 00:00:00 2001
 From: Volodymyr Turanskyy <volodymyr.turanskyy@arm.com>
 Date: Thu, 19 Dec 2024 12:01:58 +0000
 Subject: [PATCH] Revert order of libraries and update tests

--- a/arm-software/embedded/patches/llvm-project/0009-compiler-rt-Fix-tests-of-__aeabi_-idivmod-uidivmod-u.patch
+++ b/arm-software/embedded/patches/llvm-project/0009-compiler-rt-Fix-tests-of-__aeabi_-idivmod-uidivmod-u.patch
@@ -1,4 +1,4 @@
-From 25f3995ae6fd70a1eb0fb804229ecb5848137f96 Mon Sep 17 00:00:00 2001
+From 98bf707741ce72e83eea3632417e884dfcf3b47a Mon Sep 17 00:00:00 2001
 From: Victor Campos <victor.campos@arm.com>
 Date: Tue, 11 Feb 2025 09:49:56 +0000
 Subject: [compiler-rt] Fix tests of __aeabi_(idivmod|uidivmod|uldivmod) to

--- a/arm-software/embedded/patches/llvm-project/0010-compiler-rt-Add-support-for-big-endian-for-Arm-s-__n.patch
+++ b/arm-software/embedded/patches/llvm-project/0010-compiler-rt-Add-support-for-big-endian-for-Arm-s-__n.patch
@@ -1,4 +1,4 @@
-From 2c5da3adea204dc5e6fe4d990a34571a04e9ecb4 Mon Sep 17 00:00:00 2001
+From f74b4bc2866fe4bf1c744dd9b67738754c6ff127 Mon Sep 17 00:00:00 2001
 From: Victor Campos <victor.campos@arm.com>
 Date: Mon, 17 Feb 2025 11:43:36 +0000
 Subject: [compiler-rt] Add support for big endian for Arm's __negdf2vfp

--- a/arm-software/embedded/patches/llvm-project/0011-libcxx-Work-around-picolibc-argv-handling-in-tests.-.patch
+++ b/arm-software/embedded/patches/llvm-project/0011-libcxx-Work-around-picolibc-argv-handling-in-tests.-.patch
@@ -1,4 +1,4 @@
-From 2bd9e642a2f585b9042b3b472ddb387c838a94d6 Mon Sep 17 00:00:00 2001
+From a8eeb149492dcded57b2d641374ec49a888749de Mon Sep 17 00:00:00 2001
 From: Simon Tatham <simon.tatham@arm.com>
 Date: Fri, 21 Feb 2025 09:08:53 +0000
 Subject: [libcxx] Work around picolibc argv handling in tests. (#127662)

--- a/arm-software/embedded/patches/llvm-project/0012-libc-Do-not-guard-inclusion-of-wchar.h-with-_LIBCPP_.patch
+++ b/arm-software/embedded/patches/llvm-project/0012-libc-Do-not-guard-inclusion-of-wchar.h-with-_LIBCPP_.patch
@@ -1,4 +1,4 @@
-From 9c2048aa841cafd80e0c6752cf6872a9d42e6eb3 Mon Sep 17 00:00:00 2001
+From dfd92edcb6bf4396894faa26e6012af3fab436fb Mon Sep 17 00:00:00 2001
 From: Steven Cooreman <steven.cooreman@gmail.com>
 Date: Tue, 18 Feb 2025 12:12:23 +0100
 Subject: [libc++] Do not guard inclusion of wchar.h with
@@ -53,5 +53,5 @@ index e013384454b4..c23ea7113ca7 100644
  
  #endif // _LIBCPP___MBSTATE_T_H
 -- 
-2.47.1
+2.34.1
 

--- a/arm-software/embedded/patches/llvm-project/0013-LLD-ELF-ARM-Fix-resolution-of-R_ARM_THM_JUMP8-and-R_.patch
+++ b/arm-software/embedded/patches/llvm-project/0013-LLD-ELF-ARM-Fix-resolution-of-R_ARM_THM_JUMP8-and-R_.patch
@@ -1,0 +1,88 @@
+From 3f644811502c3047e6b0c830aba54324559494b5 Mon Sep 17 00:00:00 2001
+From: Victor Campos <victor.campos@arm.com>
+Date: Mon, 17 Feb 2025 10:10:35 +0000
+Subject: [LLD][ELF][ARM] Fix resolution of R_ARM_THM_JUMP8 and
+ R_ARM_THM_JUMP11 for big endian (#126933)
+
+These relocations apply to 16-bit Thumb instructions, so reading 16 bits
+rather than 32 bits ensures the correct bits are masked and written
+back. This fixes the incorrect masking and aligns the relocation logic
+with the instruction encoding.
+
+Before this patch, 32 bits were read from the ELF object. This did not
+align with the instruction size of 16 bits, but the masking incidentally
+made it all work nonetheless. However, this was the case only in little
+endian.
+
+In big endian mode, the read 32-bit word had to have its bytes reversed.
+With this byte reordering, the masking would be applied to the wrong
+bits, hence causing the incorrect encoding to be produced as a result of
+the relocation resolution.
+
+The added test checks the result for both little and big endian modes.
+---
+ lld/ELF/Arch/ARM.cpp              |  4 ++--
+ lld/test/ELF/arm-thumb-jump8-11.s | 32 +++++++++++++++++++++++++++++++
+ 2 files changed, 34 insertions(+), 2 deletions(-)
+ create mode 100644 lld/test/ELF/arm-thumb-jump8-11.s
+
+diff --git a/lld/ELF/Arch/ARM.cpp b/lld/ELF/Arch/ARM.cpp
+index 7d2953ddf64f..e667fdc0633c 100644
+--- a/lld/ELF/Arch/ARM.cpp
++++ b/lld/ELF/Arch/ARM.cpp
+@@ -663,12 +663,12 @@ void ARM::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
+   case R_ARM_THM_JUMP8:
+     // We do a 9 bit check because val is right-shifted by 1 bit.
+     checkInt(ctx, loc, val, 9, rel);
+-    write16(ctx, loc, (read32(ctx, loc) & 0xff00) | ((val >> 1) & 0x00ff));
++    write16(ctx, loc, (read16(ctx, loc) & 0xff00) | ((val >> 1) & 0x00ff));
+     break;
+   case R_ARM_THM_JUMP11:
+     // We do a 12 bit check because val is right-shifted by 1 bit.
+     checkInt(ctx, loc, val, 12, rel);
+-    write16(ctx, loc, (read32(ctx, loc) & 0xf800) | ((val >> 1) & 0x07ff));
++    write16(ctx, loc, (read16(ctx, loc) & 0xf800) | ((val >> 1) & 0x07ff));
+     break;
+   case R_ARM_THM_JUMP19:
+     // Encoding T3: Val = S:J2:J1:imm6:imm11:0
+diff --git a/lld/test/ELF/arm-thumb-jump8-11.s b/lld/test/ELF/arm-thumb-jump8-11.s
+new file mode 100644
+index 000000000000..ed54f3c0cc94
+--- /dev/null
++++ b/lld/test/ELF/arm-thumb-jump8-11.s
+@@ -0,0 +1,32 @@
++# REQUIRES: arm
++
++# RUN: llvm-mc -triple thumbv6m-arm-eabi --filetype=obj %s -o %t.o
++# RUN: ld.lld %t.o -o %t
++# RUN: llvm-objdump -d %t --no-show-raw-insn | FileCheck %s --check-prefixes=CHECK,CHECK-LE
++
++# RUN: llvm-mc -triple thumbebv6m-arm-eabi --filetype=obj %s -o %t.o
++# RUN: ld.lld %t.o -o %t
++# RUN: llvm-objdump -d %t --no-show-raw-insn | FileCheck %s --check-prefixes=CHECK,CHECK-BE
++
++# CHECK-LE:                    file format elf32-littlearm
++# CHECK-BE:                    file format elf32-bigarm
++
++# CHECK:                       Disassembly of section .text:
++
++# CHECK-LABEL: [[#%x,TARGET:]] <target>:
++# CHECK-NEXT:      [[#TARGET]]: bx lr
++
++# CHECK-LABEL:                 <_start>:
++# CHECK-NEXT:                   b      0x[[#TARGET]] <target>
++# CHECK-NEXT:                   beq    0x[[#TARGET]] <target>
++
++    .thumb
++    .section .text.1, "ax", %progbits
++target:
++    bx lr
++
++    .section .text.2, "ax", %progbits
++    .globl _start
++_start:
++    b.n target   // R_ARM_THM_JUMP11
++    beq.n target // R_ARM_THM_JUMP8
+-- 
+2.34.1
+


### PR DESCRIPTION
We need to incorporate the following upstreamed patch into the 20.x branch. So applying this as patch file.

[LLD][ELF][ARM] Fix resolution of R_ARM_THM_JUMP8 and R_ARM_THM_JUMP11 for big endian - cherry picked from https://github.com/llvm/llvm-project/pull/126933