### PR TITLE
[ATfE] Handle meson test return code in picolibc tests

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -429,26 +429,28 @@ if(C_LIBRARY STREQUAL picolibc)
         # So reconfigure to enable tests at a later point.
         ExternalProject_Add_Step(
             picolibc
-            enable-tests
+            compile-tests
             COMMAND ${MESON_EXECUTABLE} setup -Dtests=true --reconfigure <BINARY_DIR> <SOURCE_DIR>
+            COMMAND ${MESON_EXECUTABLE} compile -C <BINARY_DIR>
             USES_TERMINAL TRUE
-            EXCLUDE_FROM_MAIN TRUE
         )
-        ExternalProject_Add_StepTargets(picolibc enable-tests)
+        ExternalProject_Add_StepTargets(picolibc compile-tests)
         ExternalProject_Add_StepDependencies(
             picolibc
-            enable-tests
+            compile-tests
             picolibc-build
             compiler_rt-install
         )
+
+        # Configure a script to run the picolibc tests in order
+        # to handle the return code.
+        ExternalProject_Get_property(picolibc BINARY_DIR)
+        configure_file(check-picolibc.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/check-picolibc.cmake)
+
         ExternalProject_Add_Step(
             picolibc
             check
-            COMMAND ${MESON_EXECUTABLE} test -C <BINARY_DIR>
-            COMMAND ${Python3_EXECUTABLE}
-            ${CMAKE_CURRENT_SOURCE_DIR}/test-support/modify-picolibc-xml.py
-            --dir <BINARY_DIR>
-            --variant ${VARIANT}
+            COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/check-picolibc.cmake
             USES_TERMINAL TRUE
             EXCLUDE_FROM_MAIN TRUE
             ALWAYS TRUE
@@ -457,7 +459,7 @@ if(C_LIBRARY STREQUAL picolibc)
         ExternalProject_Add_StepDependencies(
             picolibc
             check
-            picolibc-enable-tests
+            picolibc-compile-tests
         )
         add_dependencies(check-picolibc picolibc-check)
     endif()

--- a/arm-software/embedded/arm-runtimes/check-picolibc.cmake.in
+++ b/arm-software/embedded/arm-runtimes/check-picolibc.cmake.in
@@ -1,0 +1,36 @@
+# If lit is set to ignore test failures, then meson should do the same.
+set(ignore_fail OFF)
+if(DEFINED ENV{LIT_OPTS})
+    if($ENV{LIT_OPTS} MATCHES "--ignore-fail")
+        set(ignore_fail ON)
+    endif()
+endif()
+
+# Run the tests and store the return code.
+# This will be equal to the number of test failures.
+execute_process(
+    COMMAND
+        ${MESON_EXECUTABLE}
+        test
+        -C ${BINARY_DIR}
+        --no-rebuild
+    RESULT_VARIABLE
+        failure_count
+)
+
+# Process the XML results file to ensure the results are
+# variant specific.
+execute_process(
+    COMMAND
+        ${Python3_EXECUTABLE}
+        ${CMAKE_CURRENT_SOURCE_DIR}/test-support/modify-picolibc-xml.py
+        --dir ${BINARY_DIR}
+        --variant ${VARIANT}
+    COMMAND_ERROR_IS_FATAL
+        ANY
+)
+
+# Use a message to set a return code.
+if(failure_count GREATER 0 AND NOT ignore_fail)
+message(FATAL_ERROR "Stopping due to test failures.")
+endif()


### PR DESCRIPTION
The meson test command will return the number of test failures. If any test fails, this will be non-zero, which the CMake script will interpret as the command failing. The test command is immediately followed by a second command to process the results, so this will not get executed on a failure. Since the processing sets the names in the results file to make them variant specific, this makes it very unclear from the XML results which tests failed, and causes other tests not to run.

To get around this, this patch wraps the meson test command in a new CMake script which can handle the return code. Since the other lit-based tests already use the `--ignore-fail` option to control whether or not to continue on a test failure, this script will also honour the option in the `LIT_OPTS` environment variable.

If the tests fail to build, there is another special return code, so to ensure the tests failing to build (which will generate no XML results) can be distinguished from a test failing to execute, the --no-rebuild option to not bulid the tests at the same time. Instead, the tests will be built in the build step.