### PR TITLE
[ATfE] Rebase picolibc patches

### DIFF
--- a/arm-software/embedded/patches/picolibc/0001-Enable-libcxx-builds.patch
+++ b/arm-software/embedded/patches/picolibc/0001-Enable-libcxx-builds.patch
@@ -1,4 +1,4 @@
-From cf0324ab646a164ad5b3409e1147164e076b72d0 Mon Sep 17 00:00:00 2001
+From a59afdaf3697da7a1cfc62e0f957be780d6ae11a Mon Sep 17 00:00:00 2001
 From: Simi Pallipurath <simi.pallipurath@arm.com>
 Date: Thu, 14 Nov 2024 10:07:08 +0000
 Subject: Enable libcxx builds
@@ -11,12 +11,12 @@ libc++ builds.
  2 files changed, 15 insertions(+)
 
 diff --git a/meson.build b/meson.build
-index e62ac11ab..b3881d106 100644
+index f33d011b2..2c653de02 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -1373,6 +1373,18 @@ if get_option('newlib-retargetable-locking') != get_option('newlib-multithread')
-   error('newlib-retargetable-locking and newlib-multithread must be set to the same value')
- endif
+@@ -1340,6 +1340,18 @@ NEWLIB_MAJOR_VERSION=4
+ NEWLIB_MINOR_VERSION=3
+ NEWLIB_PATCHLEVEL_VERSION=0
  
 +conf_data.set('_GNU_SOURCE', '',
 +        description: '''Enable GNU functions like strtof_l.
@@ -30,11 +30,11 @@ index e62ac11ab..b3881d106 100644
 +and extended character sets, so picolibc's small ctype is not compatible with it'''
 +)
 +
- conf_data.set('_HAVE_CC_INHIBIT_LOOP_TO_LIBCALL',
+ conf_data.set('__HAVE_CC_INHIBIT_LOOP_TO_LIBCALL',
  	      cc.has_argument('-fno-tree-loop-distribute-patterns'),
  	      description: 'Compiler flag to prevent detecting memcpy/memset patterns')
 diff --git a/picolibc.ld.in b/picolibc.ld.in
-index c6d2a7d66..b8cd3209b 100644
+index 0bcfe4ca8..c3055c49e 100644
 --- a/picolibc.ld.in
 +++ b/picolibc.ld.in
 @@ -69,6 +69,9 @@ SECTIONS

--- a/arm-software/embedded/patches/picolibc/0002-Define-picocrt_machines-for-AArch32-builds-as-well-a.patch
+++ b/arm-software/embedded/patches/picolibc/0002-Define-picocrt_machines-for-AArch32-builds-as-well-a.patch
@@ -1,4 +1,4 @@
-From 8f32c696fa3531dd557f180c09bdb6bd2689cb1c Mon Sep 17 00:00:00 2001
+From e8c748ad0040ad6043b4d10db681f683344f896d Mon Sep 17 00:00:00 2001
 From: Simi Pallipurath <simi.pallipurath@arm.com>
 Date: Thu, 14 Nov 2024 10:12:33 +0000
 Subject: Define picocrt_machines for AArch32 builds as well as 64.

--- a/arm-software/embedded/patches/picolibc/0003-Add-support-for-strict-align-no-unaligned-access-in-.patch
+++ b/arm-software/embedded/patches/picolibc/0003-Add-support-for-strict-align-no-unaligned-access-in-.patch
@@ -1,4 +1,4 @@
-From bf63b7e69303c9fff4ee9a62289f78af21f3fb3d Mon Sep 17 00:00:00 2001
+From 8e46182db50f6a8ee0b67354887e606344303b7c Mon Sep 17 00:00:00 2001
 From: Lucas Prates <lucas.prates@arm.com>
 Date: Mon, 11 Nov 2024 16:37:04 +0000
 Subject: Add support for strict-align/no-unaligned-access in AArch64
@@ -37,392 +37,392 @@ Subject: Add support for strict-align/no-unaligned-access in AArch64
  30 files changed, 30 insertions(+), 30 deletions(-)
 
 diff --git a/newlib/libc/machine/aarch64/memchr-stub.c b/newlib/libc/machine/aarch64/memchr-stub.c
-index c887bc62f..735fc9d31 100644
+index c2fabf07f..e688cf166 100644
 --- a/newlib/libc/machine/aarch64/memchr-stub.c
 +++ b/newlib/libc/machine/aarch64/memchr-stub.c
 @@ -26,7 +26,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
  # include "../../string/memchr.c"
  #else
  /* See memchr.S  */
 diff --git a/newlib/libc/machine/aarch64/memchr.S b/newlib/libc/machine/aarch64/memchr.S
-index 29fc3c3c8..70686a8da 100644
+index da1163221..dd5dec477 100644
 --- a/newlib/libc/machine/aarch64/memchr.S
 +++ b/newlib/libc/machine/aarch64/memchr.S
 @@ -7,7 +7,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
  /* See memchr-stub.c  */
  #else
  /* Assumptions:
 diff --git a/newlib/libc/machine/aarch64/memcmp-stub.c b/newlib/libc/machine/aarch64/memcmp-stub.c
-index af0cebf37..11aa224dc 100644
+index 74518257b..8b3e2b374 100644
 --- a/newlib/libc/machine/aarch64/memcmp-stub.c
 +++ b/newlib/libc/machine/aarch64/memcmp-stub.c
 @@ -26,7 +26,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
  # include "../../string/memcmp.c"
  #else
  /* See memcmp.S  */
 diff --git a/newlib/libc/machine/aarch64/memcmp.S b/newlib/libc/machine/aarch64/memcmp.S
-index 11352ff21..2c9c8e9e3 100644
+index afe78fee3..9ca75c447 100644
 --- a/newlib/libc/machine/aarch64/memcmp.S
 +++ b/newlib/libc/machine/aarch64/memcmp.S
 @@ -6,7 +6,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
  /* See memcmp-stub.c  */
  #else
  
 diff --git a/newlib/libc/machine/aarch64/memcpy-stub.c b/newlib/libc/machine/aarch64/memcpy-stub.c
-index 145f638da..df8bcf588 100644
+index 6702a67dc..5ac7ca914 100644
 --- a/newlib/libc/machine/aarch64/memcpy-stub.c
 +++ b/newlib/libc/machine/aarch64/memcpy-stub.c
 @@ -26,7 +26,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined (__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined (__ARM_FEATURE_UNALIGNED)
  # include "../../string/memcpy.c"
  #else
  /* See memcpy.S  */
 diff --git a/newlib/libc/machine/aarch64/memcpy.S b/newlib/libc/machine/aarch64/memcpy.S
-index 39ff69a16..11e573ee0 100644
+index 7ba3fe347..6ac4ea577 100644
 --- a/newlib/libc/machine/aarch64/memcpy.S
 +++ b/newlib/libc/machine/aarch64/memcpy.S
 @@ -13,7 +13,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
  /* See memcpy-stub.c  */
  #else
  #include "asmdefs.h"
 diff --git a/newlib/libc/machine/aarch64/memmove-stub.c b/newlib/libc/machine/aarch64/memmove-stub.c
-index 41fd6643c..8498d3459 100644
+index 8b9154ffd..70e342a2c 100644
 --- a/newlib/libc/machine/aarch64/memmove-stub.c
 +++ b/newlib/libc/machine/aarch64/memmove-stub.c
 @@ -26,7 +26,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
  # include "../../string/memmove.c"
  #else
  /* See memcpy.S  */
 diff --git a/newlib/libc/machine/aarch64/memrchr-stub.c b/newlib/libc/machine/aarch64/memrchr-stub.c
-index 63504543c..b9dc29211 100644
+index 6d659d4d7..eea39c7ec 100644
 --- a/newlib/libc/machine/aarch64/memrchr-stub.c
 +++ b/newlib/libc/machine/aarch64/memrchr-stub.c
 @@ -6,7 +6,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
  #include "../../string/memrchr.c"
  #else
  /* See memrchr.S */
 diff --git a/newlib/libc/machine/aarch64/memrchr.S b/newlib/libc/machine/aarch64/memrchr.S
-index a843de79e..d442e3d13 100644
+index b0afa4eea..5c78cfb14 100644
 --- a/newlib/libc/machine/aarch64/memrchr.S
 +++ b/newlib/libc/machine/aarch64/memrchr.S
 @@ -13,7 +13,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
  /* See memrchr-stub.c */
  #else
  #include "asmdefs.h"
 diff --git a/newlib/libc/machine/aarch64/memset-stub.c b/newlib/libc/machine/aarch64/memset-stub.c
-index e7e8b54f7..3c51d470f 100644
+index a11c74573..c29cb0dae 100644
 --- a/newlib/libc/machine/aarch64/memset-stub.c
 +++ b/newlib/libc/machine/aarch64/memset-stub.c
 @@ -26,7 +26,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
  # include "../../string/memset.c"
  #else
  /* See memset.S  */
 diff --git a/newlib/libc/machine/aarch64/memset.S b/newlib/libc/machine/aarch64/memset.S
-index 87a419964..7bb4525f4 100644
+index 51ea476e3..7db2e3a85 100644
 --- a/newlib/libc/machine/aarch64/memset.S
 +++ b/newlib/libc/machine/aarch64/memset.S
 @@ -13,7 +13,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
  /* See memset-stub.c  */
  #else
  #include "asmdefs.h"
 diff --git a/newlib/libc/machine/aarch64/rawmemchr-stub.c b/newlib/libc/machine/aarch64/rawmemchr-stub.c
-index 032e0560c..c57f3ec30 100644
+index 88d1e9472..3c379bfc4 100644
 --- a/newlib/libc/machine/aarch64/rawmemchr-stub.c
 +++ b/newlib/libc/machine/aarch64/rawmemchr-stub.c
 @@ -26,7 +26,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
  # include "../../string/rawmemchr.c"
  #else
  /* See rawmemchr.S.  */
 diff --git a/newlib/libc/machine/aarch64/rawmemchr.S b/newlib/libc/machine/aarch64/rawmemchr.S
-index dc4b257dd..4b114e746 100644
+index 03e3b7525..9ed0464bf 100644
 --- a/newlib/libc/machine/aarch64/rawmemchr.S
 +++ b/newlib/libc/machine/aarch64/rawmemchr.S
 @@ -32,7 +32,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
  /* See rawmemchr-stub.c.  */
  #else
  
 diff --git a/newlib/libc/machine/aarch64/stpcpy-stub.c b/newlib/libc/machine/aarch64/stpcpy-stub.c
-index 045f1a551..d7fe3066a 100644
+index 0166c6785..9dd10b2a4 100644
 --- a/newlib/libc/machine/aarch64/stpcpy-stub.c
 +++ b/newlib/libc/machine/aarch64/stpcpy-stub.c
 @@ -26,7 +26,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined (__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined (__ARM_FEATURE_UNALIGNED)
  # include "../../string/stpcpy.c"
  #else
  /* See stpcpy.S  */
 diff --git a/newlib/libc/machine/aarch64/strchr-stub.c b/newlib/libc/machine/aarch64/strchr-stub.c
-index b9ae08393..90eb01da2 100644
+index 0dcb5ca54..e187fcb4e 100644
 --- a/newlib/libc/machine/aarch64/strchr-stub.c
 +++ b/newlib/libc/machine/aarch64/strchr-stub.c
 @@ -26,7 +26,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined (__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined (__ARM_FEATURE_UNALIGNED)
  # include "../../string/strchr.c"
  #else
  /* See strchr.S  */
 diff --git a/newlib/libc/machine/aarch64/strchr.S b/newlib/libc/machine/aarch64/strchr.S
-index a735889b1..6e3575aa0 100644
+index 2d79a3911..c22509df6 100644
 --- a/newlib/libc/machine/aarch64/strchr.S
 +++ b/newlib/libc/machine/aarch64/strchr.S
 @@ -28,7 +28,7 @@
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
  /* See strchr-stub.c  */
  #else
  
 diff --git a/newlib/libc/machine/aarch64/strchrnul-stub.c b/newlib/libc/machine/aarch64/strchrnul-stub.c
-index aa1208cbb..e88cee2c6 100644
+index 407b949a6..7065c42b5 100644
 --- a/newlib/libc/machine/aarch64/strchrnul-stub.c
 +++ b/newlib/libc/machine/aarch64/strchrnul-stub.c
 @@ -26,7 +26,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
  # include "../../string/strchrnul.c"
  #else
  /* See strchrnul.S  */
 diff --git a/newlib/libc/machine/aarch64/strchrnul.S b/newlib/libc/machine/aarch64/strchrnul.S
-index c60cef7d0..3a0b1dfde 100644
+index 5999c6d68..fff1102bd 100644
 --- a/newlib/libc/machine/aarch64/strchrnul.S
 +++ b/newlib/libc/machine/aarch64/strchrnul.S
 @@ -28,7 +28,7 @@
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
  /* See strchrnul-stub.c  */
  #else
  
 diff --git a/newlib/libc/machine/aarch64/strcmp-stub.c b/newlib/libc/machine/aarch64/strcmp-stub.c
-index 652e4f651..c8d60c56d 100644
+index 77177bfe0..f74140acd 100644
 --- a/newlib/libc/machine/aarch64/strcmp-stub.c
 +++ b/newlib/libc/machine/aarch64/strcmp-stub.c
 @@ -26,7 +26,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined (__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined (__ARM_FEATURE_UNALIGNED)
  # include "../../string/strcmp.c"
  #else
  /* See strcmp.S  */
 diff --git a/newlib/libc/machine/aarch64/strcmp.S b/newlib/libc/machine/aarch64/strcmp.S
-index 641d6ae22..82635762b 100644
+index 0c8371d22..ae52d3e0e 100644
 --- a/newlib/libc/machine/aarch64/strcmp.S
 +++ b/newlib/libc/machine/aarch64/strcmp.S
 @@ -7,7 +7,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
  /* See strcmp-stub.c  */
  #else
  
 diff --git a/newlib/libc/machine/aarch64/strcpy-stub.c b/newlib/libc/machine/aarch64/strcpy-stub.c
-index 4cfa19e9c..4f9a95100 100644
+index af2e1dd3c..5adc53f76 100644
 --- a/newlib/libc/machine/aarch64/strcpy-stub.c
 +++ b/newlib/libc/machine/aarch64/strcpy-stub.c
 @@ -26,7 +26,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined (__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined (__ARM_FEATURE_UNALIGNED)
  # include "../../string/strcpy.c"
  #else
  /* See strcpy.S  */
 diff --git a/newlib/libc/machine/aarch64/strcpy.S b/newlib/libc/machine/aarch64/strcpy.S
-index 62e5f3f37..eecb81bb5 100644
+index 5429c5c10..95987d4b3 100644
 --- a/newlib/libc/machine/aarch64/strcpy.S
 +++ b/newlib/libc/machine/aarch64/strcpy.S
 @@ -28,7 +28,7 @@
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
  /* See strcpy-stub.c  */
  #else
  
 diff --git a/newlib/libc/machine/aarch64/strlen-stub.c b/newlib/libc/machine/aarch64/strlen-stub.c
-index 3d9c3876c..ec44c927c 100644
+index 59b1289ff..2f7aa7305 100644
 --- a/newlib/libc/machine/aarch64/strlen-stub.c
 +++ b/newlib/libc/machine/aarch64/strlen-stub.c
 @@ -26,7 +26,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
  # include "../../string/strlen.c"
  #else
  /* See strlen.S  */
 diff --git a/newlib/libc/machine/aarch64/strlen.S b/newlib/libc/machine/aarch64/strlen.S
-index 8e1a7cb7a..5204ad80d 100644
+index 8837c954b..f3b54c677 100644
 --- a/newlib/libc/machine/aarch64/strlen.S
 +++ b/newlib/libc/machine/aarch64/strlen.S
 @@ -25,7 +25,7 @@
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
  /* See strlen-stub.c  */
  #else
  
 diff --git a/newlib/libc/machine/aarch64/strncmp-stub.c b/newlib/libc/machine/aarch64/strncmp-stub.c
-index 504c12d7b..6751bad38 100644
+index 2202cb79e..caca7fa83 100644
 --- a/newlib/libc/machine/aarch64/strncmp-stub.c
 +++ b/newlib/libc/machine/aarch64/strncmp-stub.c
 @@ -26,7 +26,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined (__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined (__ARM_FEATURE_UNALIGNED)
  # include "../../string/strncmp.c"
  #else
  /* See strncmp.S  */
 diff --git a/newlib/libc/machine/aarch64/strncmp.S b/newlib/libc/machine/aarch64/strncmp.S
-index b2470a408..34c8bbec2 100644
+index ba7b89313..3b64978bf 100644
 --- a/newlib/libc/machine/aarch64/strncmp.S
 +++ b/newlib/libc/machine/aarch64/strncmp.S
 @@ -26,7 +26,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
  /* See strncmp-stub.c  */
  #else
  
 diff --git a/newlib/libc/machine/aarch64/strnlen-stub.c b/newlib/libc/machine/aarch64/strnlen-stub.c
-index 2f50cdbdf..b1757b1ff 100644
+index c4428f4f6..1e45ef066 100644
 --- a/newlib/libc/machine/aarch64/strnlen-stub.c
 +++ b/newlib/libc/machine/aarch64/strnlen-stub.c
 @@ -26,7 +26,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
  # include "../../string/strnlen.c"
  #else
  /* See strnlen.S  */
 diff --git a/newlib/libc/machine/aarch64/strnlen.S b/newlib/libc/machine/aarch64/strnlen.S
-index e64137665..40fbeafb0 100644
+index f186fc13f..529e10276 100644
 --- a/newlib/libc/machine/aarch64/strnlen.S
 +++ b/newlib/libc/machine/aarch64/strnlen.S
 @@ -28,7 +28,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
  /* See strnlen-stub.c  */
  #else
  
 diff --git a/newlib/libc/machine/aarch64/strrchr-stub.c b/newlib/libc/machine/aarch64/strrchr-stub.c
-index b8fe32f75..362a7086b 100644
+index 0ec573222..4dfedee46 100644
 --- a/newlib/libc/machine/aarch64/strrchr-stub.c
 +++ b/newlib/libc/machine/aarch64/strrchr-stub.c
 @@ -26,7 +26,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined (__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined (__ARM_FEATURE_UNALIGNED)
  # include "../../string/strrchr.c"
  #else
  /* See strrchr.S  */
 diff --git a/newlib/libc/machine/aarch64/strrchr.S b/newlib/libc/machine/aarch64/strrchr.S
-index 1fccba9f8..2f0cdc0c7 100644
+index a3ef3f8fe..f5ba3ad76 100644
 --- a/newlib/libc/machine/aarch64/strrchr.S
 +++ b/newlib/libc/machine/aarch64/strrchr.S
 @@ -29,7 +29,7 @@
  
  #include <picolibc.h>
  
--#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
-+#if (defined (__OPTIMIZE_SIZE__) || defined (PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
  /* See strrchr-stub.c  */
  #else
  


### PR DESCRIPTION
Recent upstream changes to picolibc mean the downstream patches no longer apply due to the context around them changing:

* The retargetable locking condition was removed.
* Various `_HAVE_` symbols were changed to `__HAVE_`.
* `PREFER_SIZE_OVER_SPEED` changed to `__PREFER_SIZE_OVER_SPEED`.

The downstream modifications themselves remain unchanged.