### PR TITLE
arm software

### DIFF
--- a/.github/workflows/atfe_nightly_build_and_test.yml
+++ b/.github/workflows/atfe_nightly_build_and_test.yml
@@ -1,0 +1,58 @@
+# This workflow runs all build scripts in parallel on Linux.
+# It is intended to be triggered as part of a **nightly build** to
+# validate all build configurations and test them automatically.
+#
+# Each build script is paired with a corresponding test script using
+# a matrix strategy. Each build+test pair runs as a separate job,
+# allowing for concurrency and clear traceability of failures.
+
+name: ATfE Nightly Build and Test
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'  # Every day at 02:00 UTC
+
+jobs:
+  build-and-test-toolchain:
+    name: Build ${{ matrix.build_script }} + Test ${{ matrix.test_script }} on ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
+
+    strategy:
+      fail-fast: false  # Prevents one job failure from cancelling all
+      matrix:
+        include:
+          - build_script: build.sh
+            test_script: test.sh
+            runner: ubuntu-22.04
+          - build_script: build_llvmlibc_overlay.sh
+            test_script: test.sh
+            runner: ubuntu-22.04
+          - build_script: build_newlib_nano_overlay.sh
+            test_script: test.sh
+            runner: ubuntu-22.04
+          - build_script: build_newlib_overlay.sh
+            test_script: test.sh
+            runner: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: ./arm-software/embedded/scripts/install_dependencies.sh
+
+      - name: Build ${{ matrix.build_script }}
+        run: ./arm-software/embedded/scripts/${{ matrix.build_script }}
+
+      - name: Test ${{ matrix.test_script }}
+        run: ./arm-software/embedded/scripts/${{ matrix.test_script }}
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-${{ matrix.build_script }}
+          path: |
+            build/**/*results.xml
+            build/**/*.junit.xml

--- a/arm-software/embedded/scripts/install_dependencies.sh
+++ b/arm-software/embedded/scripts/install_dependencies.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# This script installs the essential build dependencies for ATfE.
+
+sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+    cmake \
+    ninja-build \
+    clang

--- a/arm-software/embedded/versions.json
+++ b/arm-software/embedded/versions.json
@@ -12,7 +12,7 @@
       "tag": "main"
     },
     "newlib": {
-      "url": "https://sourceware.org/git/newlib-cygwin.git",
+      "url": "https://github.com/bminor/newlib.git",
       "tagType": "tag",
       "tag": "newlib-4.5.0"
     }


### PR DESCRIPTION
 Add nightly build and test workflow for ATfE

- Initial support for Linux Ubuntu 22.04
- Run all build scripts in parallel
- Add install dependencies script