### PR TITLE
[ATfE] Cherry-pick PRs #162 and #175 to 20.x release branch

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -442,7 +442,7 @@ if(C_LIBRARY STREQUAL picolibc)
         # Configure a script to run the picolibc tests in order
         # to handle the return code.
         ExternalProject_Get_property(picolibc BINARY_DIR)
-        configure_file(check-picolibc.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/check-picolibc.cmake)
+        configure_file(check-picolibc.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/check-picolibc.cmake @ONLY)
 
         ExternalProject_Add_Step(
             picolibc
@@ -459,6 +459,7 @@ if(C_LIBRARY STREQUAL picolibc)
             picolibc-compile-tests
         )
         add_dependencies(check-picolibc picolibc-check)
+        add_dependencies(clib-build ${C_LIBRARY}-compile-tests)
     endif()
 
 endif()

--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -426,26 +426,28 @@ if(C_LIBRARY STREQUAL picolibc)
         # So reconfigure to enable tests at a later point.
         ExternalProject_Add_Step(
             picolibc
-            enable-tests
+            compile-tests
             COMMAND ${MESON_EXECUTABLE} setup -Dtests=true --reconfigure <BINARY_DIR> <SOURCE_DIR>
+            COMMAND ${MESON_EXECUTABLE} compile -C <BINARY_DIR>
             USES_TERMINAL TRUE
-            EXCLUDE_FROM_MAIN TRUE
         )
-        ExternalProject_Add_StepTargets(picolibc enable-tests)
+        ExternalProject_Add_StepTargets(picolibc compile-tests)
         ExternalProject_Add_StepDependencies(
             picolibc
-            enable-tests
+            compile-tests
             picolibc-build
             compiler_rt-install
         )
+
+        # Configure a script to run the picolibc tests in order
+        # to handle the return code.
+        ExternalProject_Get_property(picolibc BINARY_DIR)
+        configure_file(check-picolibc.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/check-picolibc.cmake)
+
         ExternalProject_Add_Step(
             picolibc
             check
-            COMMAND ${MESON_EXECUTABLE} test -C <BINARY_DIR>
-            COMMAND ${Python3_EXECUTABLE}
-            ${CMAKE_CURRENT_SOURCE_DIR}/test-support/modify-picolibc-xml.py
-            --dir <BINARY_DIR>
-            --variant ${VARIANT}
+            COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/check-picolibc.cmake
             USES_TERMINAL TRUE
             EXCLUDE_FROM_MAIN TRUE
             ALWAYS TRUE
@@ -454,7 +456,7 @@ if(C_LIBRARY STREQUAL picolibc)
         ExternalProject_Add_StepDependencies(
             picolibc
             check
-            picolibc-enable-tests
+            picolibc-compile-tests
         )
         add_dependencies(check-picolibc picolibc-check)
     endif()

--- a/arm-software/embedded/arm-runtimes/check-picolibc.cmake.in
+++ b/arm-software/embedded/arm-runtimes/check-picolibc.cmake.in
@@ -1,0 +1,36 @@
+# If lit is set to ignore test failures, then meson should do the same.
+set(ignore_fail OFF)
+if(DEFINED ENV{LIT_OPTS})
+    if($ENV{LIT_OPTS} MATCHES "--ignore-fail")
+        set(ignore_fail ON)
+    endif()
+endif()
+
+# Run the tests and store the return code.
+# This will be equal to the number of test failures.
+execute_process(
+    COMMAND
+        ${MESON_EXECUTABLE}
+        test
+        -C ${BINARY_DIR}
+        --no-rebuild
+    RESULT_VARIABLE
+        failure_count
+)
+
+# Process the XML results file to ensure the results are
+# variant specific.
+execute_process(
+    COMMAND
+        ${Python3_EXECUTABLE}
+        ${CMAKE_CURRENT_SOURCE_DIR}/test-support/modify-picolibc-xml.py
+        --dir ${BINARY_DIR}
+        --variant ${VARIANT}
+    COMMAND_ERROR_IS_FATAL
+        ANY
+)
+
+# Use a message to set a return code.
+if(failure_count GREATER 0 AND NOT ignore_fail)
+message(FATAL_ERROR "Stopping due to test failures.")
+endif()

--- a/arm-software/embedded/arm-runtimes/check-picolibc.cmake.in
+++ b/arm-software/embedded/arm-runtimes/check-picolibc.cmake.in
@@ -10,9 +10,9 @@ endif()
 # This will be equal to the number of test failures.
 execute_process(
     COMMAND
-        ${MESON_EXECUTABLE}
+        @MESON_EXECUTABLE@
         test
-        -C ${BINARY_DIR}
+        -C @BINARY_DIR@
         --no-rebuild
     RESULT_VARIABLE
         failure_count
@@ -22,15 +22,15 @@ execute_process(
 # variant specific.
 execute_process(
     COMMAND
-        ${Python3_EXECUTABLE}
-        ${CMAKE_CURRENT_SOURCE_DIR}/test-support/modify-picolibc-xml.py
-        --dir ${BINARY_DIR}
-        --variant ${VARIANT}
+        @Python3_EXECUTABLE@
+        @CMAKE_CURRENT_SOURCE_DIR@/test-support/modify-picolibc-xml.py
+        --dir @BINARY_DIR@
+        --variant @VARIANT@
     COMMAND_ERROR_IS_FATAL
         ANY
 )
 
 # Use a message to set a return code.
 if(failure_count GREATER 0 AND NOT ignore_fail)
-message(FATAL_ERROR "Stopping due to test failures.")
+    message(FATAL_ERROR "Stopping due to test failures.")
 endif()


### PR DESCRIPTION
Both these changes are required to run a full set of tests from the test script without the build stopping on the first picolibc failure.