### PR TITLE
[ATfE][llvmlibc] Use the right one of {arm,aarch64}/entrypoints.txt

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -619,7 +619,7 @@ if(C_LIBRARY STREQUAL llvmlibc)
     set(LIBC_CFG_DIR ${CMAKE_BINARY_DIR}/llvmlibc-config)
     file(COPY
         ${llvmproject_src_dir}/libc/config/baremetal/config.json
-        ${llvmproject_src_dir}/libc/config/baremetal/arm/.
+        ${llvmproject_src_dir}/libc/config/baremetal/${cpu_family}/.
         DESTINATION
         ${LIBC_CFG_DIR}
     )


### PR DESCRIPTION
Our AArch64 builds of LLVM libc have been failing recently on the `#error` in `libc/src/math/generic/atan2l.cpp`, which knows how to implement `atan2l` as a trivial wrapper on `atan2` if long double is the same type as double, but has no fallback otherwise.

`atan2l` is included in our libc build by the configuration file `libc/config/baremetal/arm/entrypoints.txt`, which is designed for AArch32, where long double _is_ the same as double. We were unconditionally using the libc/config/baremetal/arm subdirectory, for both 32- and 64-bit libc builds, because at the time it was the best thing available – there wasn't an `aarch64` subdir alongside it. But now there is an `aarch64` subdirectory, and _its_ `entrypoints.txt` leaves out atan2l (presumably for exactly this reason), so we can switch over to using it, fixing this build failure.