### PR TITLE
Fix shell quoting in embedded/scripts directory.

### DIFF
--- a/arm-software/embedded/scripts/build.sh
+++ b/arm-software/embedded/scripts/build.sh
@@ -16,7 +16,7 @@
 set -ex
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-REPO_ROOT=$( git -C ${SCRIPT_DIR} rev-parse --show-toplevel )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
 
 clang --version
 
@@ -28,8 +28,8 @@ if [[ ! -z "${FVP_INSTALL_DIR}" ]]; then
     EXTRA_CMAKE_ARGS="${EXTRA_CMAKE_ARGS} -DENABLE_FVP_TESTING=ON -DFVP_INSTALL_DIR=${FVP_INSTALL_DIR}"
 fi
 
-mkdir -p ${REPO_ROOT}/build
-cd ${REPO_ROOT}/build
+mkdir -p "${REPO_ROOT}"/build
+cd "${REPO_ROOT}"/build
 
 cmake ../arm-software/embedded -GNinja -DFETCHCONTENT_QUIET=OFF ${EXTRA_CMAKE_ARGS}
 ninja package-llvm-toolchain

--- a/arm-software/embedded/scripts/build_llvmlibc_overlay.sh
+++ b/arm-software/embedded/scripts/build_llvmlibc_overlay.sh
@@ -16,11 +16,11 @@ export CC=clang
 export CXX=clang++
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-REPO_ROOT=$( git -C ${SCRIPT_DIR} rev-parse --show-toplevel )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
 BUILD_DIR=${REPO_ROOT}/build_llvmlibc_overlay
 
-mkdir -p ${BUILD_DIR}
-cd ${BUILD_DIR}
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
 
 cmake ../arm-software/embedded -GNinja -DFETCHCONTENT_QUIET=OFF -DLLVM_TOOLCHAIN_C_LIBRARY=llvmlibc -DLLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL=on
 ninja package-llvm-toolchain

--- a/arm-software/embedded/scripts/build_llvmlibc_toolchain.sh
+++ b/arm-software/embedded/scripts/build_llvmlibc_toolchain.sh
@@ -16,11 +16,11 @@ export CC=clang
 export CXX=clang++
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-REPO_ROOT=$( git -C ${SCRIPT_DIR} rev-parse --show-toplevel )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
 BUILD_DIR=${REPO_ROOT}/build_llvmlibc_toolchain
 
-mkdir -p ${BUILD_DIR}
-cd ${BUILD_DIR}
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
 
 cmake ../arm-software/embedded -GNinja -DFETCHCONTENT_QUIET=OFF -DLLVM_TOOLCHAIN_C_LIBRARY=llvmlibc
 ninja package-llvm-toolchain

--- a/arm-software/embedded/scripts/build_newlib_nano_overlay.sh
+++ b/arm-software/embedded/scripts/build_newlib_nano_overlay.sh
@@ -16,11 +16,11 @@ export CC=clang
 export CXX=clang++
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-REPO_ROOT=$( git -C ${SCRIPT_DIR} rev-parse --show-toplevel )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
 BUILD_DIR=${REPO_ROOT}/build_newlib_nano_overlay
 
-mkdir -p ${BUILD_DIR}
-cd ${BUILD_DIR}
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
 
 cmake ../arm-software/embedded -GNinja -DFETCHCONTENT_QUIET=OFF -DLLVM_TOOLCHAIN_C_LIBRARY=newlib-nano -DLLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL=on
 ninja package-llvm-toolchain

--- a/arm-software/embedded/scripts/build_newlib_overlay.sh
+++ b/arm-software/embedded/scripts/build_newlib_overlay.sh
@@ -16,11 +16,11 @@ export CC=clang
 export CXX=clang++
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-REPO_ROOT=$( git -C ${SCRIPT_DIR} rev-parse --show-toplevel )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
 BUILD_DIR=${REPO_ROOT}/build_newlib_overlay
 
-mkdir -p ${BUILD_DIR}
-cd ${BUILD_DIR}
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
 
 cmake ../arm-software/embedded -GNinja -DFETCHCONTENT_QUIET=OFF -DLLVM_TOOLCHAIN_C_LIBRARY=newlib -DLLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL=on
 ninja package-llvm-toolchain

--- a/arm-software/embedded/scripts/test.sh
+++ b/arm-software/embedded/scripts/test.sh
@@ -13,9 +13,9 @@
 set -ex
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-REPO_ROOT=$( git -C ${SCRIPT_DIR} rev-parse --show-toplevel )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
 
-cd ${REPO_ROOT}/build
+cd "${REPO_ROOT}"/build
 
 # If a test fails, lit will ordinarily return a non-zero result,
 # which prevents further testing. Setting the --ignore-fail option

--- a/arm-software/embedded/scripts/test_libcxx.sh
+++ b/arm-software/embedded/scripts/test_libcxx.sh
@@ -16,7 +16,7 @@
 set -ex
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-REPO_ROOT=$( git -C ${SCRIPT_DIR} rev-parse --show-toplevel )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
 
 # If a test fails, lit will ordinarily return a non-zero result,
 # which prevents further testing. Setting the --ignore-fail flag
@@ -24,5 +24,5 @@ REPO_ROOT=$( git -C ${SCRIPT_DIR} rev-parse --show-toplevel )
 # full set of results.
 export LIT_OPTS="--ignore-fail"
 
-cd ${REPO_ROOT}/build
+cd "${REPO_ROOT}"/build
 ninja check-cxx


### PR DESCRIPTION
While reviewing #270 I noticed some missing quotes in the new script, and David spotted that that's because they're the same in all the other similar scripts. Fix the whole lot.

Building in a spacey directory might fail anyway (quite likely _something_ in the overall build edifice isn't prepared to cope). But we can at least fix the issues we find.