### PR TITLE
Move Toolchain ID script to shared location

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -339,7 +339,7 @@ install(
 # Product code 'E' for Embedded.
 set(LLVM_TOOLCHAIN_PROJECT_CODE "E")
 set(LLVM_TOOLCHAIN_VERSION_SUFFIX "pre")
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/generate_toolchain_id.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../shared/cmake/generate_toolchain_id.cmake)
 
 set(llvmproject_src_dir ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 add_subdirectory(

--- a/arm-software/shared/cmake/generate_toolchain_id.cmake
+++ b/arm-software/shared/cmake/generate_toolchain_id.cmake
@@ -22,6 +22,14 @@ else()
     set(build_number 0)
 endif()
 
+# Pad build number
+string(LENGTH ${build_number} len_build_number)
+if(len_build_number LESS 4)
+    math(EXPR pad_len "4 - ${len_build_number}")
+    string(REPEAT "0" ${pad_len} pad_chars)
+    string(PREPEND build_number ${pad_chars})
+endif()
+
 # Version suffix should be optional.
 if(DEFINED LLVM_TOOLCHAIN_VERSION_SUFFIX)
     set(ID_SUFFIX "-${LLVM_TOOLCHAIN_VERSION_SUFFIX}")
@@ -35,3 +43,9 @@ set(ARM_TOOLCHAIN_ID
     "${LLVM_TOOLCHAIN_PROJECT_CODE}${build_number}${ID_SUFFIX} (${builder_name_hash})" CACHE STRING
     "Toolchain ID to identify product."
 )
+
+# Print the ID in script mode.
+get_property(cmake_role GLOBAL PROPERTY CMAKE_ROLE)
+if(cmake_role STREQUAL SCRIPT)
+    message(${ARM_TOOLCHAIN_ID})
+endif()


### PR DESCRIPTION
This patch makes a few modifications to the CMake script to generate the Arm Toolchain ID:

* The script has been moved out of the embedded build folder and into a new shared one, since it will be used by both toolchains.
* When run in script mode, the script will print the generated ID. This can then be easily captured by an external script.
* The build number is now padded to a minimum of 4 characters.