### PR TITLE
[ATfE] Don't delete temporary semihosting-features file

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
+++ b/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
@@ -131,10 +131,16 @@ def run_fvp(
     # to prevent one process reading an incomplete file being written from
     # another. This is done by creating a temporary file and replacing.
     shfeatures_path = path.join(working_directory, ":semihosting-features")
-    with tempfile.NamedTemporaryFile(dir=working_directory, delete=False) as fh:
+    try:
+        fh = tempfile.NamedTemporaryFile(dir=working_directory, delete=False)
         fh.write(b"SHFB\x01")  # NamedTemporaryFile is binary already.
-        fh.flush()  # Ensure file is complete before renaming.
+        fh.close()
         os.replace(fh.name, shfeatures_path)
+    finally:
+        try:
+            os.remove(fh.name)
+        except FileNotFoundError:
+            pass
 
     result = subprocess.run(
         command,

--- a/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
+++ b/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
@@ -129,12 +129,12 @@ def run_fvp(
     # Since multiple tests can potentially be run concurrently in the same
     # working directory, the file should be created in an atomic operation
     # to prevent one process reading an incomplete file being written from
-    # another. This is done by creating a temporary file and renaming.
+    # another. This is done by creating a temporary file and replacing.
     shfeatures_path = path.join(working_directory, ":semihosting-features")
-    with tempfile.NamedTemporaryFile(dir=working_directory) as fh:
+    with tempfile.NamedTemporaryFile(dir=working_directory, delete=False) as fh:
         fh.write(b"SHFB\x01")  # NamedTemporaryFile is binary already.
         fh.flush()  # Ensure file is complete before renaming.
-        os.rename(fh.name, shfeatures_path)
+        os.replace(fh.name, shfeatures_path)
 
     result = subprocess.run(
         command,


### PR DESCRIPTION
The NamedTemporaryFile used to create the `:semihosting-features` file for FVP testing will automatically attempt to delete itself when closed. Since this file needs to persist in order to replace any existing copy of the file, the auto deletion must be disabled.

The `os.rename` operation has also been changed to `os.replace` since renaming to an existing file will throw an error on some operating systems such as Windows.