### PR TITLE
[ATfE] Don't overwrite semihosting-features file in FVP tests

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
+++ b/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
@@ -126,9 +126,14 @@ def run_fvp(
     # request will work. This permits the test program's exit status to be
     # propagated to the exit status of the FVP, so that tests returning 77
     # for "test skipped" can be automatically detected.
+    # Since multiple tests can potentially be run concurrently in the same
+    # working directory, the file should be created in an atomic operation
+    # to prevent one process reading an incomplete file being written from
+    # another. This is done by creating a temporary file and renaming.
     shfeatures_path = path.join(working_directory, ":semihosting-features")
-    with tempfile.NamedTemporaryFile(dir=os.path.dirname(shfeatures_path)) as fh:
-        fh.write(b"SHFB\x01")  # NamedTemporaryFile is binary already
+    with tempfile.NamedTemporaryFile(dir=working_directory) as fh:
+        fh.write(b"SHFB\x01")  # NamedTemporaryFile is binary already.
+        fh.flush()  # Ensure file is complete before renaming.
         os.rename(fh.name, shfeatures_path)
 
     result = subprocess.run(

--- a/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
+++ b/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
@@ -124,10 +124,10 @@ def run_fvp(
     # request will work. This permits the test program's exit status to be
     # propagated to the exit status of the FVP, so that tests returning 77
     # for "test skipped" can be automatically detected.
-    with open(
-        path.join(working_directory, ":semihosting-features"), "wb"
-    ) as fh:
-        fh.write(b"SHFB\x01")
+    shfeatures_path = path.join(working_directory, ":semihosting-features")
+    if not path.exists(shfeatures_path):
+        with open(shfeatures_path, "wb") as fh:
+            fh.write(b"SHFB\x01")
 
     result = subprocess.run(
         command,

--- a/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
+++ b/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
@@ -2,9 +2,11 @@
 
 # SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
 
+import os
 import re
 import subprocess
 import sys
+import tempfile
 from os import environ
 from os import path
 from dataclasses import dataclass
@@ -125,9 +127,9 @@ def run_fvp(
     # propagated to the exit status of the FVP, so that tests returning 77
     # for "test skipped" can be automatically detected.
     shfeatures_path = path.join(working_directory, ":semihosting-features")
-    if not path.exists(shfeatures_path):
-        with open(shfeatures_path, "wb") as fh:
-            fh.write(b"SHFB\x01")
+    with tempfile.NamedTemporaryFile(dir=os.path.dirname(shfeatures_path)) as fh:
+        fh.write(b"SHFB\x01")  # NamedTemporaryFile is binary already
+        os.rename(fh.name, shfeatures_path)
 
     result = subprocess.run(
         command,


### PR DESCRIPTION
When running a test using an FVP, in order to propagate an exit code from the program a `:semihosting-features` file is created in the working directory. Since tests are usually run in parallel across multiple processes using the same shared directory, one process can attempt to read the file at the same time another is replacing and rewriting it.

This patch replaces the file with an atomic operation instead of opening a new file in its place.