### PR TITLE
Add SBOM JSON files for ATfE, llvmlibc overlay and newlib overlay (#183)

### DIFF
--- a/arm-software/embedded/ATfE-SBOM-llvmlibc-overlay.spdx.json
+++ b/arm-software/embedded/ATfE-SBOM-llvmlibc-overlay.spdx.json
@@ -1,0 +1,65 @@
+{
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "creationInfo": {
+        "created": "2025-03-11T14:57:55Z",
+        "creators": [
+            "Organization: Arm Limited (open-source-office@arm.com)"
+        ]
+    },
+    "dataLicense": "CC0-1.0",
+    "name": "Arm Toolchain for Embedded LLVM libc overlay",
+    "spdxVersion": "SPDX-2.3",
+    "documentNamespace": "https://github.com/arm/arm-toolchain/tree/arm-software/arm-software/embedded",
+    "packages": [
+        {
+            "SPDXID": "SPDXRef-Package-7b00a6db-5a0c-5d02-800d-c0bd1a9b0290",
+            "downloadLocation": "https://github.com/arm/arm-toolchain/tree/arm-software/arm-software/embedded",
+            "filesAnalyzed": false,
+            "licenseComments": "",
+            "licenseConcluded": "Apache-2.0 WITH LLVM-exception",
+            "licenseDeclared": "Apache-2.0 WITH LLVM-exception",
+            "name": "Arm Toolchain for Embedded",
+            "originator": "Organization: Arm Limited (open-source-office@arm.com)",
+            "supplier": "Organization: Arm Limited (open-source-office@arm.com)"
+        },
+        {
+            "SPDXID": "SPDXRef-Package-e44bc351-526b-5ca1-93c9-0f88a33b934a",
+            "downloadLocation": "https://github.com/llvm/llvm-project/tree/main/compiler-rt",
+            "filesAnalyzed": false,
+            "licenseComments": "",
+            "licenseConcluded": "Apache-2.0 WITH LLVM-exception",
+            "licenseDeclared": "Apache-2.0 WITH LLVM-exception",
+            "name": "compiler-rt",
+            "originator": "Organization: LLVM Foundation (info@llvm.org)",
+            "supplier": "Organization: LLVM Foundation (info@llvm.org)"
+        },
+        {
+            "SPDXID": "SPDXRef-Package-09ef5819-9c48-5d94-b42b-4a918b20f6e4",
+            "downloadLocation": "https://github.com/llvm/llvm-project/tree/main/libc",
+            "filesAnalyzed": false,
+            "licenseComments": "",
+            "licenseConcluded": "Apache-2.0 WITH LLVM-exception",
+            "licenseDeclared": "Apache-2.0 WITH LLVM-exception",
+            "name": "libc",
+            "originator": "Organization: LLVM Foundation (info@llvm.org)",
+            "supplier": "Organization: LLVM Foundation (info@llvm.org)"
+        }
+    ],
+    "relationships": [
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-7b00a6db-5a0c-5d02-800d-c0bd1a9b0290",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-e44bc351-526b-5ca1-93c9-0f88a33b934a",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-09ef5819-9c48-5d94-b42b-4a918b20f6e4",
+            "relationshipType": "DESCRIBES"
+        }
+    ]
+}

--- a/arm-software/embedded/ATfE-SBOM-newlib-overlay.spdx.json
+++ b/arm-software/embedded/ATfE-SBOM-newlib-overlay.spdx.json
@@ -1,0 +1,111 @@
+{
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "creationInfo": {
+        "created": "2025-03-11T14:57:58Z",
+        "creators": [
+            "Organization: Arm Limited (open-source-office@arm.com)"
+        ]
+    },
+    "dataLicense": "CC0-1.0",
+    "name": "Arm Toolchain for Embedded newlib overlay",
+    "spdxVersion": "SPDX-2.3",
+    "documentNamespace": "https://github.com/arm/arm-toolchain/tree/arm-software/arm-software/embedded",
+    "packages": [
+        {
+            "SPDXID": "SPDXRef-Package-7b00a6db-5a0c-5d02-800d-c0bd1a9b0290",
+            "downloadLocation": "https://github.com/arm/arm-toolchain/tree/arm-software/arm-software/embedded",
+            "filesAnalyzed": false,
+            "licenseComments": "",
+            "licenseConcluded": "Apache-2.0 WITH LLVM-exception",
+            "licenseDeclared": "Apache-2.0 WITH LLVM-exception",
+            "name": "Arm Toolchain for Embedded",
+            "originator": "Organization: Arm Limited (open-source-office@arm.com)",
+            "supplier": "Organization: Arm Limited (open-source-office@arm.com)"
+        },
+        {
+            "SPDXID": "SPDXRef-Package-e44bc351-526b-5ca1-93c9-0f88a33b934a",
+            "downloadLocation": "https://github.com/llvm/llvm-project/tree/main/compiler-rt",
+            "filesAnalyzed": false,
+            "licenseComments": "",
+            "licenseConcluded": "Apache-2.0 WITH LLVM-exception",
+            "licenseDeclared": "Apache-2.0 WITH LLVM-exception",
+            "name": "compiler-rt",
+            "originator": "Organization: LLVM Foundation (info@llvm.org)",
+            "supplier": "Organization: LLVM Foundation (info@llvm.org)"
+        },
+        {
+            "SPDXID": "SPDXRef-Package-55633fe2-115b-594e-a5ec-84ece9a16f80",
+            "downloadLocation": "https://github.com/llvm/llvm-project/tree/main/libcxx",
+            "filesAnalyzed": false,
+            "licenseComments": "",
+            "licenseConcluded": "Apache-2.0 WITH LLVM-exception",
+            "licenseDeclared": "Apache-2.0 WITH LLVM-exception",
+            "name": "libcxx",
+            "originator": "Organization: LLVM Foundation (info@llvm.org)",
+            "supplier": "Organization: LLVM Foundation (info@llvm.org)"
+        },
+        {
+            "SPDXID": "SPDXRef-Package-90f44391-c061-5db7-ad32-4c0951366e9e",
+            "downloadLocation": "https://github.com/llvm/llvm-project/tree/main/libcxxabi",
+            "filesAnalyzed": false,
+            "licenseComments": "",
+            "licenseConcluded": "Apache-2.0 WITH LLVM-exception",
+            "licenseDeclared": "Apache-2.0 WITH LLVM-exception",
+            "name": "libcxxabi",
+            "originator": "Organization: LLVM Foundation (info@llvm.org)",
+            "supplier": "Organization: LLVM Foundation (info@llvm.org)"
+        },
+        {
+            "SPDXID": "SPDXRef-Package-95411904-8af0-5830-8fbc-4185e16949de",
+            "downloadLocation": "https://github.com/llvm/llvm-project/tree/main/libunwind",
+            "filesAnalyzed": false,
+            "licenseComments": "",
+            "licenseConcluded": "Apache-2.0 WITH LLVM-exception",
+            "licenseDeclared": "Apache-2.0 WITH LLVM-exception",
+            "name": "libunwind",
+            "originator": "Organization: LLVM Foundation (info@llvm.org)",
+            "supplier": "Organization: LLVM Foundation (info@llvm.org)"
+        },
+        {
+            "SPDXID": "SPDXRef-Package-43e25662-200b-584e-b946-57bddf7cb24a",
+            "downloadLocation": "https://sourceware.org/newlib/",
+            "filesAnalyzed": false,
+            "licenseComments": "Detailed list of licenses is at: https://github.com/picolibc/picolibc/blob/main/COPYING.NEWLIB",
+            "name": "newlib",
+            "originator": "Organization: https://sourceware.org/newlib/ (newlib@sourceware.org)",
+            "supplier": "Organization: https://sourceware.org/newlib/ (newlib@sourceware.org)"
+        }
+    ],
+    "relationships": [
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-7b00a6db-5a0c-5d02-800d-c0bd1a9b0290",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-e44bc351-526b-5ca1-93c9-0f88a33b934a",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-55633fe2-115b-594e-a5ec-84ece9a16f80",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-90f44391-c061-5db7-ad32-4c0951366e9e",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-95411904-8af0-5830-8fbc-4185e16949de",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-43e25662-200b-584e-b946-57bddf7cb24a",
+            "relationshipType": "DESCRIBES"
+        }
+    ]
+}

--- a/arm-software/embedded/ATfE-SBOM.spdx.json
+++ b/arm-software/embedded/ATfE-SBOM.spdx.json
@@ -1,0 +1,159 @@
+{
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "creationInfo": {
+        "created": "2025-03-11T14:57:51Z",
+        "creators": [
+            "Organization: Arm Limited (open-source-office@arm.com)"
+        ]
+    },
+    "dataLicense": "CC0-1.0",
+    "name": "Arm Toolchain for Embedded",
+    "spdxVersion": "SPDX-2.3",
+    "documentNamespace": "https://github.com/arm/arm-toolchain/tree/arm-software/arm-software/embedded",
+    "packages": [
+        {
+            "SPDXID": "SPDXRef-Package-7b00a6db-5a0c-5d02-800d-c0bd1a9b0290",
+            "downloadLocation": "https://github.com/arm/arm-toolchain/tree/arm-software/arm-software/embedded",
+            "filesAnalyzed": false,
+            "licenseComments": "",
+            "licenseConcluded": "Apache-2.0 WITH LLVM-exception",
+            "licenseDeclared": "Apache-2.0 WITH LLVM-exception",
+            "name": "Arm Toolchain for Embedded",
+            "originator": "Organization: Arm Limited (open-source-office@arm.com)",
+            "supplier": "Organization: Arm Limited (open-source-office@arm.com)"
+        },
+        {
+            "SPDXID": "SPDXRef-Package-e47101d8-f397-517a-826a-074c99307e4a",
+            "downloadLocation": "https://github.com/llvm/llvm-project",
+            "filesAnalyzed": false,
+            "licenseComments": "",
+            "licenseConcluded": "Apache-2.0 WITH LLVM-exception",
+            "licenseDeclared": "Apache-2.0 WITH LLVM-exception",
+            "name": "llvm-project",
+            "originator": "Organization: LLVM Foundation (info@llvm.org)",
+            "supplier": "Organization: LLVM Foundation (info@llvm.org)"
+        },
+        {
+            "SPDXID": "SPDXRef-Package-2f874dca-9a59-5f2c-8623-486b883acceb",
+            "downloadLocation": "https://github.com/llvm/llvm-project/tree/main/clang",
+            "filesAnalyzed": false,
+            "licenseComments": "",
+            "licenseConcluded": "Apache-2.0 WITH LLVM-exception",
+            "licenseDeclared": "Apache-2.0 WITH LLVM-exception",
+            "name": "clang",
+            "originator": "Organization: LLVM Foundation (info@llvm.org)",
+            "supplier": "Organization: LLVM Foundation (info@llvm.org)"
+        },
+        {
+            "SPDXID": "SPDXRef-Package-a247e320-5008-5abf-98dd-286d8ce8d45d",
+            "downloadLocation": "https://github.com/llvm/llvm-project/tree/main/lld",
+            "filesAnalyzed": false,
+            "licenseComments": "",
+            "licenseConcluded": "Apache-2.0 WITH LLVM-exception",
+            "licenseDeclared": "Apache-2.0 WITH LLVM-exception",
+            "name": "lld",
+            "originator": "Organization: LLVM Foundation (info@llvm.org)",
+            "supplier": "Organization: LLVM Foundation (info@llvm.org)"
+        },
+        {
+            "SPDXID": "SPDXRef-Package-e44bc351-526b-5ca1-93c9-0f88a33b934a",
+            "downloadLocation": "https://github.com/llvm/llvm-project/tree/main/compiler-rt",
+            "filesAnalyzed": false,
+            "licenseComments": "",
+            "licenseConcluded": "Apache-2.0 WITH LLVM-exception",
+            "licenseDeclared": "Apache-2.0 WITH LLVM-exception",
+            "name": "compiler-rt",
+            "originator": "Organization: LLVM Foundation (info@llvm.org)",
+            "supplier": "Organization: LLVM Foundation (info@llvm.org)"
+        },
+        {
+            "SPDXID": "SPDXRef-Package-55633fe2-115b-594e-a5ec-84ece9a16f80",
+            "downloadLocation": "https://github.com/llvm/llvm-project/tree/main/libcxx",
+            "filesAnalyzed": false,
+            "licenseComments": "",
+            "licenseConcluded": "Apache-2.0 WITH LLVM-exception",
+            "licenseDeclared": "Apache-2.0 WITH LLVM-exception",
+            "name": "libcxx",
+            "originator": "Organization: LLVM Foundation (info@llvm.org)",
+            "supplier": "Organization: LLVM Foundation (info@llvm.org)"
+        },
+        {
+            "SPDXID": "SPDXRef-Package-90f44391-c061-5db7-ad32-4c0951366e9e",
+            "downloadLocation": "https://github.com/llvm/llvm-project/tree/main/libcxxabi",
+            "filesAnalyzed": false,
+            "licenseComments": "",
+            "licenseConcluded": "Apache-2.0 WITH LLVM-exception",
+            "licenseDeclared": "Apache-2.0 WITH LLVM-exception",
+            "name": "libcxxabi",
+            "originator": "Organization: LLVM Foundation (info@llvm.org)",
+            "supplier": "Organization: LLVM Foundation (info@llvm.org)"
+        },
+        {
+            "SPDXID": "SPDXRef-Package-95411904-8af0-5830-8fbc-4185e16949de",
+            "downloadLocation": "https://github.com/llvm/llvm-project/tree/main/libunwind",
+            "filesAnalyzed": false,
+            "licenseComments": "",
+            "licenseConcluded": "Apache-2.0 WITH LLVM-exception",
+            "licenseDeclared": "Apache-2.0 WITH LLVM-exception",
+            "name": "libunwind",
+            "originator": "Organization: LLVM Foundation (info@llvm.org)",
+            "supplier": "Organization: LLVM Foundation (info@llvm.org)"
+        },
+        {
+            "SPDXID": "SPDXRef-Package-8f339123-88e4-5ff4-9a69-bc4b0c8d65d0",
+            "downloadLocation": "https://github.com/picolibc/picolibc",
+            "filesAnalyzed": false,
+            "licenseComments": "Detailed list of licenses is at: https://github.com/picolibc/picolibc/blob/main/COPYING.picolibc",
+            "name": "picolibc",
+            "originator": "Person: Keith Packard (https://github.com/keith-packard)",
+            "supplier": "Person: Keith Packard (https://github.com/keith-packard)"
+        }
+    ],
+    "relationships": [
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-7b00a6db-5a0c-5d02-800d-c0bd1a9b0290",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-e47101d8-f397-517a-826a-074c99307e4a",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-2f874dca-9a59-5f2c-8623-486b883acceb",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-a247e320-5008-5abf-98dd-286d8ce8d45d",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-e44bc351-526b-5ca1-93c9-0f88a33b934a",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-55633fe2-115b-594e-a5ec-84ece9a16f80",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-90f44391-c061-5db7-ad32-4c0951366e9e",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-95411904-8af0-5830-8fbc-4185e16949de",
+            "relationshipType": "DESCRIBES"
+        },
+        {
+            "spdxElementId": "SPDXRef-DOCUMENT",
+            "relatedSpdxElement": "SPDXRef-Package-8f339123-88e4-5ff4-9a69-bc4b0c8d65d0",
+            "relationshipType": "DESCRIBES"
+        }
+    ]
+}

--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -320,6 +320,12 @@ if(LLVM_TOOLCHAIN_C_LIBRARY MATCHES "^newlib")
         COMPONENT llvm-toolchain-${LLVM_TOOLCHAIN_C_LIBRARY}-configs
     )
     install(
+        FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/ATfE-SBOM-newlib-overlay.spdx.json
+        DESTINATION .
+        COMPONENT llvm-toolchain-${LLVM_TOOLCHAIN_C_LIBRARY}-configs
+    )
+    install(
         DIRECTORY
         ${CMAKE_CURRENT_SOURCE_DIR}/newlib-samples/
         DESTINATION samples
@@ -350,6 +356,13 @@ if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL llvmlibc)
         FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/llvmlibc.cfg
         DESTINATION bin
+        COMPONENT llvm-toolchain-llvmlibc-configs
+    )
+
+    install(
+        FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/ATfE-SBOM-llvmlibc-overlay.spdx.json
+        DESTINATION .
         COMPONENT llvm-toolchain-llvmlibc-configs
     )
 
@@ -686,7 +699,7 @@ install(
 )
 
 install(
-    FILES CHANGELOG.md LICENSE.txt README.md
+    FILES CHANGELOG.md LICENSE.txt README.md ATfE-SBOM.spdx.json
     DESTINATION .
     COMPONENT llvm-toolchain-docs
 )

--- a/arm-software/embedded/scripts/SBOM_Files/generate_ATfE-SBOM-llvmlibc-overlay.py
+++ b/arm-software/embedded/scripts/SBOM_Files/generate_ATfE-SBOM-llvmlibc-overlay.py
@@ -1,0 +1,162 @@
+#  SPDX-FileCopyrightText: 2023 spdx contributors
+#
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+#
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Purpose: This script helps to generate SBOM for ATfE llvm-libc overlay package.
+#
+# Installation: Kindly refer https://github.com/spdx/tools-python for pre-requisite installation.
+#
+# Usage: python generate_ATfE-SBOM-llvmlibc-overlay.py
+#
+# Output file generated: ATfE-SBOM-llvmlibc-overlay.spdx.json
+#
+import logging
+import uuid
+from datetime import datetime
+from typing import List
+
+from spdx_tools.common.spdx_licensing import spdx_licensing
+from spdx_tools.spdx.model import (
+    Actor,
+    ActorType,
+    CreationInfo,
+    Document,
+    Package,
+    Relationship,
+    RelationshipType,
+)
+from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
+from spdx_tools.spdx.validation.validation_message import ValidationMessage
+from spdx_tools.spdx.writer.write_anything import write_file
+
+# This example shows how to use the spdx-tools to create an SPDX document from scratch,
+# validate it and write it to a file.
+
+
+def create_Package(
+    name,
+    uuid,
+    download_location,
+    actorType,
+    personName,
+    personEmail,
+    license,
+    licenseComment,
+):
+    package = Package(
+        name=name,
+        spdx_id=uuid,
+        download_location=download_location,
+        supplier=Actor(actorType, personName, personEmail),
+        originator=Actor(actorType, personName, personEmail),
+        files_analyzed=False,
+        license_concluded=spdx_licensing.parse(license),
+        license_declared=spdx_licensing.parse(license),
+        license_comment=licenseComment,
+    )
+
+    return package
+
+
+# First up, we need general information about the creation of the document, summarised by the CreationInfo class.
+creation_info = CreationInfo(
+    spdx_version="SPDX-2.3",
+    spdx_id="SPDXRef-DOCUMENT",
+    name="Arm Toolchain for Embedded LLVM libc overlay",
+    data_license="CC0-1.0",
+    document_namespace="https://github.com/arm/arm-toolchain/tree/arm-software/arm-software/embedded",
+    creators=[
+        Actor(ActorType.ORGANIZATION, "Arm Limited", "open-source-office@arm.com")
+    ],
+    created=datetime.now(),
+)
+
+# creation_info is the only required property of the Document class (have a look there!), the rest are optional lists.
+document = Document(creation_info)
+
+# The document currently does not describe anything. Let's create a package that we can add to it.
+package_url = (
+    "https://github.com/arm/arm-toolchain/tree/arm-software/arm-software/embedded"
+)
+package_uuid_atfe = "SPDXRef-Package-" + str(
+    uuid.uuid5(uuid.NAMESPACE_URL, package_url)
+)
+package_atfe = create_Package(
+    "Arm Toolchain for Embedded",
+    package_uuid_atfe,
+    package_url,
+    ActorType.ORGANIZATION,
+    "Arm Limited",
+    "open-source-office@arm.com",
+    "Apache-2.0 WITH LLVM-exception",
+    "",
+)
+
+package_url = "https://github.com/llvm/llvm-project/tree/main/compiler-rt"
+package_uuid_compiler_rt = "SPDXRef-Package-" + str(
+    uuid.uuid5(uuid.NAMESPACE_URL, package_url)
+)
+package_compiler_rt = create_Package(
+    "compiler-rt",
+    package_uuid_compiler_rt,
+    package_url,
+    ActorType.ORGANIZATION,
+    "LLVM Foundation",
+    "info@llvm.org",
+    "Apache-2.0 WITH LLVM-exception",
+    "",
+)
+
+package_url = "https://github.com/llvm/llvm-project/tree/main/libc"
+package_uuid_libc = "SPDXRef-Package-" + str(
+    uuid.uuid5(uuid.NAMESPACE_URL, package_url)
+)
+package_libc = create_Package(
+    "libc",
+    package_uuid_libc,
+    package_url,
+    ActorType.ORGANIZATION,
+    "LLVM Foundation",
+    "info@llvm.org",
+    "Apache-2.0 WITH LLVM-exception",
+    "",
+)
+
+# Now that we have a package defined, we can add it to the document's package property.
+document.packages = [package_atfe, package_compiler_rt, package_libc]
+
+# A DESCRIBES relationship asserts that the document indeed describes the package.
+describes_relationship_atfe = Relationship(
+    "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, package_uuid_atfe
+)
+
+describes_relationship_compiler_rt = Relationship(
+    "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, package_uuid_compiler_rt
+)
+
+describes_relationship_libc = Relationship(
+    "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, package_uuid_libc
+)
+
+document.relationships = [
+    describes_relationship_atfe,
+    describes_relationship_compiler_rt,
+    describes_relationship_libc,
+]
+
+# This library provides comprehensive validation against the SPDX specification.
+validation_messages: List[ValidationMessage] = validate_full_spdx_document(document)
+
+for message in validation_messages:
+    logging.warning(message.validation_message)
+    logging.warning(message.context)
+
+# If the document is valid, validation_messages will be empty.
+assert validation_messages == []
+
+# Using the write_file() method from the write_anything module.
+write_file(document, "ATfE-SBOM-llvmlibc-overlay.spdx.json")

--- a/arm-software/embedded/scripts/SBOM_Files/generate_ATfE-SBOM-newlib-overlay.py
+++ b/arm-software/embedded/scripts/SBOM_Files/generate_ATfE-SBOM-newlib-overlay.py
@@ -1,0 +1,230 @@
+#  SPDX-FileCopyrightText: 2023 spdx contributors
+#
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+#
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Purpose: This script helps to generate SBOM for ATfE newlib overlay package.
+#
+# Installation: Kindly refer https://github.com/spdx/tools-python for pre-requisite installation.
+#
+# Usage: python generate_ATfE-SBOM-newlib-overlay
+#
+# Output file generated: ATfE-SBOM-newlib-overlay.spdx.json
+#
+import logging
+import uuid
+from datetime import datetime
+from typing import List
+
+from spdx_tools.common.spdx_licensing import spdx_licensing
+from spdx_tools.spdx.model import (
+    Actor,
+    ActorType,
+    CreationInfo,
+    Document,
+    Package,
+    Relationship,
+    RelationshipType,
+)
+from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
+from spdx_tools.spdx.validation.validation_message import ValidationMessage
+from spdx_tools.spdx.writer.write_anything import write_file
+
+# This example shows how to use the spdx-tools to create an SPDX document from scratch,
+# validate it and write it to a file.
+
+
+def create_Package(
+    name,
+    uuid,
+    download_location,
+    actorType,
+    personName,
+    personEmail,
+    license,
+    licenseComment,
+):
+    package = Package(
+        name=name,
+        spdx_id=uuid,
+        download_location=download_location,
+        supplier=Actor(actorType, personName, personEmail),
+        originator=Actor(actorType, personName, personEmail),
+        files_analyzed=False,
+        license_concluded=spdx_licensing.parse(license),
+        license_declared=spdx_licensing.parse(license),
+        license_comment=licenseComment,
+    )
+
+    return package
+
+
+# First up, we need general information about the creation of the document, summarised by the CreationInfo class.
+creation_info = CreationInfo(
+    spdx_version="SPDX-2.3",
+    spdx_id="SPDXRef-DOCUMENT",
+    name="Arm Toolchain for Embedded newlib overlay",
+    data_license="CC0-1.0",
+    document_namespace="https://github.com/arm/arm-toolchain/tree/arm-software/arm-software/embedded",
+    creators=[
+        Actor(ActorType.ORGANIZATION, "Arm Limited", "open-source-office@arm.com")
+    ],
+    created=datetime.now(),
+)
+
+# creation_info is the only required property of the Document class (have a look there!), the rest are optional lists.
+document = Document(creation_info)
+
+# The document currently does not describe anything. Let's create a package that we can add to it.
+package_url = (
+    "https://github.com/arm/arm-toolchain/tree/arm-software/arm-software/embedded"
+)
+package_uuid_atfe = "SPDXRef-Package-" + str(
+    uuid.uuid5(uuid.NAMESPACE_URL, package_url)
+)
+package_atfe = create_Package(
+    "Arm Toolchain for Embedded",
+    package_uuid_atfe,
+    package_url,
+    ActorType.ORGANIZATION,
+    "Arm Limited",
+    "open-source-office@arm.com",
+    "Apache-2.0 WITH LLVM-exception",
+    "",
+)
+
+package_url = "https://github.com/llvm/llvm-project/tree/main/compiler-rt"
+package_uuid_compiler_rt = "SPDXRef-Package-" + str(
+    uuid.uuid5(uuid.NAMESPACE_URL, package_url)
+)
+package_compiler_rt = create_Package(
+    "compiler-rt",
+    package_uuid_compiler_rt,
+    package_url,
+    ActorType.ORGANIZATION,
+    "LLVM Foundation",
+    "info@llvm.org",
+    "Apache-2.0 WITH LLVM-exception",
+    "",
+)
+
+package_url = "https://github.com/llvm/llvm-project/tree/main/libcxx"
+package_uuid_libcxx = "SPDXRef-Package-" + str(
+    uuid.uuid5(uuid.NAMESPACE_URL, package_url)
+)
+package_libcxx = create_Package(
+    "libcxx",
+    package_uuid_libcxx,
+    package_url,
+    ActorType.ORGANIZATION,
+    "LLVM Foundation",
+    "info@llvm.org",
+    "Apache-2.0 WITH LLVM-exception",
+    "",
+)
+
+package_url = "https://github.com/llvm/llvm-project/tree/main/libcxxabi"
+package_uuid_libcxxabi = "SPDXRef-Package-" + str(
+    uuid.uuid5(uuid.NAMESPACE_URL, package_url)
+)
+package_libcxxabi = create_Package(
+    "libcxxabi",
+    package_uuid_libcxxabi,
+    package_url,
+    ActorType.ORGANIZATION,
+    "LLVM Foundation",
+    "info@llvm.org",
+    "Apache-2.0 WITH LLVM-exception",
+    "",
+)
+
+package_url = "https://github.com/llvm/llvm-project/tree/main/libunwind"
+package_uuid_libunwind = "SPDXRef-Package-" + str(
+    uuid.uuid5(uuid.NAMESPACE_URL, package_url)
+)
+package_libunwind = create_Package(
+    "libunwind",
+    package_uuid_libunwind,
+    package_url,
+    ActorType.ORGANIZATION,
+    "LLVM Foundation",
+    "info@llvm.org",
+    "Apache-2.0 WITH LLVM-exception",
+    "",
+)
+
+package_url = "https://sourceware.org/newlib/"
+package_uuid_newlib = "SPDXRef-Package-" + str(
+    uuid.uuid5(uuid.NAMESPACE_URL, package_url)
+)
+package_newlib = create_Package(
+    "newlib",
+    package_uuid_newlib,
+    package_url,
+    ActorType.ORGANIZATION,
+    "https://sourceware.org/newlib/",
+    "newlib@sourceware.org",
+    "",
+    "Detailed list of licenses is at: https://github.com/picolibc/picolibc/blob/main/COPYING.NEWLIB",
+)
+
+# Now that we have a package defined, we can add it to the document's package property.
+document.packages = [
+    package_atfe,
+    package_compiler_rt,
+    package_libcxx,
+    package_libcxxabi,
+    package_libunwind,
+    package_newlib,
+]
+
+# A DESCRIBES relationship asserts that the document indeed describes the package.
+describes_relationship_atfe = Relationship(
+    "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, package_uuid_atfe
+)
+
+describes_relationship_compiler_rt = Relationship(
+    "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, package_uuid_compiler_rt
+)
+
+describes_relationship_libcxx = Relationship(
+    "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, package_uuid_libcxx
+)
+
+
+describes_relationship_libcxxabi = Relationship(
+    "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, package_uuid_libcxxabi
+)
+
+describes_relationship_libunwind = Relationship(
+    "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, package_uuid_libunwind
+)
+
+describes_relationship_newlib = Relationship(
+    "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, package_uuid_newlib
+)
+
+document.relationships += [
+    describes_relationship_atfe,
+    describes_relationship_compiler_rt,
+    describes_relationship_libcxx,
+    describes_relationship_libcxxabi,
+    describes_relationship_libunwind,
+    describes_relationship_newlib,
+]
+
+# This library provides comprehensive validation against the SPDX specification.
+validation_messages: List[ValidationMessage] = validate_full_spdx_document(document)
+
+for message in validation_messages:
+    logging.warning(message.validation_message)
+    logging.warning(message.context)
+
+# If the document is valid, validation_messages will be empty.
+assert validation_messages == []
+
+# Using the write_file() method from the write_anything module.
+write_file(document, "ATfE-SBOM-newlib-overlay.spdx.json")

--- a/arm-software/embedded/scripts/SBOM_Files/generate_ATfE-SBOM.py
+++ b/arm-software/embedded/scripts/SBOM_Files/generate_ATfE-SBOM.py
@@ -1,0 +1,290 @@
+#  SPDX-FileCopyrightText: 2023 spdx contributors
+#
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+#
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Purpose: This script helps to generate SBOM for ATfE.
+#
+# Installation: Kindly refer https://github.com/spdx/tools-python for pre-requisite installation.
+#
+# Usage: python generate_ATfE-SBOM.py
+#
+# Output file generated: ATfE-SBOM.spdx.json
+#
+import logging
+import uuid
+from datetime import datetime
+from typing import List
+
+from spdx_tools.common.spdx_licensing import spdx_licensing
+from spdx_tools.spdx.model import (
+    Actor,
+    ActorType,
+    CreationInfo,
+    Document,
+    Package,
+    Relationship,
+    RelationshipType,
+)
+from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
+from spdx_tools.spdx.validation.validation_message import ValidationMessage
+from spdx_tools.spdx.writer.write_anything import write_file
+
+# This example shows how to use the spdx-tools to create an SPDX document from scratch,
+# validate it and write it to a file.
+
+
+def create_Package(
+    name,
+    uuid,
+    download_location,
+    actorType,
+    personName,
+    personEmail,
+    license,
+    licenseComment,
+):
+    package = Package(
+        name=name,
+        spdx_id=uuid,
+        download_location=download_location,
+        supplier=Actor(actorType, personName, personEmail),
+        originator=Actor(actorType, personName, personEmail),
+        files_analyzed=False,
+        license_concluded=spdx_licensing.parse(license),
+        license_declared=spdx_licensing.parse(license),
+        license_comment=licenseComment,
+    )
+
+    return package
+
+
+# First up, we need general information about the creation of the document, summarised by the CreationInfo class.
+creation_info = CreationInfo(
+    spdx_version="SPDX-2.3",
+    spdx_id="SPDXRef-DOCUMENT",
+    name="Arm Toolchain for Embedded",
+    data_license="CC0-1.0",
+    document_namespace="https://github.com/arm/arm-toolchain/tree/arm-software/arm-software/embedded",
+    creators=[
+        Actor(ActorType.ORGANIZATION, "Arm Limited", "open-source-office@arm.com")
+    ],
+    created=datetime.now(),
+)
+
+# creation_info is the only required property of the Document class (have a look there!), the rest are optional lists.
+document = Document(creation_info)
+
+# The document currently does not describe anything. Let's create a package that we can add to it.
+package_url = (
+    "https://github.com/arm/arm-toolchain/tree/arm-software/arm-software/embedded"
+)
+package_uuid_atfe = "SPDXRef-Package-" + str(
+    uuid.uuid5(uuid.NAMESPACE_URL, package_url)
+)
+package_atfe = create_Package(
+    "Arm Toolchain for Embedded",
+    package_uuid_atfe,
+    package_url,
+    ActorType.ORGANIZATION,
+    "Arm Limited",
+    "open-source-office@arm.com",
+    "Apache-2.0 WITH LLVM-exception",
+    "",
+)
+
+package_url = "https://github.com/llvm/llvm-project"
+package_uuid_llvm = "SPDXRef-Package-" + str(
+    uuid.uuid5(uuid.NAMESPACE_URL, package_url)
+)
+package_llvm = create_Package(
+    "llvm-project",
+    package_uuid_llvm,
+    package_url,
+    ActorType.ORGANIZATION,
+    "LLVM Foundation",
+    "info@llvm.org",
+    "Apache-2.0 WITH LLVM-exception",
+    "",
+)
+
+package_url = "https://github.com/llvm/llvm-project/tree/main/clang"
+package_uuid_clang = "SPDXRef-Package-" + str(
+    uuid.uuid5(uuid.NAMESPACE_URL, package_url)
+)
+package_clang = create_Package(
+    "clang",
+    package_uuid_clang,
+    package_url,
+    ActorType.ORGANIZATION,
+    "LLVM Foundation",
+    "info@llvm.org",
+    "Apache-2.0 WITH LLVM-exception",
+    "",
+)
+
+package_url = "https://github.com/llvm/llvm-project/tree/main/lld"
+package_uuid_lld = "SPDXRef-Package-" + str(uuid.uuid5(uuid.NAMESPACE_URL, package_url))
+package_lld = create_Package(
+    "lld",
+    package_uuid_lld,
+    package_url,
+    ActorType.ORGANIZATION,
+    "LLVM Foundation",
+    "info@llvm.org",
+    "Apache-2.0 WITH LLVM-exception",
+    "",
+)
+
+package_url = "https://github.com/llvm/llvm-project/tree/main/compiler-rt"
+package_uuid_compiler_rt = "SPDXRef-Package-" + str(
+    uuid.uuid5(uuid.NAMESPACE_URL, package_url)
+)
+package_compiler_rt = create_Package(
+    "compiler-rt",
+    package_uuid_compiler_rt,
+    package_url,
+    ActorType.ORGANIZATION,
+    "LLVM Foundation",
+    "info@llvm.org",
+    "Apache-2.0 WITH LLVM-exception",
+    "",
+)
+
+package_url = "https://github.com/llvm/llvm-project/tree/main/libcxx"
+package_uuid_libcxx = "SPDXRef-Package-" + str(
+    uuid.uuid5(uuid.NAMESPACE_URL, package_url)
+)
+package_libcxx = create_Package(
+    "libcxx",
+    package_uuid_libcxx,
+    package_url,
+    ActorType.ORGANIZATION,
+    "LLVM Foundation",
+    "info@llvm.org",
+    "Apache-2.0 WITH LLVM-exception",
+    "",
+)
+
+package_url = "https://github.com/llvm/llvm-project/tree/main/libcxxabi"
+package_uuid_libcxxabi = "SPDXRef-Package-" + str(
+    uuid.uuid5(uuid.NAMESPACE_URL, package_url)
+)
+package_libcxxabi = create_Package(
+    "libcxxabi",
+    package_uuid_libcxxabi,
+    package_url,
+    ActorType.ORGANIZATION,
+    "LLVM Foundation",
+    "info@llvm.org",
+    "Apache-2.0 WITH LLVM-exception",
+    "",
+)
+
+package_url = "https://github.com/llvm/llvm-project/tree/main/libunwind"
+package_uuid_libunwind = "SPDXRef-Package-" + str(
+    uuid.uuid5(uuid.NAMESPACE_URL, package_url)
+)
+package_libunwind = create_Package(
+    "libunwind",
+    package_uuid_libunwind,
+    package_url,
+    ActorType.ORGANIZATION,
+    "LLVM Foundation",
+    "info@llvm.org",
+    "Apache-2.0 WITH LLVM-exception",
+    "",
+)
+
+package_url = "https://github.com/picolibc/picolibc"
+package_uuid_picolibc = "SPDXRef-Package-" + str(
+    uuid.uuid5(uuid.NAMESPACE_URL, package_url)
+)
+package_picolibc = create_Package(
+    "picolibc",
+    package_uuid_picolibc,
+    package_url,
+    ActorType.PERSON,
+    "Keith Packard",
+    "https://github.com/keith-packard",
+    "",
+    "Detailed list of licenses is at: https://github.com/picolibc/picolibc/blob/main/COPYING.picolibc",
+)
+
+# Now that we have a package defined, we can add it to the document's package property.
+document.packages = [
+    package_atfe,
+    package_llvm,
+    package_clang,
+    package_lld,
+    package_compiler_rt,
+    package_libcxx,
+    package_libcxxabi,
+    package_libunwind,
+    package_picolibc,
+]
+
+# A DESCRIBES relationship asserts that the document indeed describes the package.
+describes_relationship_atfe = Relationship(
+    "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, package_uuid_atfe
+)
+
+describes_relationship_llvm = Relationship(
+    "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, package_uuid_llvm
+)
+
+describes_relationship_clang = Relationship(
+    "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, package_uuid_clang
+)
+
+describes_relationship_lld = Relationship(
+    "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, package_uuid_lld
+)
+
+describes_relationship_compiler_rt = Relationship(
+    "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, package_uuid_compiler_rt
+)
+
+describes_relationship_libcxx = Relationship(
+    "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, package_uuid_libcxx
+)
+
+describes_relationship_libcxxabi = Relationship(
+    "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, package_uuid_libcxxabi
+)
+
+describes_relationship_libunwind = Relationship(
+    "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, package_uuid_libunwind
+)
+
+describes_relationship_picolibc = Relationship(
+    "SPDXRef-DOCUMENT", RelationshipType.DESCRIBES, package_uuid_picolibc
+)
+
+document.relationships = [
+    describes_relationship_atfe,
+    describes_relationship_llvm,
+    describes_relationship_clang,
+    describes_relationship_lld,
+    describes_relationship_compiler_rt,
+    describes_relationship_libcxx,
+    describes_relationship_libcxxabi,
+    describes_relationship_libunwind,
+    describes_relationship_picolibc,
+]
+
+# This library provides comprehensive validation against the SPDX specification.
+validation_messages: List[ValidationMessage] = validate_full_spdx_document(document)
+
+for message in validation_messages:
+    logging.warning(message.validation_message)
+    logging.warning(message.context)
+
+# If the document is valid, validation_messages will be empty.
+assert validation_messages == []
+
+# Using the write_file() method from the write_anything module.
+write_file(document, "ATfE-SBOM.spdx.json")


### PR DESCRIPTION
Add SBOM JSON files for ATfE, llvmlibc overlay and newlib overlay; and Python scripts which generate these SBOM JSON files.
This is cherry-pick from arm-software branch commit: e5cde593ba2c951c0df5be388524f7b518efc4b2