### PR TITLE
[libc++][test] extend XFAIL clauses to cover Amazon Linux too

### DIFF
--- a/libcxx/test/std/input.output/iostream.format/std.manip/setfill_wchar_max.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/std.manip/setfill_wchar_max.pass.cpp
@@ -17,6 +17,7 @@
 // XFAIL: target={{.*}}-windows{{.*}} && libcpp-abi-version=1
 // XFAIL: target=armv{{7|8}}{{l?}}{{.*}}-linux-gnueabihf && libcpp-abi-version=1
 // XFAIL: target=aarch64{{.*}}-linux-gnu && libcpp-abi-version=1
+// XFAIL: target=aarch64{{.*}}-amazon-linux && libcpp-abi-version=1
 
 #include <iomanip>
 #include <ostream>

--- a/libcxx/test/std/re/re.alg/re.alg.match/awk.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.match/awk.locale.pass.cpp
@@ -19,6 +19,7 @@
 // TODO: investigation needed
 // TODO(netbsd): incomplete support for locales
 // XFAIL: target={{.*}}-linux-gnu{{.*}}, netbsd, freebsd
+// XFAIL: target={{.*}}-amazon-linux{{.*}}
 // REQUIRES: locale.cs_CZ.ISO8859-2
 
 #include <regex>

--- a/libcxx/test/std/re/re.alg/re.alg.match/basic.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.match/basic.locale.pass.cpp
@@ -23,6 +23,7 @@
 
 // TODO: investigation needed
 // XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
+// XFAIL: target={{.*}}-amazon-linux{{.*}}
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.alg/re.alg.match/ecma.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.match/ecma.locale.pass.cpp
@@ -23,6 +23,7 @@
 
 // TODO: investigation needed
 // XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
+// XFAIL: target={{.*}}-amazon-linux{{.*}}
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.alg/re.alg.match/extended.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.match/extended.locale.pass.cpp
@@ -23,6 +23,7 @@
 
 // TODO: investigation needed
 // XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
+// XFAIL: target={{.*}}-amazon-linux{{.*}}
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.alg/re.alg.search/awk.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.search/awk.locale.pass.cpp
@@ -23,6 +23,7 @@
 
 // TODO: investigation needed
 // XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
+// XFAIL: target={{.*}}-amazon-linux{{.*}}
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.alg/re.alg.search/basic.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.search/basic.locale.pass.cpp
@@ -23,6 +23,7 @@
 
 // TODO: investigation needed
 // XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
+// XFAIL: target={{.*}}-amazon-linux{{.*}}
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.alg/re.alg.search/ecma.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.search/ecma.locale.pass.cpp
@@ -23,6 +23,7 @@
 
 // TODO: investigation needed
 // XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
+// XFAIL: target={{.*}}-amazon-linux{{.*}}
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.alg/re.alg.search/extended.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.search/extended.locale.pass.cpp
@@ -23,6 +23,7 @@
 
 // TODO: investigation needed
 // XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
+// XFAIL: target={{.*}}-amazon-linux{{.*}}
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.traits/lookup_collatename.pass.cpp
+++ b/libcxx/test/std/re/re.traits/lookup_collatename.pass.cpp
@@ -24,6 +24,7 @@
 
 // TODO: investigation needed
 // XFAIL: target={{.*}}-linux-gnu{{.*}}
+// XFAIL: target={{.*}}-amazon-linux{{.*}}
 
 #include <regex>
 #include <iterator>


### PR DESCRIPTION
It's a cherry-pick from the main branch.

The default triple of Amazon Linux on AArch64 is aarch64-amazon-linux, see issue highlighded by PR #109263, somewhat serious linker issues are encountered if any other triple is being used.

Unfortunately, this makes XFAIL lines like
`XFAIL: target=aarch64{{.*}}-linux-gnu` ineffective, making it impossible to complete all of the check-cxx on Amazon Linux without failing.