### PR TITLE
[ATfE] Add multilib.yaml mapping form Armv8-A big endian to Armv7-A big endian

### DIFF
--- a/arm-software/embedded/arm-multilib/multilib.yaml.in
+++ b/arm-software/embedded/arm-multilib/multilib.yaml.in
@@ -158,9 +158,15 @@ Mappings:
 - Match: --target=(arm|thumb)v(8|8\.[1-9]|9|9\.[1-9])a-unknown-none-eabi
   Flags:
   - --target=armv7-unknown-none-eabi
+- Match: --target=(arm|thumb)ebv(8|8\.[1-9]|9|9\.[1-9])a-unknown-none-eabi
+  Flags:
+  - --target=armebv7-unknown-none-eabi
 - Match: --target=(arm|thumb)v(8|8\.[1-9]|9|9\.[1-9])a-unknown-none-eabihf
   Flags:
   - --target=armv7-unknown-none-eabihf
+- Match: --target=(arm|thumb)ebv(8|8\.[1-9]|9|9\.[1-9])a-unknown-none-eabihf
+  Flags:
+  - --target=armebv7-unknown-none-eabihf
 - Match: --target=(arm|thumb)v(8|8\.[1-9]|9|9\.[1-9])r-unknown-none-eabi
   Flags:
   - --target=armv7r-unknown-none-eabi

--- a/arm-software/embedded/test/multilib/armv8a.test
+++ b/arm-software/embedded/test/multilib/armv8a.test
@@ -1,25 +1,183 @@
-# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none         | FileCheck %s
-# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -marm   | FileCheck %s
-# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -mthumb | FileCheck %s
-# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -march=armv9.5-a | FileCheck %s
-# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -march=armv8.2-a+fp16 | FileCheck %s
-# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -march=armv8.5-a+nodotprod | FileCheck %s
-# CHECK: arm-none-eabi/armv7a_soft_nofp_exn_rtti_unaligned{{$}}
-# CHECK-EMPTY:
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none         | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-EXNRTTI
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -marm   | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-EXNRTTI
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -mthumb | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-EXNRTTI
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -march=armv9.5-a | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-EXNRTTI
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -march=armv8.2-a+fp16 | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-EXNRTTI
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -march=armv8.5-a+nodotprod | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-EXNRTTI
+# CHECK-SOFT-NOFP-EXNRTTI: arm-none-eabi/armv7a_soft_nofp_exn_rtti_unaligned{{$}}
+# CHECK-SOFT-NOFP-EXNRTTI-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=vfpv3-d16 | FileCheck --check-prefix=VFPV3 %s
-# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=neon-vfpv3 | FileCheck --check-prefix=VFPV3 %s
-# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=vfpv3 | FileCheck --check-prefix=VFPV3 %s
-# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=vfpv3-d16-fp16 | FileCheck --check-prefix=VFPV3 %s
-# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=vfpv3-fp16 | FileCheck --check-prefix=VFPV3 %s
-# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=vfpv4-d16 | FileCheck --check-prefix=VFPV3 %s
-# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=vfpv4 | FileCheck --check-prefix=VFPV3 %s
-# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=neon-fp16 | FileCheck --check-prefix=VFPV3 %s
-# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=neon-vfpv4 | FileCheck --check-prefix=VFPV3 %s
-# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=vfpv3-d16 -marm | FileCheck --check-prefix=VFPV3 %s
-# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=vfpv3-d16 -mthumb | FileCheck --check-prefix=VFPV3 %s
-# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=fp-armv8 -march=armv9.5-a | FileCheck --check-prefix=VFPV3 %s
-# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=fp-armv8 -march=armv8.2-a+fp16 | FileCheck --check-prefix=VFPV3 %s
-# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=fp-armv8 -march=armv8.5-a+nodotprod | FileCheck --check-prefix=VFPV3 %s
-# VFPV3: arm-none-eabi/armv7a_hard_vfpv3_d16_exn_rtti_unaligned{{$}}
-# VFPV3-EMPTY:
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=none         | FileCheck %s --check-prefix=CHECK-SOFT-NOFP
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=none -marm   | FileCheck %s --check-prefix=CHECK-SOFT-NOFP
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=none -mthumb | FileCheck %s --check-prefix=CHECK-SOFT-NOFP
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=none -march=armv9.5-a | FileCheck %s --check-prefix=CHECK-SOFT-NOFP
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=none -march=armv8.2-a+fp16 | FileCheck %s --check-prefix=CHECK-SOFT-NOFP
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=none -march=armv8.5-a+nodotprod | FileCheck %s --check-prefix=CHECK-SOFT-NOFP
+# CHECK-SOFT-NOFP: arm-none-eabi/armv7a_soft_nofp_unaligned{{$}}
+# CHECK-SOFT-NOFP-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -mbig-endian        | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-EXNRTTI-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -marm -mbig-endian  | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-EXNRTTI-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -mthumb -mbig-endian | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-EXNRTTI-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -march=armv9.5-a -mbig-endian | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-EXNRTTI-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -march=armv8.2-a+fp16 -mbig-endian | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-EXNRTTI-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -march=armv8.5-a+nodotprod -mbig-endian | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-EXNRTTI-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -mbig-endian -mno-unaligned-access        | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-EXNRTTI-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -marm -mbig-endian -mno-unaligned-access  | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-EXNRTTI-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -mthumb -mbig-endian -mno-unaligned-access | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-EXNRTTI-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -march=armv9.5-a -mbig-endian -mno-unaligned-access | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-EXNRTTI-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -march=armv8.2-a+fp16 -mbig-endian -mno-unaligned-access | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-EXNRTTI-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=none -march=armv8.5-a+nodotprod -mbig-endian -mno-unaligned-access | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-EXNRTTI-BE
+# CHECK-SOFT-NOFP-EXNRTTI-BE: arm-none-eabi/armebv7a_soft_nofp_exn_rtti{{$}}
+# CHECK-SOFT-NOFP-EXNRTTI-BE-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=none -mbig-endian        | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=none -marm -mbig-endian  | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=none -mthumb -mbig-endian | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=none -march=armv9.5-a -mbig-endian | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=none -march=armv8.2-a+fp16 -mbig-endian | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=none -march=armv8.5-a+nodotprod -mbig-endian | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=none -mbig-endian -mno-unaligned-access        | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=none -marm -mbig-endian -mno-unaligned-access  | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=none -mthumb -mbig-endian -mno-unaligned-access | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=none -march=armv9.5-a -mbig-endian -mno-unaligned-access | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=none -march=armv8.2-a+fp16 -mbig-endian -mno-unaligned-access | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-BE
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=none -march=armv8.5-a+nodotprod -mbig-endian -mno-unaligned-access | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-BE
+# CHECK-SOFT-NOFP-BE: arm-none-eabi/armebv7a_soft_nofp{{$}}
+# CHECK-SOFT-NOFP-BE-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=vfpv3-d16 | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=neon-vfpv3 | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=vfpv3 | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=vfpv3-d16-fp16 | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=vfpv3-fp16 | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=vfpv4-d16 | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=vfpv4 | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=neon-fp16 | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=neon-vfpv4 | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=vfpv3-d16 -marm | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=vfpv3-d16 -mthumb | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=fp-armv8 -march=armv9.5-a | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=fp-armv8 -march=armv8.2-a+fp16 | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mfpu=fp-armv8 -march=armv8.5-a+nodotprod | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI %s
+# CHECK-VFPV3-EXNRTTI: arm-none-eabi/armv7a_hard_vfpv3_d16_exn_rtti_unaligned{{$}}
+# CHECK-VFPV3-EXNRTTI-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -fno-exceptions -fno-rtti -mfpu=vfpv3-d16 | FileCheck --check-prefix=CHECK-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -fno-exceptions -fno-rtti -mfpu=neon-vfpv3 | FileCheck --check-prefix=CHECK-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -fno-exceptions -fno-rtti -mfpu=vfpv3 | FileCheck --check-prefix=CHECK-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -fno-exceptions -fno-rtti -mfpu=vfpv3-d16-fp16 | FileCheck --check-prefix=CHECK-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -fno-exceptions -fno-rtti -mfpu=vfpv3-fp16 | FileCheck --check-prefix=CHECK-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -fno-exceptions -fno-rtti -mfpu=vfpv4-d16 | FileCheck --check-prefix=CHECK-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -fno-exceptions -fno-rtti -mfpu=vfpv4 | FileCheck --check-prefix=CHECK-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -fno-exceptions -fno-rtti -mfpu=neon-fp16 | FileCheck --check-prefix=CHECK-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -fno-exceptions -fno-rtti -mfpu=neon-vfpv4 | FileCheck --check-prefix=CHECK-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -fno-exceptions -fno-rtti -mfpu=vfpv3-d16 -marm | FileCheck --check-prefix=CHECK-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -fno-exceptions -fno-rtti -mfpu=vfpv3-d16 -mthumb | FileCheck --check-prefix=CHECK-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -fno-exceptions -fno-rtti -mfpu=fp-armv8 -march=armv9.5-a | FileCheck --check-prefix=CHECK-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -fno-exceptions -fno-rtti -mfpu=fp-armv8 -march=armv8.2-a+fp16 | FileCheck --check-prefix=CHECK-VFPV3 %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -fno-exceptions -fno-rtti -mfpu=fp-armv8 -march=armv8.5-a+nodotprod | FileCheck --check-prefix=CHECK-VFPV3 %s
+# CHECK-VFPV3: arm-none-eabi/armv7a_hard_vfpv3_d16_unaligned{{$}}
+# CHECK-VFPV3-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -mfpu=neon-vfpv3 | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -mfpu=vfpv3 | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -mfpu=vfpv3-d16-fp16 | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -mfpu=vfpv3-fp16 | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -mfpu=vfpv4-d16 | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -mfpu=vfpv4 | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -mfpu=neon-fp16 | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -mfpu=neon-vfpv4 | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -marm | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -mfpu=vfpv3-d16 -mthumb | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -mfpu=fp-armv8 -march=armv9.5-a | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -mfpu=fp-armv8 -march=armv8.2-a+fp16 | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -mfpu=fp-armv8 -march=armv8.5-a+nodotprod | FileCheck --check-prefix=CHECK-VFPV3-EXNRTTI-BE %s
+# CHECK-VFPV3-EXNRTTI-BE: arm-none-eabi/armebv7a_hard_vfpv3_d16_exn_rtti{{$}}
+# CHECK-VFPV3-EXNRTTI-BE-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -fno-exceptions -fno-rtti -mfpu=vfpv3-d16 | FileCheck --check-prefix=CHECK-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -fno-exceptions -fno-rtti -mfpu=neon-vfpv3 | FileCheck --check-prefix=CHECK-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -fno-exceptions -fno-rtti -mfpu=vfpv3 | FileCheck --check-prefix=CHECK-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -fno-exceptions -fno-rtti -mfpu=vfpv3-d16-fp16 | FileCheck --check-prefix=CHECK-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -fno-exceptions -fno-rtti -mfpu=vfpv3-fp16 | FileCheck --check-prefix=CHECK-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -fno-exceptions -fno-rtti -mfpu=vfpv4-d16 | FileCheck --check-prefix=CHECK-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -fno-exceptions -fno-rtti -mfpu=vfpv4 | FileCheck --check-prefix=CHECK-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -fno-exceptions -fno-rtti -mfpu=neon-fp16 | FileCheck --check-prefix=CHECK-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -fno-exceptions -fno-rtti -mfpu=neon-vfpv4 | FileCheck --check-prefix=CHECK-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -fno-exceptions -fno-rtti -mfpu=vfpv3-d16 -marm | FileCheck --check-prefix=CHECK-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -fno-exceptions -fno-rtti -mfpu=vfpv3-d16 -mthumb | FileCheck --check-prefix=CHECK-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -fno-exceptions -fno-rtti -mfpu=fp-armv8 -march=armv9.5-a | FileCheck --check-prefix=CHECK-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -fno-exceptions -fno-rtti -mfpu=fp-armv8 -march=armv8.2-a+fp16 | FileCheck --check-prefix=CHECK-VFPV3-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabihf -mbig-endian -fno-exceptions -fno-rtti -mfpu=fp-armv8 -march=armv8.5-a+nodotprod | FileCheck --check-prefix=CHECK-VFPV3-BE %s
+# CHECK-VFPV3-BE: arm-none-eabi/armebv7a_hard_vfpv3_d16{{$}}
+# CHECK-VFPV3-BE-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=vfpv3-d16 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=neon-vfpv3 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=vfpv3 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=vfpv3-d16-fp16 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=vfpv3-fp16 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=vfpv4-d16 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=vfpv4 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=neon-fp16 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=neon-vfpv4 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=vfpv3-d16 -mfloat-abi=softfp -marm | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=vfpv3-d16 -mfloat-abi=softfp -mthumb | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=fp-armv8 -mfloat-abi=softfp -march=armv9.5-a | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=fp-armv8 -mfloat-abi=softfp -march=armv8.2-a+fp16 | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mfpu=fp-armv8 -mfloat-abi=softfp -march=armv8.5-a+nodotprod | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI %s
+# CHECK-VFPV3-SOFTFP-EXNRTTI: arm-none-eabi/armv7a_soft_vfpv3_d16_exn_rtti_unaligned{{$}}
+# CHECK-VFPV3-SOFTFP-EXNRTTI-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=vfpv3-d16 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=neon-vfpv3 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=vfpv3 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=vfpv3-d16-fp16 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=vfpv3-fp16 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=vfpv4-d16 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=vfpv4 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=neon-fp16 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=neon-vfpv4 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=vfpv3-d16 -mfloat-abi=softfp -marm | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=vfpv3-d16 -mfloat-abi=softfp -mthumb | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=fp-armv8 -mfloat-abi=softfp -march=armv9.5-a | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=fp-armv8 -mfloat-abi=softfp -march=armv8.2-a+fp16 | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -fno-exceptions -fno-rtti -mfpu=fp-armv8 -mfloat-abi=softfp -march=armv8.5-a+nodotprod | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP %s
+# CHECK-VFPV3-SOFTFP: arm-none-eabi/armv7a_soft_vfpv3_d16_unaligned{{$}}
+# CHECK-VFPV3-SOFTFP-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -mfpu=vfpv3-d16 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -mfpu=neon-vfpv3 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -mfpu=vfpv3 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -mfpu=vfpv3-d16-fp16 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -mfpu=vfpv3-fp16 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -mfpu=vfpv4-d16 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -mfpu=vfpv4 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -mfpu=neon-fp16 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -mfpu=neon-vfpv4 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -mfpu=vfpv3-d16 -mfloat-abi=softfp -marm | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -mfpu=vfpv3-d16 -mfloat-abi=softfp -mthumb | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -mfpu=fp-armv8 -mfloat-abi=softfp -march=armv9.5-a | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -mfpu=fp-armv8 -mfloat-abi=softfp -march=armv8.2-a+fp16 | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -mfpu=fp-armv8 -mfloat-abi=softfp -march=armv8.5-a+nodotprod | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-EXNRTTI-BE %s
+# CHECK-VFPV3-SOFTFP-EXNRTTI-BE: arm-none-eabi/armebv7a_soft_vfpv3_d16_exn_rtti{{$}}
+# CHECK-VFPV3-SOFTFP-EXNRTTI-BE-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -fno-exceptions -fno-rtti -mfpu=vfpv3-d16 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -fno-exceptions -fno-rtti -mfpu=neon-vfpv3 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -fno-exceptions -fno-rtti -mfpu=vfpv3 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -fno-exceptions -fno-rtti -mfpu=vfpv3-d16-fp16 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -fno-exceptions -fno-rtti -mfpu=vfpv3-fp16 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -fno-exceptions -fno-rtti -mfpu=vfpv4-d16 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -fno-exceptions -fno-rtti -mfpu=vfpv4 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -fno-exceptions -fno-rtti -mfpu=neon-fp16 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -fno-exceptions -fno-rtti -mfpu=neon-vfpv4 -mfloat-abi=softfp | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -fno-exceptions -fno-rtti -mfpu=vfpv3-d16 -mfloat-abi=softfp -marm | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -fno-exceptions -fno-rtti -mfpu=vfpv3-d16 -mfloat-abi=softfp -mthumb | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -fno-exceptions -fno-rtti -mfpu=fp-armv8 -mfloat-abi=softfp -march=armv9.5-a | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -fno-exceptions -fno-rtti -mfpu=fp-armv8 -mfloat-abi=softfp -march=armv8.2-a+fp16 | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-BE %s
+# RUN: %clang -print-multi-directory --target=armv8a-none-eabi -mbig-endian -fno-exceptions -fno-rtti -mfpu=fp-armv8 -mfloat-abi=softfp -march=armv8.5-a+nodotprod | FileCheck --check-prefix=CHECK-VFPV3-SOFTFP-BE %s
+# CHECK-VFPV3-SOFTFP-BE: arm-none-eabi/armebv7a_soft_vfpv3_d16{{$}}
+# CHECK-VFPV3-SOFTFP-BE-EMPTY:


### PR DESCRIPTION
This is a cherry-pick of #230.

This mapping is necessary to make the multilib variant selection work for Armv8-A big endian, since the library variants supposed to be used in this case are chosen on the presence of the multilib flag corresponding to Armv7-A.

Besides this change, this commit introduces more testing to cover more cases of this mapping.