### PR TITLE
[ATfE] Rebase picolibc patches

### DIFF
--- a/arm-software/embedded/patches/picolibc/0001-Enable-libcxx-builds.patch
+++ b/arm-software/embedded/patches/picolibc/0001-Enable-libcxx-builds.patch
@@ -1,4 +1,4 @@
-From 253cf7620fe0f935831d5dd4d408ff0b907cd31c Mon Sep 17 00:00:00 2001
+From cf0324ab646a164ad5b3409e1147164e076b72d0 Mon Sep 17 00:00:00 2001
 From: Simi Pallipurath <simi.pallipurath@arm.com>
 Date: Thu, 14 Nov 2024 10:07:08 +0000
 Subject: Enable libcxx builds
@@ -11,10 +11,10 @@ libc++ builds.
  2 files changed, 15 insertions(+)
 
 diff --git a/meson.build b/meson.build
-index 75dac5275..bc7286442 100644
+index e62ac11ab..b3881d106 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -1364,6 +1364,18 @@ if get_option('newlib-retargetable-locking') != get_option('newlib-multithread')
+@@ -1373,6 +1373,18 @@ if get_option('newlib-retargetable-locking') != get_option('newlib-multithread')
    error('newlib-retargetable-locking and newlib-multithread must be set to the same value')
  endif
  
@@ -34,13 +34,13 @@ index 75dac5275..bc7286442 100644
  	      cc.has_argument('-fno-tree-loop-distribute-patterns'),
  	      description: 'Compiler flag to prevent detecting memcpy/memset patterns')
 diff --git a/picolibc.ld.in b/picolibc.ld.in
-index 295131644..0abacadf0 100644
+index c6d2a7d66..b8cd3209b 100644
 --- a/picolibc.ld.in
 +++ b/picolibc.ld.in
-@@ -68,6 +68,9 @@ SECTIONS
- 		*(.literal.unlikely .text.unlikely .literal.unlikely.* .text.unlikely.*)
+@@ -69,6 +69,9 @@ SECTIONS
  		*(.literal.startup .text.startup .literal.startup.* .text.startup.*)
- 		*(.literal .text .literal.* .text.* .opd .opd.* @EXTRA_TEXT_SECTIONS@)
+ 		*(SORT(.text.sorted.*))
+ 		*(.literal .text .literal.* .text.* .opd .opd.* .branch_lt .branch_lt.* @EXTRA_TEXT_SECTIONS@)
 +		PROVIDE (__start___lcxx_override = .);
 +		*(__lcxx_override)
 +		PROVIDE (__stop___lcxx_override = .);

--- a/arm-software/embedded/patches/picolibc/0002-Define-picocrt_machines-for-AArch32-builds-as-well-a.patch
+++ b/arm-software/embedded/patches/picolibc/0002-Define-picocrt_machines-for-AArch32-builds-as-well-a.patch
@@ -1,4 +1,4 @@
-From 306f3aac00a63d9cda13be3af8bf4ae8d7d3c9d8 Mon Sep 17 00:00:00 2001
+From 8f32c696fa3531dd557f180c09bdb6bd2689cb1c Mon Sep 17 00:00:00 2001
 From: Simi Pallipurath <simi.pallipurath@arm.com>
 Date: Thu, 14 Nov 2024 10:12:33 +0000
 Subject: Define picocrt_machines for AArch32 builds as well as 64.

--- a/arm-software/embedded/patches/picolibc/0003-Add-support-for-strict-align-no-unaligned-access-in-.patch
+++ b/arm-software/embedded/patches/picolibc/0003-Add-support-for-strict-align-no-unaligned-access-in-.patch
@@ -1,4 +1,4 @@
-From b3120ec265258f0104bef4a21bc1189de101ab43 Mon Sep 17 00:00:00 2001
+From bf63b7e69303c9fff4ee9a62289f78af21f3fb3d Mon Sep 17 00:00:00 2001
 From: Lucas Prates <lucas.prates@arm.com>
 Date: Mon, 11 Nov 2024 16:37:04 +0000
 Subject: Add support for strict-align/no-unaligned-access in AArch64


### PR DESCRIPTION
Upstream picolibc changes mean the first patch no longer applies cleanly. Only the context around our downstream modification has changed, so the patches have been rebased.