### PR TITLE
Temporarily disable automerge for 20.x release branch

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -17,8 +17,6 @@ jobs:
         branches:
           - from_branch: main
             to_branch: arm-software
-          - from_branch: release/20.x
-            to_branch: release/arm-software/20.x
     steps:
       - name: Configure Access Token
         uses: actions/create-github-app-token@v1


### PR DESCRIPTION
This temporarily disables Automerge workflow runs for the 20.x release
branch. As the 20.1.0 release approaches upstream, this is necessary to
ensure the commit used for the Arm Toolchain release is consistent
with the one used upstream.

While the Automerge is disabled for the branch, any incoming changes
from upstream will be reviewed and manually merged into the downstream
`release/arm-software/20.x` branch.

The workflow will be re-enabled for the branch once the release is done.
