### PR TITLE
Use pull to update target branch in Automerge Workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           git remote set-branches --add origin ${{ matrix.branches.from_branch }}
           git fetch origin ${{ matrix.branches.from_branch }}:${{ matrix.branches.from_branch }}
-          git fetch origin --update-head-ok --unshallow ${{ matrix.branches.to_branch }}:${{ matrix.branches.to_branch }}
+          git pull --unshallow --ff-only origin ${{ matrix.branches.to_branch }}
       - name: Run automerge
         run: python3 arm-software/ci/automerge.py --project-name ${{ github.repository }} --from-branch ${{ matrix.branches.from_branch }} --to-branch ${{ matrix.branches.to_branch }} --verbose
         env:


### PR DESCRIPTION
This updates the Automerge Workflow to use a `git pull --unshallow`
command instead of `git fetch --unshallow` to obtain the history of the
target branch. Using `git pull` ensures the worktree contents will also
be correctly up-to-date if any new changes are added to the remote
between the 'Checkout' step and the 'Fetch Branches' step.
