### PR TITLE
Add minimal libc++ support with llvmlibc

### DIFF
--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_be.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_be.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_soft_nofp.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_soft_nofp_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_exn_rtti_unaligned.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_soft_nofp.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_soft_nofp_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_unaligned.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_be.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_be.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_soft_nofp.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_soft_nofp_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_exn_rtti_unaligned.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_exn_rtti_unaligned.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_unaligned.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_unaligned.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armebv6m_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armebv6m_soft_nofp.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armebv6m_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armebv6m_soft_nofp_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armebv7a_hard_vfpv3_d16.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armebv7a_hard_vfpv3_d16.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armebv7a_hard_vfpv3_d16_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armebv7a_hard_vfpv3_d16_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armebv7a_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armebv7a_soft_nofp.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armebv7a_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armebv7a_soft_nofp_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armebv7a_soft_vfpv3_d16.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armebv7a_soft_vfpv3_d16.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armebv7a_soft_vfpv3_d16_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armebv7a_soft_vfpv3_d16_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armebv7m_hard_fpv4_sp_d16.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armebv7m_hard_fpv4_sp_d16.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armebv7m_hard_fpv4_sp_d16_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armebv7m_hard_fpv4_sp_d16_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armebv7m_soft_fpv4_sp_d16.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armebv7m_soft_fpv4_sp_d16.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armebv7m_soft_fpv4_sp_d16_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armebv7m_soft_fpv4_sp_d16_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armebv7m_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armebv7m_soft_nofp.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armebv7m_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armebv7m_soft_nofp_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv4t.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv4t.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv4t_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv4t_exn_rtti.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv5te.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv5te.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv5te_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv5te_exn_rtti.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv6m_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv6m_soft_nofp.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv6m_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv6m_soft_nofp_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv6m_soft_nofp_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv6m_soft_nofp_exn_rtti_unaligned.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv6m_soft_nofp_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv6m_soft_nofp_unaligned.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_hard_vfpv3_d16.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_hard_vfpv3_d16.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_hard_vfpv3_d16_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_hard_vfpv3_d16_exn_rtti.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_hard_vfpv3_d16_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_hard_vfpv3_d16_exn_rtti_unaligned.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_hard_vfpv3_d16_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_hard_vfpv3_d16_unaligned.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_nofp.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_nofp_exn_rtti.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_nofp_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_nofp_exn_rtti_unaligned.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_nofp_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_nofp_unaligned.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_vfpv3_d16.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_vfpv3_d16.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_vfpv3_d16_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_vfpv3_d16_exn_rtti.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_vfpv3_d16_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_vfpv3_d16_exn_rtti_unaligned.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_vfpv3_d16_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_vfpv3_d16_unaligned.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7m_hard_fpv4_sp_d16.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7m_hard_fpv4_sp_d16.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7m_hard_fpv4_sp_d16_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7m_hard_fpv4_sp_d16_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7m_hard_fpv4_sp_d16_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7m_hard_fpv4_sp_d16_exn_rtti_unaligned.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7m_hard_fpv4_sp_d16_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7m_hard_fpv4_sp_d16_unaligned.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7m_hard_fpv5_d16.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7m_hard_fpv5_d16.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7m_hard_fpv5_d16_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7m_hard_fpv5_d16_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_fpv4_sp_d16.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_fpv4_sp_d16.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_fpv4_sp_d16_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_fpv4_sp_d16_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_fpv4_sp_d16_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_fpv4_sp_d16_exn_rtti_unaligned.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_fpv4_sp_d16_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_fpv4_sp_d16_unaligned.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_nofp.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_nofp_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_nofp_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_nofp_exn_rtti_unaligned.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_nofp_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7m_soft_nofp_unaligned.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3_d16.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3_d16.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3_d16_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3_d16_exn_rtti.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3_d16_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3_d16_exn_rtti_unaligned.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3_d16_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3_d16_unaligned.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3xd.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3xd.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3xd_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3xd_exn_rtti.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3xd_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3xd_exn_rtti_unaligned.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3xd_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3xd_unaligned.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_nofp.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_nofp_exn_rtti.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_nofp_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_nofp_exn_rtti_unaligned.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_nofp_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_nofp_unaligned.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_vfpv3xd.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_vfpv3xd.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_vfpv3xd_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_vfpv3xd_exn_rtti.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_vfpv3xd_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_vfpv3xd_exn_rtti_unaligned.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_vfpv3xd_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_vfpv3xd_unaligned.json
@@ -32,7 +32,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv8m.main_hard_fp_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8m.main_hard_fp_exn_rtti_unaligned.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv8m.main_hard_fp_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8m.main_hard_fp_unaligned.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv8m.main_soft_nofp_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8m.main_soft_nofp_exn_rtti_unaligned.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-multilib/json/variants/armv8m.main_soft_nofp_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8m.main_soft_nofp_unaligned.json
@@ -31,7 +31,7 @@
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "llvmlibc": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"

--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -610,9 +610,6 @@ if(C_LIBRARY STREQUAL llvmlibc)
     if(ENABLE_LIBC_TESTS)
         message(FATAL_ERROR "Tests cannot yet be enabled using llvm libc.")
     endif()
-    if(ENABLE_CXX_LIBS)
-        message(FATAL_ERROR "We aren't yet able to build C++ libraries to go with llvm-libc.")
-    endif()
 
     # LLVM libc lacks a configuration for AArch64, but the AArch32 one works
     # fine. However, setting the configuration for both architectures to the
@@ -751,6 +748,23 @@ if(ENABLE_CXX_LIBS)
                 -DLLVM_LIT_ARGS=${cxxlibs_lit_args}
             )
         endif()
+    elseif(C_LIBRARY STREQUAL llvmlibc)
+        set(cxxlibs_extra_cmake_options
+            -DLIBCXXABI_ENABLE_THREADS=OFF
+            -DLIBCXX_ENABLE_MONOTONIC_CLOCK=OFF
+            -DLIBCXX_ENABLE_RANDOM_DEVICE=OFF
+            -DLIBCXX_ENABLE_THREADS=OFF
+            -DLIBCXX_ENABLE_WIDE_CHARACTERS=OFF
+            -DLIBCXX_ENABLE_FILESYSTEM=OFF
+            -DLIBCXX_ENABLE_LOCALIZATION=OFF
+            -DLIBCXX_ENABLE_UNICODE=OFF
+            -DLIBUNWIND_ENABLE_THREADS=OFF
+            -DLIBCXXABI_ENABLE_EXCEPTIONS=${ENABLE_EXCEPTIONS}
+            -DLIBCXXABI_ENABLE_STATIC_UNWINDER=${ENABLE_EXCEPTIONS}
+            -DLIBCXX_ENABLE_EXCEPTIONS=${ENABLE_EXCEPTIONS}
+            -DLIBCXX_ENABLE_RTTI=${ENABLE_RTTI}
+            )
+            set(lib_compile_flags "${lib_compile_flags} \"-Dvfprintf(stream$<COMMA> format$<COMMA> vlist)=vprintf(format$<COMMA> vlist)\" \"-Dfprintf(stream$<COMMA> format$<COMMA> ...)=printf(format)\" -D_LIBCPP_PRINT=1")
     elseif(C_LIBRARY MATCHES "^newlib")
         set(cxxlibs_extra_cmake_options
             -DLIBCXXABI_ENABLE_THREADS=OFF

--- a/arm-software/embedded/docs/llvmlibc.md
+++ b/arm-software/embedded/docs/llvmlibc.md
@@ -71,8 +71,8 @@ directory containing sample programs that use LLVM libc.
 
 ## Limitations of LLVM libc in Arm Toolchain for Embedded
 
-At present, this toolchain does not build any C++ libraries to go with
-LLVM libc.
+At present, this toolchain builds C++ libraries limited to what is supported with
+LLVM libc, for example, iostream is not available.
 
 At the time of writing this (2024-07), LLVM libc is a work in
 progress. It is incomplete: not all standard C library functionality


### PR DESCRIPTION
Particular missing piece is iostreams. libc++ testing remains disabled.