### PR TITLE
Install Qemu on GH actions hosts

### DIFF
--- a/.github/workflows/atfe_nightly_build_and_test.yml
+++ b/.github/workflows/atfe_nightly_build_and_test.yml
@@ -22,6 +22,8 @@ jobs:
   build-and-test-toolchain:
     name: Build ${{ matrix.build_script }} + Test ${{ matrix.test_script }} on ${{ matrix.runner }}
     runs-on: ${{ matrix.runner }}
+    # Ensure the workflow only runs on the arm-toolchain repository and not on forks
+    if: github.repository == 'arm/arm-toolchain'
 
     strategy:
       fail-fast: false  # Prevents one job failure from cancelling all

--- a/arm-software/embedded/scripts/install_dependencies.sh
+++ b/arm-software/embedded/scripts/install_dependencies.sh
@@ -14,7 +14,8 @@ sudo apt-get update && sudo apt-get install -y --no-install-recommends \
     ninja-build=1.10.1-1 \
     clang=1:14.0-55~exp2 \
     python3-pip \
-    python3-setuptools
+    python3-setuptools \
+    qemu-system-x86=1:6.2+dfsg-2ubuntu6.26
 
 # Upgrade pip and install meson with a pinned version
 python3 -m pip install --upgrade pip

--- a/arm-software/embedded/scripts/install_dependencies.sh
+++ b/arm-software/embedded/scripts/install_dependencies.sh
@@ -15,7 +15,8 @@ sudo apt-get update && sudo apt-get install -y --no-install-recommends \
     clang=1:14.0-55~exp2 \
     python3-pip \
     python3-setuptools \
-    qemu-system-x86=1:6.2+dfsg-2ubuntu6.26
+    qemu-system-x86=1:6.2+dfsg-2ubuntu6.26 \
+    qemu-system-arm=1:6.2+dfsg-2ubuntu6.26
 
 # Upgrade pip and install meson with a pinned version
 python3 -m pip install --upgrade pip

--- a/arm-software/embedded/scripts/install_dependencies.sh
+++ b/arm-software/embedded/scripts/install_dependencies.sh
@@ -15,7 +15,6 @@ sudo apt-get update && sudo apt-get install -y --no-install-recommends \
     clang=1:14.0-55~exp2 \
     python3-pip \
     python3-setuptools \
-    qemu-system-x86=1:6.2+dfsg-2ubuntu6.26 \
     qemu-system-arm=1:6.2+dfsg-2ubuntu6.26
 
 # Upgrade pip and install meson with a pinned version


### PR DESCRIPTION
- The missing package is causing an error when running build.sh
- Ensure the workflow only runs on the arm-toolchain repository