### PR TITLE
Make baremetal-semihosting-aarch64 sample work on recent qemu

### DIFF
--- a/arm-software/embedded/samples/src/baremetal-semihosting-aarch64/Makefile
+++ b/arm-software/embedded/samples/src/baremetal-semihosting-aarch64/Makefile
@@ -10,7 +10,7 @@ include ../../Makefile.conf
 build: hello.elf
 
 hello.elf: *.c
-	$(BIN_PATH)/clang $(AARCH64_TARGET) $(CRT_SEMIHOST) -g -T ../../ldscripts/raspi3b.ld -o hello.elf $^
+	$(BIN_PATH)/clang $(AARCH64_TARGET) $(CRT_SEMIHOST) -Wl,--pic-veneer -mno-unaligned-access -g -T ../../ldscripts/raspi3b.ld -o hello.elf $^
 
 %.img: %.elf
 	$(BIN_PATH)/llvm-objcopy -O binary $< $@


### PR DESCRIPTION
Make a temporary fix to avoid a couple of problems with the startup code on more recent qemu versions, such as the recent 9.2.2 release.

The first problem is that the thunk generated for the branch from _start to _cstart loads the destination address from a literal. As this thunk executes before the memory is set up we get an abort on the read. Fix this by forcing the linker to use a position independent thunk that is execute-only.

The second problem is that the picolibc startup code assumes that qemu-system-aarch64 will start in EL1. This is not always the case. When --kernel is an ELF file qemu will start in EL3, when --kernel is not ELF then qemu will start in either EL2 (if implemented) or EL1, with EL2 preferred. When starting up in EL2 this means that the startup code writing to EL1 system registers is not being used while still executing in EL2, including enabling unaligned access. To work around this disable unaligned accesses.

Ideally this needs fixing in the startup code. Which should test at run time what exception level it starts in and switch to EL1 if not in EL1.