### PR TITLE
Update baremetal-semihosting-aarch64 sample make.bat for qemu (#232)

### DIFF
--- a/arm-software/embedded/samples/src/baremetal-semihosting-aarch64/make.bat
+++ b/arm-software/embedded/samples/src/baremetal-semihosting-aarch64/make.bat
@@ -40,6 +40,6 @@ if exist hello.img del /q hello.img
 @exit /B 1
 
 :build_fn
-%BIN_PATH%\clang.exe --target=aarch64-none-elf -nostartfiles -lcrt0-semihost -lsemihost -g -T ..\..\ldscripts\raspi3b.ld -o hello.elf hello.c
+%BIN_PATH%\clang.exe --target=aarch64-none-elf -nostartfiles -lcrt0-semihost -lsemihost -Wl,--pic-veneer -mno-unaligned-access -g -T ..\..\ldscripts\raspi3b.ld -o hello.elf hello.c
 %BIN_PATH%\llvm-objcopy.exe -O binary hello.elf hello.img
 @exit /B


### PR DESCRIPTION
This applies the change https://github.com/arm/arm-toolchain/pull/227 Makefile to the Windows make.bat. The rest of the commit message is the same as that PR.

Make a temporary fix to avoid a couple of problems with the startup code on more recent qemu versions, such as the recent 9.2.2 release.

The first problem is that the thunk generated for the branch from _start to _cstart loads the destination address from a literal. As this thunk executes before the memory is set up we get an abort on the read. Fix this by forcing the linker to use a position independent thunk that is execute-only.

The second problem is that the picolibc startup code assumes that qemu-system-aarch64 will start in EL1. This is not always the case. When --kernel is an ELF file qemu will start in EL3, when --kernel is not ELF then qemu will start in either EL2 (if implemented) or EL1, with EL2 preferred. When starting up in EL2 this means that the startup code writing to EL1 system registers is not being used while still executing in EL2, including enabling unaligned access. To work around this disable unaligned accesses.

Ideally this needs fixing in the startup code. Which should test at run time what exception level it starts in and switch to EL1 if not in EL1.