### PR TITLE
[ATfE] Add newline to boilerplate pattern for Corstone model

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
+++ b/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
@@ -149,6 +149,7 @@ def run_fvp(
     Ethos-U rev [0-9a-z]+ --- \w{3} {1,2}\d{1,2} \d{4} \d{2}:\d{2}:\d{2}
     \(C\) COPYRIGHT (?:\d{4}|\d{4}-\d{4})(?:,\s?(?:\d{4}|\d{4}-\d{4}))* Arm Limited
     ALL RIGHTS RESERVED
+
 """
         # Not all Corstone-310 versions print the "Info" message.
         stop_info_pattern = "\nInfo: /OSCI/SystemC: Simulation stopped by user.\n"


### PR DESCRIPTION
The regular expression for the boilerplate pattern for Corstone's output
has one extra newline that must be accounted for.