### PR TITLE
[ATfL] Restore obligatory linking with -ldl. Apparently this is needed for RHEL8

### DIFF
--- a/arm-software/linux/build.sh
+++ b/arm-software/linux/build.sh
@@ -382,6 +382,8 @@ shared_lib_build() {
     cp -d ${ATFL_DIR}.libs/lib/libFortranRuntime.so* \
         "${ATFL_DIR}/lib/${ATFL_TARGET_TRIPLE}"
     rm -r "${ATFL_DIR}.libs"
+    echo '-L<CFGDIR>/../runtimes/runtimes-bins/openmp/runtime/src $-Wl,--push-state $-Wl,--as-needed $-lomp $-ldl $-Wl,--pop-state' >bin/clang.cfg
+    echo '-L<CFGDIR>/../runtimes/runtimes-bins/openmp/runtime/src $-Wl,--push-state $-Wl,--as-needed $-lomp $-ldl $-Wl,--pop-state' >bin/clang++.cfg
     run_command ninja ${NINJA_ARGS} check-all | tee -a "${LOGS_DIR}/shared_lib.txt"
 }
 


### PR DESCRIPTION
It's a cherry-pick from the arm-software branch.

In my previous commit I've misread the reason why those two lines were introduced. Now we cannot build for RHEL8 and this patch restores those two lines.