### PR TITLE
Disable libcxx tests on armebv7m_hard_fpv4_sp_d16 variants. (#172)

### DIFF
--- a/arm-software/embedded/arm-multilib/json/variants/armebv7m_hard_fpv4_sp_d16.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armebv7m_hard_fpv4_sp_d16.json
@@ -22,7 +22,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "ON"
+            "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {
             "ENABLE_CXX_LIBS": "ON",

--- a/arm-software/embedded/arm-multilib/json/variants/armebv7m_hard_fpv4_sp_d16_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armebv7m_hard_fpv4_sp_d16_exn_rtti.json
@@ -22,7 +22,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "ON"
+            "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {
             "ENABLE_CXX_LIBS": "ON",


### PR DESCRIPTION
Some libcxx tests are failing on this variant, despite whether any of the failures are exclusive to this variant is unknown.

For now the libcxx tests will remain disabled while we focus on having C library tests passing for new variants we add.

(cherry picked from commit b4a8b67d75ce61b5b996ca2a98e3fce813a4a4d0)