### PR TITLE
[Downstream change][tests] Mark the tests failing with timeout as unsupported

### DIFF
--- a/llvm/utils/lit/tests/googletest-timeout.py
+++ b/llvm/utils/lit/tests/googletest-timeout.py
@@ -1,4 +1,5 @@
 # REQUIRES: lit-max-individual-test-time
+# UNSUPPORTED: system-linux
 
 ###############################################################################
 # Check tests can hit timeout when set

--- a/llvm/utils/lit/tests/max-time.py
+++ b/llvm/utils/lit/tests/max-time.py
@@ -1,4 +1,5 @@
 # UNSUPPORTED: system-windows
+# UNSUPPORTED: system-linux
 
 # Test overall lit timeout (--max-time).
 #

--- a/llvm/utils/lit/tests/xunit-output-report-failures-only.py
+++ b/llvm/utils/lit/tests/xunit-output-report-failures-only.py
@@ -1,3 +1,4 @@
+# UNSUPPORTED: system-linux
 ## Check xunit output.
 # RUN: not %{lit} --report-failures-only --xunit-xml-output %t.xunit.xml %{inputs}/xunit-output
 # RUN: FileCheck --input-file=%t.xunit.xml %s

--- a/llvm/utils/lit/tests/xunit-output.py
+++ b/llvm/utils/lit/tests/xunit-output.py
@@ -1,4 +1,5 @@
 # UNSUPPORTED: system-windows
+# UNSUPPORTED: system-linux
 
 # Check xunit output
 # RUN: rm -rf %t.xunit.xml


### PR DESCRIPTION
Initial upstream attempt: https://github.com/llvm/llvm-project/pull/126527

Downstream issue: https://github.com/arm/arm-toolchain/issues/177

There are some test cases which tend to fail with timeout when started on heavy loaded shared machines. As our CI machines are mostly shared, those failures tend to introduce unnecessary disturbance to our work. It is better to disable those tests.

For more context, please read issue #177.