### PR TITLE
Make Automerge script verbose

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -41,6 +41,6 @@ jobs:
           git fetch origin ${{ matrix.branches.from_branch }}:${{ matrix.branches.from_branch }}
           git fetch origin --update-head-ok --unshallow ${{ matrix.branches.to_branch }}:${{ matrix.branches.to_branch }}
       - name: Run automerge
-        run: python3 arm-software/ci/automerge.py --project-name ${{ github.repository }} --from-branch ${{ matrix.branches.from_branch }} --to-branch ${{ matrix.branches.to_branch }}
+        run: python3 arm-software/ci/automerge.py --project-name ${{ github.repository }} --from-branch ${{ matrix.branches.from_branch }} --to-branch ${{ matrix.branches.to_branch }} --verbose
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/arm-software/ci/automerge.py
+++ b/arm-software/ci/automerge.py
@@ -47,6 +47,7 @@ class Git:
 
     def run_cmd(self, args: list[str], check: bool = True) -> str:
         git_cmd = ["git", "-C", str(self.repo_path)] + args
+        logger.debug("Running git command: %s", git_cmd)
         git_process = subprocess.run(git_cmd, check=check, capture_output=True, text=True)
         return git_process.stdout
 
@@ -79,15 +80,21 @@ def prefix_current_commit_message(git_repo: Git) -> None:
     git_repo.run_cmd(["commit", "--amend", "--message=" + commit_msg])
 
 
-def merge_commit(git_repo: Git, to_branch: str, commit_hash: str, ignored_paths: list[str], dry_run: bool) -> None:
+def merge_commit(git_repo: Git, to_branch: str, commit_hash: str, ignored_paths: list[str], dry_run: bool, verbose: bool) -> None:
     logger.info("Merging commit %s into %s", commit_hash, to_branch)
     git_repo.run_cmd(["switch", to_branch])
+    if verbose:
+        current_head = git_repo.run_cmd(["log", "--no-walk", "HEAD", "--pretty=reference"])
+        logger.debug("Current HEAD of %s is %s", to_branch, current_head)
     git_repo.run_cmd(["merge", commit_hash, "--no-commit", "--no-ff"], check=False)
     restore_changes_to_ignored_files(git_repo, ignored_paths)
     if has_unresolved_conflicts(git_repo):
         logger.info("Merge failed")
         git_repo.run_cmd(["merge", "--abort"])
         raise MergeConflictError(commit_hash)
+    if verbose:
+        commit_content = git_repo.run_cmd(["diff", "--cached"])
+        logger.debug("Changes being commited:\n%s", commit_content)
     git_repo.run_cmd(["commit", "--reuse-message", commit_hash])
     prefix_current_commit_message(git_repo)
     if dry_run:
@@ -180,8 +187,16 @@ def main():
         action="store_true",
         help="Process changes locally, but don't merge them into the remote repository and don't create PRs",
     )
+    arg_parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print verbose log messages during automerge run",
+    )
 
     args = arg_parser.parse_args()
+
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
 
     try:
         if pr_exist_for_label(args.project_name, MERGE_CONFLICT_LABEL):
@@ -196,7 +211,7 @@ def main():
 
         merge_commits = get_merge_commit_list(git_repo, args.from_branch, args.to_branch)
         for commit_hash in merge_commits:
-            merge_commit(git_repo, args.to_branch, commit_hash, ignored_paths, args.dry_run)
+            merge_commit(git_repo, args.to_branch, commit_hash, ignored_paths, args.dry_run, args.verbose)
     except MergeConflictError as conflict:
         process_conflict(
             git_repo,


### PR DESCRIPTION
This adds a `--verbose` option to the automerge script, and enables it
in the Automerge Workflow. This option will increase observability of
the steps being performed by the script, allowing for any unexpected
behaviours to be investigated.
For now the verbose option includes the logging of the following:
- All Git commands being executed by the script
- The current HEAD of the target branch before each merge attempt
- The diff containing the changes being commited for each merge
