### PR TITLE
Add CFI ignore file for ATfE.

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -703,10 +703,10 @@ if(NOT PREBUILT_TARGET_LIBRARIES)
     endforeach()
 endif()
 
-FILE(WRITE "${CMAKE_BINARY_DIR}/${TARGET_CFI_DIR}/cfi_ignorelist.txt" "")
+FILE(WRITE "${CMAKE_BINARY_DIR}/llvm/${TARGET_CFI_DIR}/cfi_ignorelist.txt" "")
 install(
     FILES
-    ${CMAKE_BINARY_DIR}/${TARGET_CFI_DIR}/cfi_ignorelist.txt
+    ${CMAKE_BINARY_DIR}/llvm/${TARGET_CFI_DIR}/cfi_ignorelist.txt
     DESTINATION ${TARGET_CFI_DIR}
     COMPONENT llvm-toolchain-libs
 )


### PR DESCRIPTION
Add CFI ignore file for ATfE. This fixes an issue observed with https://github.com/arm/arm-toolchain/commit/1ce251795b2d1bc31ff7c80989b5b188b334a2bd 

There are at least 3 ways by which cfi-ignore file can be invoked:
1. With the binary installer, by executing the program. For example: `clang --target=aarch64-none-elf -march=armv8-a -c test.c -flto -fsanitize=cfi -fvisibility=hidden`
2. With the binary installer, by executing the "cpp-baremetal-semihosting-cfi" example code in "samples" directory, without  "-fno-sanitize-ignorelist" in MakeFile
3. By compiling the source code and using the compiled binary to execute the program. For example: `./build/llvm/bin/clang --target=aarch64-none-elf -march=armv8-a -c test.c -flto -fsanitize=cfi -fvisibility=hidden`

Previous patch version did not work for scenario 3, and this patch version fixes it. 