### PR TITLE
[ATfE] Restrict variable replacement in check-picolibc script

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -445,7 +445,7 @@ if(C_LIBRARY STREQUAL picolibc)
         # Configure a script to run the picolibc tests in order
         # to handle the return code.
         ExternalProject_Get_property(picolibc BINARY_DIR)
-        configure_file(check-picolibc.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/check-picolibc.cmake)
+        configure_file(check-picolibc.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/check-picolibc.cmake @ONLY)
 
         ExternalProject_Add_Step(
             picolibc
@@ -462,6 +462,7 @@ if(C_LIBRARY STREQUAL picolibc)
             picolibc-compile-tests
         )
         add_dependencies(check-picolibc picolibc-check)
+        add_dependencies(clib-build ${C_LIBRARY}-compile-tests)
     endif()
 
 endif()

--- a/arm-software/embedded/arm-runtimes/check-picolibc.cmake.in
+++ b/arm-software/embedded/arm-runtimes/check-picolibc.cmake.in
@@ -10,9 +10,9 @@ endif()
 # This will be equal to the number of test failures.
 execute_process(
     COMMAND
-        ${MESON_EXECUTABLE}
+        @MESON_EXECUTABLE@
         test
-        -C ${BINARY_DIR}
+        -C @BINARY_DIR@
         --no-rebuild
     RESULT_VARIABLE
         failure_count
@@ -22,15 +22,15 @@ execute_process(
 # variant specific.
 execute_process(
     COMMAND
-        ${Python3_EXECUTABLE}
-        ${CMAKE_CURRENT_SOURCE_DIR}/test-support/modify-picolibc-xml.py
-        --dir ${BINARY_DIR}
-        --variant ${VARIANT}
+        @Python3_EXECUTABLE@
+        @CMAKE_CURRENT_SOURCE_DIR@/test-support/modify-picolibc-xml.py
+        --dir @BINARY_DIR@
+        --variant @VARIANT@
     COMMAND_ERROR_IS_FATAL
         ANY
 )
 
 # Use a message to set a return code.
 if(failure_count GREATER 0 AND NOT ignore_fail)
-message(FATAL_ERROR "Stopping due to test failures.")
+    message(FATAL_ERROR "Stopping due to test failures.")
 endif()


### PR DESCRIPTION
The `LIT_OPTS` environment variable should be evaluated at runtime, not during configuration. The `@ONLY` option can be used to limit replacement to only the variables that need replacing during configuration.

Additionally, compiling the tests has been added as a dependancy of building the library so that it can be done in parallel.