### PR TITLE
[ATfE] Remove pre-release package suffix

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -338,7 +338,6 @@ install(
 # Generate a toolchain ID.
 # Product code 'E' for Embedded.
 set(LLVM_TOOLCHAIN_PROJECT_CODE "E")
-set(LLVM_TOOLCHAIN_VERSION_SUFFIX "")
 include(${CMAKE_CURRENT_SOURCE_DIR}/../shared/cmake/generate_toolchain_id.cmake)
 
 set(llvmproject_src_dir ${CMAKE_CURRENT_SOURCE_DIR}/../..)


### PR DESCRIPTION
Setting the suffix to nothing will correctly generate the toolchain ID, but leads to an incorrectly formatted package name. Instead, the suffix should not be set at all.