### PR TITLE
[Downstream Change][LLD][AArch64] Increase alignment of AArch64AbsLon…

### DIFF
--- a/arm-software/embedded/patches/llvm-project/0016-Increase-alignment-of-AArch64AbsLongThunk-to-8.patch
+++ b/arm-software/embedded/patches/llvm-project/0016-Increase-alignment-of-AArch64AbsLongThunk-to-8.patch
@@ -1,0 +1,543 @@
+From 061b2de3ac5500d3b018508a826bb1283aef24b6 Mon Sep 17 00:00:00 2001
+From: Peter Smith <peter.smith@arm.com>
+Date: Tue, 1 Apr 2025 09:49:27 +0100
+Subject: [PATCH] Increase alignment of AArch64AbsLongThunk to 8
+
+This permits an AArch64AbsLongThunk to be used in an environment where
+unaligned accesses are disabled.
+
+The AArch64AbsLongThunk does a load of an 8-byte address. When unaligned
+accesses are disabled this address must be 8-byte aligned.
+
+The vast majority of AArch64 systems will have unaligned accesses
+enabled in userspace. However, after a reset, before the MMU has been
+enabled, all memory accesses are to "device" memory, which requires
+aligned accesses. In systems with multi-stage boot loaders a thunk may
+be required to a later stage before the MMU has been enabled.
+
+As we only want to increase the alignment when the ldr is used we delay
+the increase in thunk alignment until we know we are going to write an
+ldr. We also need to account for the ThunkSection alignment increase
+when this happens.
+
+In some of the test updates, particularly those with shared CHECK lines
+with position independent thunks it was easier to ensure that the thunks
+started at an 8-byte aligned address in all cases.
+
+This is a cherry-pick of upstream llvm-project PR 133738 to the
+arm-software release/20.x branch.
+
+Downstream issue: #243
+---
+ lld/ELF/SyntheticSections.cpp                 |   8 +-
+ lld/ELF/Thunks.cpp                            |   3 +
+ lld/test/ELF/aarch64-call26-thunk.s           |  16 +-
+ .../ELF/aarch64-cortex-a53-843419-thunk.s     |   2 +-
+ lld/test/ELF/aarch64-jump26-thunk.s           |  15 +-
+ .../ELF/aarch64-range-thunk-extension-plt32.s |  10 +-
+ lld/test/ELF/aarch64-thunk-align.s            |  42 +++++
+ lld/test/ELF/aarch64-thunk-bti-multipass.s    |   4 +-
+ lld/test/ELF/aarch64-thunk-bti.s              | 150 +++++++++---------
+ 9 files changed, 151 insertions(+), 99 deletions(-)
+ create mode 100644 lld/test/ELF/aarch64-thunk-align.s
+
+diff --git a/lld/ELF/SyntheticSections.cpp b/lld/ELF/SyntheticSections.cpp
+index b03c4282ab1a..3bb9815336a7 100644
+--- a/lld/ELF/SyntheticSections.cpp
++++ b/lld/ELF/SyntheticSections.cpp
+@@ -4317,14 +4317,20 @@ InputSection *ThunkSection::getTargetInputSection() const {
+ 
+ bool ThunkSection::assignOffsets() {
+   uint64_t off = 0;
++  bool changed = false;
+   for (Thunk *t : thunks) {
++    if (t->alignment > addralign) {
++      addralign = t->alignment;
++      changed = true;
++    }
+     off = alignToPowerOf2(off, t->alignment);
+     t->setOffset(off);
+     uint32_t size = t->size();
+     t->getThunkTargetSym()->size = size;
+     off += size;
+   }
+-  bool changed = off != size;
++  if (off != size)
++    changed = true;
+   size = off;
+   return changed;
+ }
+diff --git a/lld/ELF/Thunks.cpp b/lld/ELF/Thunks.cpp
+index 4e4e0684a3f5..c1a95b6c8950 100644
+--- a/lld/ELF/Thunks.cpp
++++ b/lld/ELF/Thunks.cpp
+@@ -661,6 +661,9 @@ void AArch64ABSLongThunk::addSymbols(ThunkSection &isec) {
+ 
+ void AArch64ABSLongThunk::addLongMapSyms() {
+   addSymbol("$d", STT_NOTYPE, 8, *tsec);
++  // The ldr in the long Thunk requires 8-byte alignment when
++  // unaligned accesses are disabled.
++  alignment = 8;
+ }
+ 
+ // This Thunk has a maximum range of 4Gb, this is sufficient for all programs
+diff --git a/lld/test/ELF/aarch64-call26-thunk.s b/lld/test/ELF/aarch64-call26-thunk.s
+index 8c3034f568b3..4200bb09eaef 100644
+--- a/lld/test/ELF/aarch64-call26-thunk.s
++++ b/lld/test/ELF/aarch64-call26-thunk.s
+@@ -9,13 +9,13 @@
+ _start:
+     bl big
+ 
+-// CHECK: Disassembly of section .text:
++// CHECK-LABEL: <_start>:
++// CHECK-NEXT: 210120: bl      0x210128 <__AArch64AbsLongThunk_big>
++// CHECK-NEXT:         udf     #0x0
+ // CHECK-EMPTY:
+-// CHECK-NEXT: <_start>:
+-// CHECK-NEXT:    210120:       bl      0x210124
+-// CHECK: <__AArch64AbsLongThunk_big>:
+-// CHECK-NEXT:    210124:       ldr     x16, 0x21012c
+-// CHECK-NEXT:    210128:       br      x16
+-// CHECK-NEXT:    21012c:       00 00 00 00     .word   0x00000000
+-// CHECK-NEXT:    210130:       10 00 00 00     .word   0x00000010
++// CHECK-LABEL: <__AArch64AbsLongThunk_big>:
++// CHECK-NEXT: 210128: ldr     x16, 0x210130 <__AArch64AbsLongThunk_big+0x8>
++// CHECK-NEXT:         br      x16
++// CHECK-NEXT: 00 00 00 00   .word   0x00000000
++// CHECK-NEXT: 10 00 00 00   .word   0x00000010
+ 
+diff --git a/lld/test/ELF/aarch64-cortex-a53-843419-thunk.s b/lld/test/ELF/aarch64-cortex-a53-843419-thunk.s
+index 484de11ac554..4fca2113c39a 100644
+--- a/lld/test/ELF/aarch64-cortex-a53-843419-thunk.s
++++ b/lld/test/ELF/aarch64-cortex-a53-843419-thunk.s
+@@ -24,7 +24,7 @@ _start:
+         /// Thunk to far_away, size 16-bytes goes here.
+ 
+         .section .text.02, "ax", %progbits
+-        .space 4096 - 28
++        .space 4096 - 32
+ 
+         /// Erratum sequence will only line up at address 0 modulo 0xffc when
+         /// Thunk is inserted.
+diff --git a/lld/test/ELF/aarch64-jump26-thunk.s b/lld/test/ELF/aarch64-jump26-thunk.s
+index 7fea5eebc366..3c9ce69920ef 100644
+--- a/lld/test/ELF/aarch64-jump26-thunk.s
++++ b/lld/test/ELF/aarch64-jump26-thunk.s
+@@ -11,10 +11,11 @@ _start:
+ 
+ // CHECK: Disassembly of section .text:
+ // CHECK-EMPTY:
+-// CHECK-NEXT: <_start>:
+-// CHECK-NEXT:    210120:       b       0x210124
+-// CHECK: <__AArch64AbsLongThunk_big>:
+-// CHECK-NEXT:    210124:       ldr     x16, 0x21012c
+-// CHECK-NEXT:    210128:       br      x16
+-// CHECK-NEXT:    21012c:       00 00 00 00     .word   0x00000000
+-// CHECK-NEXT:    210130:       10 00 00 00     .word   0x00000010
++// CHECK-LABEL: <_start>:
++// CHECK-NEXT: 210120: b       0x210128
++// CHECK-NEXT:         udf      #0x0
++// CHECK-LABEL: <__AArch64AbsLongThunk_big>:
++// CHECK-NEXT: 210128: ldr     x16, 0x210130
++// CHECK-NEXT:         br      x16
++// CHECK-NEXT: 00 00 00 00     .word   0x00000000
++// CHECK-NEXT: 10 00 00 00     .word   0x00000010
+diff --git a/lld/test/ELF/aarch64-range-thunk-extension-plt32.s b/lld/test/ELF/aarch64-range-thunk-extension-plt32.s
+index 1d09012a2295..9ebf7f5c6952 100644
+--- a/lld/test/ELF/aarch64-range-thunk-extension-plt32.s
++++ b/lld/test/ELF/aarch64-range-thunk-extension-plt32.s
+@@ -9,14 +9,14 @@
+ 
+ // The word should be an offset to the range extension thunk.
+ // CHECK-LABEL: <_start>:
+-// CHECK-NEXT:    10000:       04 00 00 00     .word   0x00000004
++// CHECK-NEXT: 10000: 08 00 00 00     .word   0x00000008
+ 
+ // The thunk redirects to the address of callee.
+ // CHECK-LABEL: <__AArch64AbsLongThunk_callee>:
+-// CHECK-NEXT:    10004:       ldr     x16, 0x1000c <__AArch64AbsLongThunk_callee+0x8>
+-// CHECK-NEXT:    10008:       br      x16
+-// CHECK-NEXT:    1000c:       00 00 00 00     .word   0x00000000
+-// CHECK-NEXT:    10010:       02 00 00 00     .word   0x00000002
++// CHECK-NEXT: 10008: ldr     x16, 0x10010 <__AArch64AbsLongThunk_callee+0x8>
++// CHECK-NEXT:        br      x16
++// CHECK-NEXT: 00 00 00 00    .word   0x00000000
++// CHECK-NEXT: 02 00 00 00    .word   0x00000002
+ 
+ // CHECK-LABEL: <callee>:
+ // CHECK-NEXT:    200000000:      ret
+diff --git a/lld/test/ELF/aarch64-thunk-align.s b/lld/test/ELF/aarch64-thunk-align.s
+new file mode 100644
+index 000000000000..425a00c7564a
+--- /dev/null
++++ b/lld/test/ELF/aarch64-thunk-align.s
+@@ -0,0 +1,42 @@
++// REQUIRES: aarch64
++// RUN: llvm-mc -filetype=obj -triple=aarch64 %s -o %t
++// RUN: ld.lld -Ttext=0x12000 -defsym long=0x10000000 -defsym short=0x8012004 -defsym short2=0x8012008 -defsym short3=0x801200c %t -o %t.exe
++// RUN: llvm-objdump -d --no-show-raw-insn %t.exe | FileCheck %s
++
++/// The AArch64AbsLongThunk requires 8-byte alignment just in case unaligned
++/// accesses are disabled. This increases the thunk section alignment to 8,
++/// and the alignment of the AArch64AbsLongThunk to 8. The short thunk form
++/// can still use 4-byte alignment.
++.text
++.type _start, %function
++.globl _start
++_start:
++ b short
++ b short2
++ b short3
++ b long
++ nop
++
++// CHECK-LABEL: <_start>:
++// CHECK-NEXT: 12000: b       0x12018 <__AArch64AbsLongThunk_short>
++// CHECK-NEXT:        b       0x1201c <__AArch64AbsLongThunk_short2>
++// CHECK-NEXT:        b       0x12020 <__AArch64AbsLongThunk_short3>
++// CHECK-NEXT:        b       0x12028 <__AArch64AbsLongThunk_long>
++// CHECK-NEXT:        nop
++// CHECK-NEXT:        udf     #0x0
++// CHECK-EMPTY:
++// CHECK-LABEL: <__AArch64AbsLongThunk_short>:
++// CHECK-NEXT: 12018: b       0x8012004 <__AArch64AbsLongThunk_long+0x7ffffdc>
++// CHECK-EMPY:
++// CHECK-LABEL: <__AArch64AbsLongThunk_short2>:
++// CHECK-NEXT: 1201c: b       0x8012008 <__AArch64AbsLongThunk_long+0x7ffffe0>
++// CHECK-EMPTY:
++// CHECK-LABEL: <__AArch64AbsLongThunk_short3>:
++// CHECK-NEXT: 12020: b       0x801200c <__AArch64AbsLongThunk_long+0x7ffffe4>
++// CHECK-NEXT:        udf     #0x0
++// CHECK-EMPTY:
++// CHECK-LABEL: <__AArch64AbsLongThunk_long>:
++// CHECK-NEXT: 12028: ldr     x16, 0x12030 <__AArch64AbsLongThunk_long+0x8>
++// CHECK-NEXT:        br      x16
++// CHECK-NEXT: 00 00 00 10   .word   0x10000000
++// CHECK-NEXT: 00 00 00 00   .word   0x00000000
+diff --git a/lld/test/ELF/aarch64-thunk-bti-multipass.s b/lld/test/ELF/aarch64-thunk-bti-multipass.s
+index 4f0d7343cc6b..f2ff914fb850 100644
+--- a/lld/test/ELF/aarch64-thunk-bti-multipass.s
++++ b/lld/test/ELF/aarch64-thunk-bti-multipass.s
+@@ -38,10 +38,10 @@ _start:
+ /// and will need a long branch thunk, which in turn needs a BTI landing pad.
+ 
+ // CHECK-LABEL: <_start>:
+-// CHECK-NEXT: 10001000: bl  0x10002004 <__AArch64AbsLongThunk_fn1>
++// CHECK-NEXT: 10001000: bl  0x10002008 <__AArch64AbsLongThunk_fn1>
+ 
+ // CHECK-LABEL: <__AArch64AbsLongThunk_fn1>:
+-// CHECK-NEXT: 10002004: ldr     x16, 0x1000200c <__AArch64AbsLongThunk_fn1+0x8>
++// CHECK-NEXT: 10002008: ldr     x16, 0x10002010 <__AArch64AbsLongThunk_fn1+0x8>
+ // CHECK-NEXT:           br      x16
+ // CHECK-NEXT:           00 30 00 18    .word   0x18003000
+ // CHECK-NEXT:           00 00 00 00    .word   0x00000000
+diff --git a/lld/test/ELF/aarch64-thunk-bti.s b/lld/test/ELF/aarch64-thunk-bti.s
+index a447fe4ee927..0672ad75d809 100644
+--- a/lld/test/ELF/aarch64-thunk-bti.s
++++ b/lld/test/ELF/aarch64-thunk-bti.s
+@@ -52,19 +52,17 @@ _start:
+  bl via_plt
+ /// We cannot add landing pads for absolute symbols.
+  bl absolute
+-
+ /// padding so that we require thunks that can be placed after this section.
+ /// The thunks are close enough to the target to be short.
++ .balign 8
+  .space 0x1000
+ 
+ // CHECK-PADS-LABEL: <_start>:
+-// CHECK-PADS-NEXT: 10001000: bl      0x1000203c
+-// CHECK-PADS-NEXT:           bl      0x10002040
++// CHECK-PADS-NEXT: 10001000: bl      0x10002040
+ // CHECK-PADS-NEXT:           bl      0x10002044
+ // CHECK-PADS-NEXT:           bl      0x10002048
+ // CHECK-PADS-NEXT:           bl      0x1000204c
+ // CHECK-PADS-NEXT:           bl      0x10002050
+-// CHECK-PADS-NEXT:           b       0x10002050
+ // CHECK-PADS-NEXT:           bl      0x10002054
+ // CHECK-PADS-NEXT:           b       0x10002054
+ // CHECK-PADS-NEXT:           bl      0x10002058
+@@ -72,73 +70,75 @@ _start:
+ // CHECK-PADS-NEXT:           bl      0x1000205c
+ // CHECK-PADS-NEXT:           b       0x1000205c
+ // CHECK-PADS-NEXT:           bl      0x10002060
++// CHECK-PADS-NEXT:           b       0x10002060
+ // CHECK-PADS-NEXT:           bl      0x10002064
++// CHECK-PADS-NEXT:           bl      0x10002068
+ 
+ // CHECK-LABEL: <__AArch64ADRPThunk_>:
+-// CHECK-NEXT: 1000203c: b       0x18001000 <bti_c_target>
++// CHECK-NEXT: 10002040: b       0x18001000 <bti_c_target>
+ 
+ // CHECK-LABEL: <__AArch64ADRPThunk_>:
+-// CHECK-NEXT: 10002040: b       0x18001008 <bti_j_target>
++// CHECK-NEXT: 10002044: b       0x18001008 <bti_j_target>
+ 
+ // CHECK-LABEL: <__AArch64ADRPThunk_>:
+-// CHECK-NEXT: 10002044: b       0x18001010 <bti_jc_target>
++// CHECK-NEXT: 10002048: b       0x18001010 <bti_jc_target>
+ 
+ // CHECK-LABEL: <__AArch64ADRPThunk_>:
+-// CHECK-NEXT: 10002048: b       0x18001018 <paciasp_target>
++// CHECK-NEXT: 1000204c: b       0x18001018 <paciasp_target>
+ 
+ // CHECK-LABEL: <__AArch64ADRPThunk_>:
+-// CHECK-NEXT: 1000204c: b       0x18001020 <pacibsp_target>
++// CHECK-NEXT: 10002050: b       0x18001020 <pacibsp_target>
+ 
+ // CHECK-LABEL: <__AArch64ADRPThunk_>:
+-// CHECK-NEXT: 10002050: b       0x18001038 <fn2>
++// CHECK-NEXT: 10002054: b       0x18001038 <fn2>
+ 
+ // CHECK-LABEL: <__AArch64ADRPThunk_>:
+-// CHECK-NEXT: 10002054:       b       0x18001034 <fn1>
++// CHECK-NEXT: 10002058:       b       0x18001034 <fn1>
+ 
+ // CHECK-LABEL: <__AArch64ADRPThunk_>:
+-// CHECK-NEXT: 10002058:       b       0x18001040 <fn3>
++// CHECK-NEXT: 1000205c:       b       0x18001040 <fn3>
+ 
+ // CHECK-LABEL: <__AArch64ADRPThunk_>:
+-// CHECK-NEXT: 1000205c:       b       0x18001050 <fn4>
++// CHECK-NEXT: 10002060:       b       0x18001050 <fn4>
+ 
+ // CHECK-LABEL: <__AArch64ADRPThunk_via_plt>:
+-// CHECK-NEXT: 10002060:       b       0x18001080 <via_plt@plt>
++// CHECK-NEXT: 10002064:       b       0x18001080 <via_plt@plt>
+ 
+ // CHECK-LABEL: <__AArch64ADRPThunk_absolute>:
+-// CHECK-NEXT: 10002064:       b       0x18001098 <absolute@plt>
++// CHECK-NEXT: 10002068:       b       0x18001098 <absolute@plt>
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+-// CHECK-EXE-NEXT: 1000203c: b       0x18001000 <bti_c_target>
++// CHECK-EXE-NEXT: 10002040: b       0x18001000 <bti_c_target>
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+-// CHECK-EXE-NEXT: 10002040: b       0x18001008 <bti_j_target>
++// CHECK-EXE-NEXT: 10002044: b       0x18001008 <bti_j_target>
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+-// CHECK-EXE-NEXT: 10002044: b       0x18001010 <bti_jc_target>
++// CHECK-EXE-NEXT: 10002048: b       0x18001010 <bti_jc_target>
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+-// CHECK-EXE-NEXT: 10002048: b       0x18001018 <paciasp_target>
++// CHECK-EXE-NEXT: 1000204c: b       0x18001018 <paciasp_target>
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+-// CHECK-EXE-NEXT: 1000204c: b       0x18001020 <pacibsp_target>
++// CHECK-EXE-NEXT: 10002050: b       0x18001020 <pacibsp_target>
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+-// CHECK-EXE-NEXT: 10002050: b       0x18001038 <fn2>
++// CHECK-EXE-NEXT: 10002054: b       0x18001038 <fn2>
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+-// CHECK-EXE-NEXT: 10002054: b       0x18001034 <fn1>
++// CHECK-EXE-NEXT: 10002058: b       0x18001034 <fn1>
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+-// CHECK-EXE-NEXT: 10002058: b       0x18001040 <fn3>
++// CHECK-EXE-NEXT: 1000205c: b       0x18001040 <fn3>
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+-// CHECK-EXE-NEXT: 1000205c: b       0x18001050 <fn4>
++// CHECK-EXE-NEXT: 10002060: b       0x18001050 <fn4>
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_via_plt>:
+-// CHECK-EXE-NEXT: 10002060: b       0x18001080 <via_plt@plt>
++// CHECK-EXE-NEXT: 10002064: b       0x18001080 <via_plt@plt>
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_absolute>:
+-// CHECK-EXE-NEXT: 10002064:   ldr     x16, 0x1000206c <__AArch64AbsLongThunk_absolute+0x8>
++// CHECK-EXE-NEXT: 10002068:   ldr     x16, 0x10002070 <__AArch64AbsLongThunk_absolute+0x8>
+ // CHECK-EXE-NEXT:             br      x16
+ // CHECK-EXE-NEXT: 00 00 00 f0 .word   0xf0000000
+ // CHECK-EXE-NEXT: 00 00 00 00 .word   0x00000000
+@@ -278,21 +278,21 @@ long_calls:
+  bl via_plt
+ /// We cannot add landing pads for absolute symbols.
+  bl absolute
+-
++ .balign 8
+ /// PLT entries have BTI at start.
+ // CHECK-LABEL: <via_plt@plt>:
+ // CHECK-NEXT:           bti     c
+ // CHECK-NEXT:           adrp    x16, 0x30000000
+-// CHECK-NEXT:           ldr     x17, [x16, #0x198]
+-// CHECK-NEXT:           add     x16, x16, #0x198
++// CHECK-NEXT:           ldr     x17, [x16, #0x1a0]
++// CHECK-NEXT:           add     x16, x16, #0x1a0
+ // CHECK-NEXT:           br      x17
+ // CHECK-NEXT:           nop
+ 
+ // CHECK: <absolute@plt>:
+ // CHECK-NEXT:           bti     c
+ // CHECK-NEXT:           adrp    x16, 0x30000000
+-// CHECK-NEXT:           ldr     x17, [x16, #0x1a0]
+-// CHECK-NEXT:           add     x16, x16, #0x1a0
++// CHECK-NEXT:           ldr     x17, [x16, #0x1a8]
++// CHECK-NEXT:           add     x16, x16, #0x1a8
+ // CHECK-NEXT:           br      x17
+ // CHECK-NEXT:           nop
+ 
+@@ -305,25 +305,25 @@ long_calls:
+ // CHECK-EXE-NEXT:           nop
+ 
+ // CHECK-LABEL: <long_calls>:
+-// CHECK-NEXT: 30000000: bl      0x3000003c <__AArch64ADRPThunk_>
+-// CHECK-NEXT:           bl      0x30000048 <__AArch64ADRPThunk_>
+-// CHECK-NEXT:           bl      0x30000054 <__AArch64ADRPThunk_>
+-// CHECK-NEXT:           bl      0x30000060 <__AArch64ADRPThunk_>
+-// CHECK-NEXT:           bl      0x3000006c <__AArch64ADRPThunk_>
+-// CHECK-NEXT:           bl      0x30000078 <__AArch64ADRPThunk_>
+-// CHECK-NEXT:           b       0x30000078 <__AArch64ADRPThunk_>
+-// CHECK-NEXT:           bl      0x30000084 <__AArch64ADRPThunk_>
+-// CHECK-NEXT:           b       0x30000084 <__AArch64ADRPThunk_>
+-// CHECK-NEXT:           bl      0x30000090 <__AArch64ADRPThunk_>
+-// CHECK-NEXT:           b       0x30000090 <__AArch64ADRPThunk_>
+-// CHECK-NEXT:           bl      0x3000009c <__AArch64ADRPThunk_>
+-// CHECK-NEXT:           b       0x3000009c <__AArch64ADRPThunk_>
+-// CHECK-NEXT:           bl      0x300000a8 <__AArch64ADRPThunk_via_plt>
+-// CHECK-NEXT:           bl      0x300000b4 <__AArch64ADRPThunk_absolute>
++// CHECK-NEXT: 30000000: bl      0x30000040 <__AArch64ADRPThunk_>
++// CHECK-NEXT:           bl      0x3000004c <__AArch64ADRPThunk_>
++// CHECK-NEXT:           bl      0x30000058 <__AArch64ADRPThunk_>
++// CHECK-NEXT:           bl      0x30000064 <__AArch64ADRPThunk_>
++// CHECK-NEXT:           bl      0x30000070 <__AArch64ADRPThunk_>
++// CHECK-NEXT:           bl      0x3000007c <__AArch64ADRPThunk_>
++// CHECK-NEXT:           b       0x3000007c <__AArch64ADRPThunk_>
++// CHECK-NEXT:           bl      0x30000088 <__AArch64ADRPThunk_>
++// CHECK-NEXT:           b       0x30000088 <__AArch64ADRPThunk_>
++// CHECK-NEXT:           bl      0x30000094 <__AArch64ADRPThunk_>
++// CHECK-NEXT:           b       0x30000094 <__AArch64ADRPThunk_>
++// CHECK-NEXT:           bl      0x300000a0 <__AArch64ADRPThunk_>
++// CHECK-NEXT:           b       0x300000a0 <__AArch64ADRPThunk_>
++// CHECK-NEXT:           bl      0x300000ac <__AArch64ADRPThunk_via_plt>
++// CHECK-NEXT:           bl      0x300000b8 <__AArch64ADRPThunk_absolute>
+ 
+ /// bti_c_target.
+ // CHECK-LABEL: <__AArch64ADRPThunk_>:
+-// CHECK-NEXT: 3000003c: adrp    x16, 0x18001000 <bti_c_target>
++// CHECK-NEXT: 30000040: adrp    x16, 0x18001000 <bti_c_target>
+ // CHECK-NEXT:           add     x16, x16, #0x0
+ // CHECK-NEXT:           br      x16
+ /// bti_j_target.
+@@ -378,84 +378,84 @@ long_calls:
+ // CHECK-NEXT:           br      x16
+ 
+ // CHECK-EXE-LABEL: <long_calls>:
+-// CHECK-EXE-NEXT: 30000000: bl      0x3000003c <__AArch64AbsLongThunk_>
+-// CHECK-EXE-NEXT:           bl      0x3000004c <__AArch64AbsLongThunk_>
+-// CHECK-EXE-NEXT:           bl      0x3000005c <__AArch64AbsLongThunk_>
+-// CHECK-EXE-NEXT:           bl      0x3000006c <__AArch64AbsLongThunk_>
+-// CHECK-EXE-NEXT:           bl      0x3000007c <__AArch64AbsLongThunk_>
+-// CHECK-EXE-NEXT:           bl      0x3000008c <__AArch64AbsLongThunk_>
+-// CHECK-EXE-NEXT:           b       0x3000008c <__AArch64AbsLongThunk_>
+-// CHECK-EXE-NEXT:           bl      0x3000009c <__AArch64AbsLongThunk_>
+-// CHECK-EXE-NEXT:           b       0x3000009c <__AArch64AbsLongThunk_>
+-// CHECK-EXE-NEXT:           bl      0x300000ac <__AArch64AbsLongThunk_>
+-// CHECK-EXE-NEXT:           b       0x300000ac <__AArch64AbsLongThunk_>
+-// CHECK-EXE-NEXT:           bl      0x300000bc <__AArch64AbsLongThunk_>
+-// CHECK-EXE-NEXT:           b       0x300000bc <__AArch64AbsLongThunk_>
+-// CHECK-EXE-NEXT:           bl      0x300000cc <__AArch64AbsLongThunk_via_plt>
+-// CHECK-EXE-NEXT:           bl      0x300000dc <__AArch64AbsLongThunk_absolute>
+-
+-// CHECK-EXE-LABEL: 000000003000003c <__AArch64AbsLongThunk_>:
+-// CHECK-EXE-NEXT: 3000003c: ldr     x16, 0x30000044 <__AArch64AbsLongThunk_+0x8>
++// CHECK-EXE-NEXT: 30000000: bl      0x30000040 <__AArch64AbsLongThunk_>
++// CHECK-EXE-NEXT:           bl      0x30000050 <__AArch64AbsLongThunk_>
++// CHECK-EXE-NEXT:           bl      0x30000060 <__AArch64AbsLongThunk_>
++// CHECK-EXE-NEXT:           bl      0x30000070 <__AArch64AbsLongThunk_>
++// CHECK-EXE-NEXT:           bl      0x30000080 <__AArch64AbsLongThunk_>
++// CHECK-EXE-NEXT:           bl      0x30000090 <__AArch64AbsLongThunk_>
++// CHECK-EXE-NEXT:           b       0x30000090 <__AArch64AbsLongThunk_>
++// CHECK-EXE-NEXT:           bl      0x300000a0 <__AArch64AbsLongThunk_>
++// CHECK-EXE-NEXT:           b       0x300000a0 <__AArch64AbsLongThunk_>
++// CHECK-EXE-NEXT:           bl      0x300000b0 <__AArch64AbsLongThunk_>
++// CHECK-EXE-NEXT:           b       0x300000b0 <__AArch64AbsLongThunk_>
++// CHECK-EXE-NEXT:           bl      0x300000c0 <__AArch64AbsLongThunk_>
++// CHECK-EXE-NEXT:           b       0x300000c0 <__AArch64AbsLongThunk_>
++// CHECK-EXE-NEXT:           bl      0x300000d0 <__AArch64AbsLongThunk_via_plt>
++// CHECK-EXE-NEXT:           bl      0x300000e0 <__AArch64AbsLongThunk_absolute>
++
++// CHECK-EXE-LABEL: 0000000030000040 <__AArch64AbsLongThunk_>:
++// CHECK-EXE-NEXT: 30000040: ldr     x16, 0x30000048 <__AArch64AbsLongThunk_+0x8>
+ // CHECK-EXE-NEXT:           br      x16
+ // CHECK-EXE-NEXT:     00 10 00 18   .word   0x18001000
+ // CHECK-EXE-NEXT:     00 00 00 00   .word   0x00000000
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+-// CHECK-EXE-NEXT: 3000004c: ldr     x16, 0x30000054 <__AArch64AbsLongThunk_+0x8>
++// CHECK-EXE-NEXT: 30000050: ldr     x16, 0x30000058 <__AArch64AbsLongThunk_+0x8>
+ // CHECK-EXE-NEXT:           br      x16
+ // CHECK-EXE-NEXT:     08 10 00 18   .word   0x18001008
+ // CHECK-EXE-NEXT:     00 00 00 00   .word   0x00000000
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+-// CHECK-EXE-NEXT: 3000005c: ldr     x16, 0x30000064 <__AArch64AbsLongThunk_+0x8>
++// CHECK-EXE-NEXT: 30000060: ldr     x16, 0x30000068 <__AArch64AbsLongThunk_+0x8>
+ // CHECK-EXE-NEXT:           br      x16
+ // CHECK-EXE-NEXT:     10 10 00 18   .word   0x18001010
+ // CHECK-EXE-NEXT:     00 00 00 00   .word   0x00000000
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+-// CHECK-EXE-NEXT: 3000006c: ldr     x16, 0x30000074 <__AArch64AbsLongThunk_+0x8>
++// CHECK-EXE-NEXT: 30000070: ldr     x16, 0x30000078 <__AArch64AbsLongThunk_+0x8>
+ // CHECK-EXE-NEXT:           br      x16
+ // CHECK-EXE-NEXT:     18 10 00 18   .word   0x18001018
+ // CHECK-EXE-NEXT:     00 00 00 00   .word   0x00000000
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+-// CHECK-EXE-NEXT: 3000007c: ldr     x16, 0x30000084 <__AArch64AbsLongThunk_+0x8>
++// CHECK-EXE-NEXT: 30000080: ldr     x16, 0x30000088 <__AArch64AbsLongThunk_+0x8>
+ // CHECK-EXE-NEXT:           br      x16
+ // CHECK-EXE-NEXT:     20 10 00 18   .word   0x18001020
+ // CHECK-EXE-NEXT:     00 00 00 00   .word   0x00000000
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+-// CHECK-EXE-NEXT: 3000008c: ldr     x16, 0x30000094 <__AArch64AbsLongThunk_+0x8>
++// CHECK-EXE-NEXT: 30000090: ldr     x16, 0x30000098 <__AArch64AbsLongThunk_+0x8>
+ // CHECK-EXE-NEXT:           br      x16
+ // CHECK-EXE-NEXT:     28 10 00 18   .word   0x18001028
+ // CHECK-EXE-NEXT:     00 00 00 00   .word   0x00000000
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+-// CHECK-EXE-NEXT: 3000009c: ldr     x16, 0x300000a4 <__AArch64AbsLongThunk_+0x8>
++// CHECK-EXE-NEXT: 300000a0: ldr     x16, 0x300000a8 <__AArch64AbsLongThunk_+0x8>
+ // CHECK-EXE-NEXT:           br      x16
+ // CHECK-EXE-NEXT:     30 10 00 18   .word   0x18001030
+ // CHECK-EXE-NEXT:     00 00 00 00   .word   0x00000000
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+-// CHECK-EXE-NEXT: 300000ac: ldr     x16, 0x300000b4 <__AArch64AbsLongThunk_+0x8>
++// CHECK-EXE-NEXT: 300000b0: ldr     x16, 0x300000b8 <__AArch64AbsLongThunk_+0x8>
+ // CHECK-EXE-NEXT:           br      x16
+ // CHECK-EXE-NEXT:     3c 10 00 18   .word   0x1800103c
+ // CHECK-EXE-NEXT:     00 00 00 00   .word   0x00000000
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_>:
+-// CHECK-EXE-NEXT: 300000bc: ldr     x16, 0x300000c4 <__AArch64AbsLongThunk_+0x8>
++// CHECK-EXE-NEXT: 300000c0: ldr     x16, 0x300000c8 <__AArch64AbsLongThunk_+0x8>
+ // CHECK-EXE-NEXT:           br      x16
+ // CHECK-EXE-NEXT:     44 10 00 18   .word   0x18001044
+ // CHECK-EXE-NEXT:     00 00 00 00   .word   0x00000000
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_via_plt>:
+-// CHECK-EXE-NEXT: 300000cc: ldr     x16, 0x300000d4 <__AArch64AbsLongThunk_via_plt+0x8>
++// CHECK-EXE-NEXT: 300000d0: ldr     x16, 0x300000d8 <__AArch64AbsLongThunk_via_plt+0x8>
+ // CHECK-EXE-NEXT:           br      x16
+ // CHECK-EXE-NEXT:     80 10 00 18   .word   0x18001080
+ // CHECK-EXE-NEXT:     00 00 00 00   .word   0x00000000
+ 
+ // CHECK-EXE-LABEL: <__AArch64AbsLongThunk_absolute>:
+-// CHECK-EXE-NEXT: 300000dc: ldr     x16, 0x300000e4 <__AArch64AbsLongThunk_absolute+0x8>
++// CHECK-EXE-NEXT: 300000e0: ldr     x16, 0x300000e8 <__AArch64AbsLongThunk_absolute+0x8>
+ // CHECK-EXE-NEXT:           br      x16
+ // CHECK-EXE-NEXT:     00 00 00 f0   .word   0xf0000000
+ // CHECK-EXE-NEXT:     00 00 00 00   .word   0x00000000
+-- 
+2.34.1
+


### PR DESCRIPTION
This permits an AArch64AbsLongThunk to be used in an environment where unaligned accesses are disabled.

The AArch64AbsLongThunk does a load of an 8-byte address. When unaligned accesses are disabled this address must be 8-byte aligned.

The vast majority of AArch64 systems will have unaligned accesses enabled in userspace. However, after a reset, before the MMU has been enabled, all memory accesses are to "device" memory, which requires aligned accesses. In systems with multi-stage boot loaders a thunk may be required to a later stage before the MMU has been enabled.

As we only want to increase the alignment when the ldr is used we delay the increase in thunk alignment until we know we are going to write an ldr. We also need to account for the ThunkSection alignment increase when this happens.

In some of the test updates, particularly those with shared CHECK lines with position independent thunks it was easier to ensure that the thunks started at an 8-byte aligned address in all cases.

This is a cherry-pick of upstream llvm-project PR 133738 to the arm-software release/20.x branch.

Downstream issue: #243