### PR TITLE
Add nightly build and test workflow for ATfE

### DIFF
--- a/.github/workflows/atfe_nightly_build_and_test.yml
+++ b/.github/workflows/atfe_nightly_build_and_test.yml
@@ -31,13 +31,13 @@ jobs:
             test_script: test.sh
             runner: ubuntu-22.04
           - build_script: build_llvmlibc_overlay.sh
-            test_script: test.sh
+            test_script: ''
             runner: ubuntu-22.04
           - build_script: build_newlib_nano_overlay.sh
-            test_script: test.sh
+            test_script: ''
             runner: ubuntu-22.04
           - build_script: build_newlib_overlay.sh
-            test_script: test.sh
+            test_script: ''
             runner: ubuntu-22.04
 
     steps:
@@ -51,6 +51,7 @@ jobs:
         run: ./arm-software/embedded/scripts/${{ matrix.build_script }}
 
       - name: Test ${{ matrix.test_script }}
+        if: matrix.test_script != ''
         run: ./arm-software/embedded/scripts/${{ matrix.test_script }}
 
       - name: Upload test results

--- a/.github/workflows/atfe_nightly_build_and_test.yml
+++ b/.github/workflows/atfe_nightly_build_and_test.yml
@@ -45,14 +45,26 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: ./arm-software/embedded/scripts/install_dependencies.sh
+        run: bash ./arm-software/embedded/scripts/install_dependencies.sh
+
+      - name: Apply llvm-project patches
+        run: |
+          python3 arm-software/embedded/cmake/patch_repo.py \
+            --method apply \
+            arm-software/embedded/patches/llvm-project
+
+      - name: Apply llvm-project-perf patches
+        run: |
+          python3 arm-software/embedded/cmake/patch_repo.py \
+            --method apply \
+            arm-software/embedded/patches/llvm-project-perf
 
       - name: Build ${{ matrix.build_script }}
-        run: ./arm-software/embedded/scripts/${{ matrix.build_script }}
+        run: bash ./arm-software/embedded/scripts/${{ matrix.build_script }}
 
       - name: Test ${{ matrix.test_script }}
         if: matrix.test_script != ''
-        run: ./arm-software/embedded/scripts/${{ matrix.test_script }}
+        run: bash ./arm-software/embedded/scripts/${{ matrix.test_script }}
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
@@ -62,3 +74,13 @@ jobs:
           path: |
             build/**/*results.xml
             build/**/*.junit.xml
+
+      - name: Upload built packages
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: built-packages-${{ matrix.build_script }}
+          path: |
+            build/**/*.dmg
+            build/**/*.tar.xz
+            build/**/*.zip

--- a/.github/workflows/atfe_nightly_build_and_test.yml
+++ b/.github/workflows/atfe_nightly_build_and_test.yml
@@ -1,0 +1,63 @@
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This workflow runs all build scripts in parallel on Linux.
+# It is intended to be triggered as part of a **nightly build** to
+# validate all build configurations and test them automatically.
+#
+# Each build script is paired with a corresponding test script using
+# a matrix strategy. Each build+test pair runs as a separate job,
+# allowing for concurrency and clear traceability of failures.
+
+name: ATfE Nightly Build and Test
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'  # Every day at 02:00 UTC
+
+jobs:
+  build-and-test-toolchain:
+    name: Build ${{ matrix.build_script }} + Test ${{ matrix.test_script }} on ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
+
+    strategy:
+      fail-fast: false  # Prevents one job failure from cancelling all
+      matrix:
+        include:
+          - build_script: build.sh
+            test_script: test.sh
+            runner: ubuntu-22.04
+          - build_script: build_llvmlibc_overlay.sh
+            test_script: test.sh
+            runner: ubuntu-22.04
+          - build_script: build_newlib_nano_overlay.sh
+            test_script: test.sh
+            runner: ubuntu-22.04
+          - build_script: build_newlib_overlay.sh
+            test_script: test.sh
+            runner: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: ./arm-software/embedded/scripts/install_dependencies.sh
+
+      - name: Build ${{ matrix.build_script }}
+        run: ./arm-software/embedded/scripts/${{ matrix.build_script }}
+
+      - name: Test ${{ matrix.test_script }}
+        run: ./arm-software/embedded/scripts/${{ matrix.test_script }}
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-${{ matrix.build_script }}
+          path: |
+            build/**/*results.xml
+            build/**/*.junit.xml

--- a/arm-software/embedded/scripts/install_dependencies.sh
+++ b/arm-software/embedded/scripts/install_dependencies.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set -e
+
+# This script installs the essential build dependencies for ATfE.
+
+sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+    cmake \
+    ninja-build \
+    clang

--- a/arm-software/embedded/scripts/install_dependencies.sh
+++ b/arm-software/embedded/scripts/install_dependencies.sh
@@ -4,12 +4,18 @@
 # Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# This script installs the essential build dependencies for ATfE.
 
 set -e
 
-# This script installs the essential build dependencies for ATfE.
-
 sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-    cmake \
-    ninja-build \
-    clang
+    cmake=3.22.1-1ubuntu1.22.04.2 \
+    ninja-build=1.10.1-1 \
+    clang=1:14.0-55~exp2 \
+    python3-pip \
+    python3-setuptools
+
+# Upgrade pip and install meson with a pinned version
+python3 -m pip install --upgrade pip
+python3 -m pip install meson==1.2.3

--- a/arm-software/embedded/versions.json
+++ b/arm-software/embedded/versions.json
@@ -12,7 +12,7 @@
       "tag": "main"
     },
     "newlib": {
-      "url": "https://sourceware.org/git/newlib-cygwin.git",
+      "url": "https://github.com/bminor/newlib.git",
       "tagType": "tag",
       "tag": "newlib-4.5.0"
     }


### PR DESCRIPTION
Add nightly build and test workflow for ATfE

-  Initial support for Linux Ubuntu 22.04
-  Run all build scripts in parallel
-  Add install dependencies script
-  Update source for Newlib. Use GitHub mirror

