### PR TITLE
[ATfE] Add required strictly aligned variants for Armv8.1-M Main

### DIFF
--- a/arm-software/embedded/arm-multilib/json/multilib.json
+++ b/arm-software/embedded/arm-multilib/json/multilib.json
@@ -486,9 +486,19 @@
             "flags": "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+mve -mfpu=none -munaligned-access"
         },
         {
+            "variant": "armv8.1m.main_hard_nofp_mve_exn_rtti",
+            "json": "armv8.1m.main_hard_nofp_mve_exn_rtti.json",
+            "flags": "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+mve -mfpu=none -mno-unaligned-access"
+        },
+        {
             "variant": "armv8.1m.main_hard_nofp_mve_unaligned",
             "json": "armv8.1m.main_hard_nofp_mve_unaligned.json",
             "flags": "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+mve -mfpu=none -fno-exceptions -fno-rtti -munaligned-access"
+        },
+        {
+            "variant": "armv8.1m.main_hard_nofp_mve",
+            "json": "armv8.1m.main_hard_nofp_mve.json",
+            "flags": "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+mve -mfpu=none -fno-exceptions -fno-rtti -mno-unaligned-access"
         },
         {
             "variant": "armv8.1m.main_softfp_nomve",
@@ -501,9 +511,19 @@
             "flags": "--target=thumbv8.1m.main-unknown-none-eabi -mfpu=none -mbranch-protection=pac-ret+bti -munaligned-access"
         },
         {
+            "variant": "armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti",
+            "json": "armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti.json",
+            "flags": "--target=thumbv8.1m.main-unknown-none-eabi -mfpu=none -mbranch-protection=pac-ret+bti -mno-unaligned-access"
+        },
+        {
             "variant": "armv8.1m.main_soft_nofp_nomve_pacret_bti_unaligned",
             "json": "armv8.1m.main_soft_nofp_nomve_pacret_bti_unaligned.json",
             "flags": "--target=thumbv8.1m.main-unknown-none-eabi -mfpu=none -mbranch-protection=pac-ret+bti -fno-exceptions -fno-rtti -munaligned-access"
+        },
+        {
+            "variant": "armv8.1m.main_soft_nofp_nomve_pacret_bti",
+            "json": "armv8.1m.main_soft_nofp_nomve_pacret_bti.json",
+            "flags": "--target=thumbv8.1m.main-unknown-none-eabi -mfpu=none -mbranch-protection=pac-ret+bti -fno-exceptions -fno-rtti -mno-unaligned-access"
         },
         {
             "variant": "armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti_unaligned",
@@ -511,9 +531,19 @@
             "flags": "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti -munaligned-access"
         },
         {
+            "variant": "armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti",
+            "json": "armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti.json",
+            "flags": "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti -mno-unaligned-access"
+        },
+        {
             "variant": "armv8.1m.main_hard_fp_nomve_pacret_bti_unaligned",
             "json": "armv8.1m.main_hard_fp_nomve_pacret_bti_unaligned.json",
             "flags": "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti -fno-exceptions -fno-rtti -munaligned-access"
+        },
+        {
+            "variant": "armv8.1m.main_hard_fp_nomve_pacret_bti",
+            "json": "armv8.1m.main_hard_fp_nomve_pacret_bti.json",
+            "flags": "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti -fno-exceptions -fno-rtti -mno-unaligned-access"
         },
         {
             "variant": "armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti_unaligned",
@@ -521,9 +551,19 @@
             "flags": "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti -munaligned-access"
         },
         {
+            "variant": "armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti",
+            "json": "armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti.json",
+            "flags": "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti -mno-unaligned-access"
+        },
+        {
             "variant": "armv8.1m.main_hard_fpdp_nomve_pacret_bti_unaligned",
             "json": "armv8.1m.main_hard_fpdp_nomve_pacret_bti_unaligned.json",
             "flags": "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti -fno-exceptions -fno-rtti -munaligned-access"
+        },
+        {
+            "variant": "armv8.1m.main_hard_fpdp_nomve_pacret_bti",
+            "json": "armv8.1m.main_hard_fpdp_nomve_pacret_bti.json",
+            "flags": "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+fp16 -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti -fno-exceptions -fno-rtti -mno-unaligned-access"
         },
         {
             "variant": "armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti_unaligned",
@@ -531,9 +571,19 @@
             "flags": "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+mve -mfpu=none -mbranch-protection=pac-ret+bti -munaligned-access"
         },
         {
+            "variant": "armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti",
+            "json": "armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti.json",
+            "flags": "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+mve -mfpu=none -mbranch-protection=pac-ret+bti -mno-unaligned-access"
+        },
+        {
             "variant": "armv8.1m.main_hard_nofp_mve_pacret_bti_unaligned",
             "json": "armv8.1m.main_hard_nofp_mve_pacret_bti_unaligned.json",
             "flags": "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+mve -mfpu=none -mbranch-protection=pac-ret+bti -fno-exceptions -fno-rtti -munaligned-access"
+        },
+        {
+            "variant": "armv8.1m.main_hard_nofp_mve_pacret_bti",
+            "json": "armv8.1m.main_hard_nofp_mve_pacret_bti.json",
+            "flags": "--target=thumbv8.1m.main-unknown-none-eabihf -march=thumbv8.1m.main+mve -mfpu=none -mbranch-protection=pac-ret+bti -fno-exceptions -fno-rtti -mno-unaligned-access"
         }
     ]
 }

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti.json
@@ -1,0 +1,40 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "armv8.1m.main",
+            "VARIANT": "armv8.1m.main_hard_fp_nomve_pacret_bti",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+nomve+pacbti -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti -mno-unaligned-access",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "fvp",
+            "FVP_MODEL": "corstone-310",
+            "FVP_CONFIG": "cortex-m85 m-pacbti m-fp mve-none",
+            "BOOT_FLASH_ADDRESS": "0x01000000",
+            "BOOT_FLASH_SIZE": "2M",
+            "FLASH_ADDRESS": "0x60000000",
+            "FLASH_SIZE": "0x1000000",
+            "RAM_ADDRESS": "0x61000000",
+            "RAM_SIZE": "0x1000000",
+            "STACK_SIZE": "4K"
+        },
+        "picolibc": {
+            "PICOLIBC_BUILD_TYPE": "release",
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "newlib": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "llvmlibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti.json
@@ -1,0 +1,40 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "armv8.1m.main",
+            "VARIANT": "armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+nomve+pacbti -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti -mno-unaligned-access",
+            "ENABLE_EXCEPTIONS": "ON",
+            "ENABLE_RTTI": "ON",
+            "TEST_EXECUTOR": "fvp",
+            "FVP_MODEL": "corstone-310",
+            "FVP_CONFIG": "cortex-m85 m-pacbti m-fp mve-none",
+            "BOOT_FLASH_ADDRESS": "0x01000000",
+            "BOOT_FLASH_SIZE": "2M",
+            "FLASH_ADDRESS": "0x60000000",
+            "FLASH_SIZE": "0x1000000",
+            "RAM_ADDRESS": "0x61000000",
+            "RAM_SIZE": "0x1000000",
+            "STACK_SIZE": "4K"
+        },
+        "picolibc": {
+            "PICOLIBC_BUILD_TYPE": "release",
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "newlib": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "llvmlibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti.json
@@ -1,0 +1,40 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "armv8.1m.main",
+            "VARIANT": "armv8.1m.main_hard_fpdp_nomve_pacret_bti",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+nomve+pacbti -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti -mno-unaligned-access",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "fvp",
+            "FVP_MODEL": "corstone-310",
+            "FVP_CONFIG": "cortex-m85 m-pacbti m-fp mve-none",
+            "BOOT_FLASH_ADDRESS": "0x01000000",
+            "BOOT_FLASH_SIZE": "2M",
+            "FLASH_ADDRESS": "0x60000000",
+            "FLASH_SIZE": "0x1000000",
+            "RAM_ADDRESS": "0x61000000",
+            "RAM_SIZE": "0x1000000",
+            "STACK_SIZE": "4K"
+        },
+        "picolibc": {
+            "PICOLIBC_BUILD_TYPE": "release",
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "newlib": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "llvmlibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti.json
@@ -1,0 +1,40 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "armv8.1m.main",
+            "VARIANT": "armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+nomve+pacbti -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti -mno-unaligned-access",
+            "ENABLE_EXCEPTIONS": "ON",
+            "ENABLE_RTTI": "ON",
+            "TEST_EXECUTOR": "fvp",
+            "FVP_MODEL": "corstone-310",
+            "FVP_CONFIG": "cortex-m85 m-pacbti m-fp mve-none",
+            "BOOT_FLASH_ADDRESS": "0x01000000",
+            "BOOT_FLASH_SIZE": "2M",
+            "FLASH_ADDRESS": "0x60000000",
+            "FLASH_SIZE": "0x1000000",
+            "RAM_ADDRESS": "0x61000000",
+            "RAM_SIZE": "0x1000000",
+            "STACK_SIZE": "4K"
+        },
+        "picolibc": {
+            "PICOLIBC_BUILD_TYPE": "release",
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "newlib": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "llvmlibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve.json
@@ -1,0 +1,40 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "armv8.1m.main",
+            "VARIANT": "armv8.1m.main_hard_nofp_mve",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+mve -mfpu=none -mno-unaligned-access",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "mps3-an547",
+            "QEMU_CPU": "cortex-m55",
+            "BOOT_FLASH_ADDRESS": "0x00000000",
+            "BOOT_FLASH_SIZE": "512K",
+            "FLASH_ADDRESS": "0x60000000",
+            "FLASH_SIZE": "0x1000000",
+            "RAM_ADDRESS": "0x61000000",
+            "RAM_SIZE": "0x1000000",
+            "STACK_SIZE": "4K"
+        },
+        "picolibc": {
+            "PICOLIBC_BUILD_TYPE": "release",
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "newlib": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "llvmlibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_exn_rtti.json
@@ -1,0 +1,40 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "armv8.1m.main",
+            "VARIANT": "armv8.1m.main_hard_nofp_mve_exn_rtti",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+mve -mfpu=none -mno-unaligned-access",
+            "ENABLE_EXCEPTIONS": "ON",
+            "ENABLE_RTTI": "ON",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "mps3-an547",
+            "QEMU_CPU": "cortex-m55",
+            "BOOT_FLASH_ADDRESS": "0x00000000",
+            "BOOT_FLASH_SIZE": "512K",
+            "FLASH_ADDRESS": "0x60000000",
+            "FLASH_SIZE": "0x1000000",
+            "RAM_ADDRESS": "0x61000000",
+            "RAM_SIZE": "0x1000000",
+            "STACK_SIZE": "4K"
+        },
+        "picolibc": {
+            "PICOLIBC_BUILD_TYPE": "release",
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "newlib": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "llvmlibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti.json
@@ -1,0 +1,40 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "armv8.1m.main",
+            "VARIANT": "armv8.1m.main_hard_nofp_mve_pacret_bti",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+mve+pacbti -mfpu=none -mbranch-protection=pac-ret+bti -mno-unaligned-access",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "fvp",
+            "FVP_MODEL": "corstone-310",
+            "FVP_CONFIG": "cortex-m85 m-pacbti m-nofp mve-int",
+            "BOOT_FLASH_ADDRESS": "0x01000000",
+            "BOOT_FLASH_SIZE": "2M",
+            "FLASH_ADDRESS": "0x60000000",
+            "FLASH_SIZE": "0x1000000",
+            "RAM_ADDRESS": "0x61000000",
+            "RAM_SIZE": "0x1000000",
+            "STACK_SIZE": "4K"
+        },
+        "picolibc": {
+            "PICOLIBC_BUILD_TYPE": "release",
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "newlib": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "llvmlibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti.json
@@ -1,0 +1,40 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "armv8.1m.main",
+            "VARIANT": "armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+mve+pacbti -mfpu=none -mbranch-protection=pac-ret+bti -mno-unaligned-access",
+            "ENABLE_EXCEPTIONS": "ON",
+            "ENABLE_RTTI": "ON",
+            "TEST_EXECUTOR": "fvp",
+            "FVP_MODEL": "corstone-310",
+            "FVP_CONFIG": "cortex-m85 m-pacbti m-nofp mve-int",
+            "BOOT_FLASH_ADDRESS": "0x01000000",
+            "BOOT_FLASH_SIZE": "2M",
+            "FLASH_ADDRESS": "0x60000000",
+            "FLASH_SIZE": "0x1000000",
+            "RAM_ADDRESS": "0x61000000",
+            "RAM_SIZE": "0x1000000",
+            "STACK_SIZE": "4K"
+        },
+        "picolibc": {
+            "PICOLIBC_BUILD_TYPE": "release",
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "newlib": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "llvmlibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti.json
@@ -1,0 +1,40 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "armv8.1m.main",
+            "VARIANT": "armv8.1m.main_soft_nofp_nomve_pacret_bti",
+            "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv8.1m.main+nomve+pacbti -mfpu=none -mbranch-protection=pac-ret+bti -mno-unaligned-access",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "fvp",
+            "FVP_MODEL": "corstone-310",
+            "FVP_CONFIG": "cortex-m85 m-pacbti m-nofp mve-none",
+            "BOOT_FLASH_ADDRESS": "0x01000000",
+            "BOOT_FLASH_SIZE": "2M",
+            "FLASH_ADDRESS": "0x60000000",
+            "FLASH_SIZE": "0x1000000",
+            "RAM_ADDRESS": "0x61000000",
+            "RAM_SIZE": "0x1000000",
+            "STACK_SIZE": "4K"
+        },
+        "picolibc": {
+            "PICOLIBC_BUILD_TYPE": "release",
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "newlib": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "llvmlibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti.json
@@ -1,0 +1,40 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "armv8.1m.main",
+            "VARIANT": "armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti",
+            "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv8.1m.main+nomve+pacbti -mfpu=none -mbranch-protection=pac-ret+bti -mno-unaligned-access",
+            "ENABLE_EXCEPTIONS": "ON",
+            "ENABLE_RTTI": "ON",
+            "TEST_EXECUTOR": "fvp",
+            "FVP_MODEL": "corstone-310",
+            "FVP_CONFIG": "cortex-m85 m-pacbti m-nofp mve-none",
+            "BOOT_FLASH_ADDRESS": "0x01000000",
+            "BOOT_FLASH_SIZE": "2M",
+            "FLASH_ADDRESS": "0x60000000",
+            "FLASH_SIZE": "0x1000000",
+            "RAM_ADDRESS": "0x61000000",
+            "RAM_SIZE": "0x1000000",
+            "STACK_SIZE": "4K"
+        },
+        "picolibc": {
+            "PICOLIBC_BUILD_TYPE": "release",
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "newlib": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "llvmlibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/arm-software/embedded/test/multilib/armv8.1m.main.test
+++ b/arm-software/embedded/test/multilib/armv8.1m.main.test
@@ -45,10 +45,109 @@
 # HARD-NOFP-MVE-EXN-RTTI-UNALIGNED: arm-none-eabi/armv8.1m.main_hard_nofp_mve_exn_rtti_unaligned{{$}}
 # HARD-NOFP-MVE-EXN-RTTI-UNALIGNED-EMPTY:
 
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=none -mno-unaligned-access | FileCheck --check-prefix=HARD-NOFP-MVE-EXN-RTTI %s
+# HARD-NOFP-MVE-EXN-RTTI: arm-none-eabi/armv8.1m.main_hard_nofp_mve_exn_rtti{{$}}
+# HARD-NOFP-MVE-EXN-RTTI-EMPTY:
+
 # RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=none -fno-exceptions -fno-rtti | FileCheck --check-prefix=HARD-NOFP-MVE-UNALIGNED %s
 # RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=none -fno-exceptions -fno-rtti -munaligned-access | FileCheck --check-prefix=HARD-NOFP-MVE-UNALIGNED %s
 # HARD-NOFP-MVE-UNALIGNED: arm-none-eabi/armv8.1m.main_hard_nofp_mve_unaligned{{$}}
 # HARD-NOFP-MVE-UNALIGNED-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=none -fno-exceptions -fno-rtti -mno-unaligned-access | FileCheck --check-prefix=HARD-NOFP-MVE %s
+# HARD-NOFP-MVE: arm-none-eabi/armv8.1m.main_hard_nofp_mve{{$}}
+# HARD-NOFP-MVE-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti -mno-unaligned-access | FileCheck --check-prefix=HARD-FPDP-PACBTI-EXN-RTTI %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti -mno-unaligned-access | FileCheck --check-prefix=HARD-FPDP-PACBTI-EXN-RTTI %s
+# HARD-FPDP-PACBTI-EXN-RTTI: arm-none-eabi/armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti{{$}}
+# HARD-FPDP-PACBTI-EXN-RTTI-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti | FileCheck --check-prefix=HARD-FPDP-PACBTI-EXN-RTTI-UNALIGNED %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti -munaligned-access | FileCheck --check-prefix=HARD-FPDP-PACBTI-EXN-RTTI-UNALIGNED %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti | FileCheck --check-prefix=HARD-FPDP-PACBTI-EXN-RTTI-UNALIGNED %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti -munaligned-access | FileCheck --check-prefix=HARD-FPDP-PACBTI-EXN-RTTI-UNALIGNED %s
+# HARD-FPDP-PACBTI-EXN-RTTI-UNALIGNED: arm-none-eabi/armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti_unaligned{{$}}
+# HARD-FPDP-PACBTI-EXN-RTTI-UNALIGNED-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main -mfpu=fp-armv8-fullfp16-d16 -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti -mno-unaligned-access | FileCheck --check-prefix=HARD-FPDP-PACBTI %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=fp-armv8-fullfp16-d16 -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti -mno-unaligned-access | FileCheck --check-prefix=HARD-FPDP-PACBTI %s
+# HARD-FPDP-PACBTI: arm-none-eabi/armv8.1m.main_hard_fpdp_nomve_pacret_bti{{$}}
+# HARD-FPDP-PACBTI-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main -mfpu=fp-armv8-fullfp16-d16 -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti | FileCheck --check-prefix=HARD-FPDP-PACBTI-UNALIGNED %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main -mfpu=fp-armv8-fullfp16-d16 -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti -munaligned-access | FileCheck --check-prefix=HARD-FPDP-PACBTI-UNALIGNED %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=fp-armv8-fullfp16-d16 -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti | FileCheck --check-prefix=HARD-FPDP-PACBTI-UNALIGNED %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=fp-armv8-fullfp16-d16 -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti -munaligned-access | FileCheck --check-prefix=HARD-FPDP-PACBTI-UNALIGNED %s
+# HARD-FPDP-PACBTI-UNALIGNED: arm-none-eabi/armv8.1m.main_hard_fpdp_nomve_pacret_bti_unaligned{{$}}
+# HARD-FPDP-PACBTI-UNALIGNED-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti -mno-unaligned-access | FileCheck --check-prefix=HARD-FP-PACBTI-EXN-RTTI %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti -mno-unaligned-access | FileCheck --check-prefix=HARD-FP-PACBTI-EXN-RTTI %s
+# HARD-FP-PACBTI-EXN-RTTI: arm-none-eabi/armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti{{$}}
+# HARD-FP-PACBTI-EXN-RTTI-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti | FileCheck --check-prefix=HARD-FP-PACBTI-EXN-RTTI-UNALIGNED %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti -munaligned-access | FileCheck --check-prefix=HARD-FP-PACBTI-EXN-RTTI-UNALIGNED %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti | FileCheck --check-prefix=HARD-FP-PACBTI-EXN-RTTI-UNALIGNED %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti -munaligned-access | FileCheck --check-prefix=HARD-FP-PACBTI-EXN-RTTI-UNALIGNED %s
+# HARD-FP-PACBTI-EXN-RTTI-UNALIGNED: arm-none-eabi/armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti_unaligned{{$}}
+# HARD-FP-PACBTI-EXN-RTTI-UNALIGNED-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main -mfpu=fp-armv8-fullfp16-sp-d16 -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti -mno-unaligned-access | FileCheck --check-prefix=HARD-FP-PACBTI %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=fp-armv8-fullfp16-sp-d16 -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti -mno-unaligned-access | FileCheck --check-prefix=HARD-FP-PACBTI %s
+# HARD-FP-PACBTI: arm-none-eabi/armv8.1m.main_hard_fp_nomve_pacret_bti{{$}}
+# HARD-FP-PACBTI-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main -mfpu=fp-armv8-fullfp16-sp-d16 -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti | FileCheck --check-prefix=HARD-FP-PACBTI-UNALIGNED %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main -mfpu=fp-armv8-fullfp16-sp-d16 -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti -munaligned-access | FileCheck --check-prefix=HARD-FP-PACBTI-UNALIGNED %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=fp-armv8-fullfp16-sp-d16 -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti | FileCheck --check-prefix=HARD-FP-PACBTI-UNALIGNED %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=fp-armv8-fullfp16-sp-d16 -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti -munaligned-access | FileCheck --check-prefix=HARD-FP-PACBTI-UNALIGNED %s
+# HARD-FP-PACBTI-UNALIGNED: arm-none-eabi/armv8.1m.main_hard_fp_nomve_pacret_bti_unaligned{{$}}
+# HARD-FP-PACBTI-UNALIGNED-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=none -mbranch-protection=pac-ret+bti -mno-unaligned-access | FileCheck --check-prefix=HARD-NOFP-MVE-PACBTI-EXN-RTTI %s
+# HARD-NOFP-MVE-PACBTI-EXN-RTTI: arm-none-eabi/armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti{{$}}
+# HARD-NOFP-MVE-PACBTI-EXN-RTTI-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=none -mbranch-protection=pac-ret+bti | FileCheck --check-prefix=HARD-NOFP-MVE-PACBTI-EXN-RTTI-UNALIGNED %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=none -mbranch-protection=pac-ret+bti -munaligned-access | FileCheck --check-prefix=HARD-NOFP-MVE-PACBTI-EXN-RTTI-UNALIGNED %s
+# HARD-NOFP-MVE-PACBTI-EXN-RTTI-UNALIGNED: arm-none-eabi/armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti_unaligned{{$}}
+# HARD-NOFP-MVE-PACBTI-EXN-RTTI-UNALIGNED-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=none -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti -mno-unaligned-access | FileCheck --check-prefix=HARD-NOFP-MVE-PACBTI %s
+# HARD-NOFP-MVE-PACBTI: arm-none-eabi/armv8.1m.main_hard_nofp_mve_pacret_bti{{$}}
+# HARD-NOFP-MVE-PACBTI-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=none -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti | FileCheck --check-prefix=HARD-NOFP-MVE-PACBTI-UNALIGNED %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabihf -march=armv8.1m.main+mve -mfpu=none -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti -munaligned-access | FileCheck --check-prefix=HARD-NOFP-MVE-PACBTI-UNALIGNED %s
+# HARD-NOFP-MVE-PACBTI-UNALIGNED: arm-none-eabi/armv8.1m.main_hard_nofp_mve_pacret_bti_unaligned{{$}}
+# HARD-NOFP-MVE-PACBTI-UNALIGNED-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabi -march=armv8.1m.main -mfpu=none -mbranch-protection=pac-ret+bti -mno-unaligned-access | FileCheck --check-prefix=SOFT-NOFP-PACBTI-EXN-RTTI %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabi -march=armv8.1m.main+mve -mfpu=none -mbranch-protection=pac-ret+bti -mno-unaligned-access | FileCheck --check-prefix=SOFT-NOFP-PACBTI-EXN-RTTI %s
+# SOFT-NOFP-PACBTI-EXN-RTTI: arm-none-eabi/armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti{{$}}
+# SOFT-NOFP-PACBTI-EXN-RTTI-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabi -march=armv8.1m.main -mfpu=none -mbranch-protection=pac-ret+bti | FileCheck --check-prefix=SOFT-NOFP-PACBTI-EXN-RTTI-UNALIGNED %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabi -march=armv8.1m.main -mfpu=none -mbranch-protection=pac-ret+bti -munaligned-access | FileCheck --check-prefix=SOFT-NOFP-PACBTI-EXN-RTTI-UNALIGNED %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabi -march=armv8.1m.main+mve -mfpu=none -mbranch-protection=pac-ret+bti | FileCheck --check-prefix=SOFT-NOFP-PACBTI-EXN-RTTI-UNALIGNED %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabi -march=armv8.1m.main+mve -mfpu=none -mbranch-protection=pac-ret+bti -munaligned-access | FileCheck --check-prefix=SOFT-NOFP-PACBTI-EXN-RTTI-UNALIGNED %s
+# SOFT-NOFP-PACBTI-EXN-RTTI-UNALIGNED: arm-none-eabi/armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti_unaligned{{$}}
+# SOFT-NOFP-PACBTI-EXN-RTTI-UNALIGNED-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabi -march=armv8.1m.main -mfpu=none -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti -mno-unaligned-access | FileCheck --check-prefix=SOFT-NOFP-PACBTI %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabi -march=armv8.1m.main+mve -mfpu=none -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti -mno-unaligned-access | FileCheck --check-prefix=SOFT-NOFP-PACBTI %s
+# SOFT-NOFP-PACBTI: arm-none-eabi/armv8.1m.main_soft_nofp_nomve_pacret_bti{{$}}
+# SOFT-NOFP-PACBTI-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabi -march=armv8.1m.main -mfpu=none -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti | FileCheck --check-prefix=SOFT-NOFP-PACBTI-UNALIGNED %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabi -march=armv8.1m.main -mfpu=none -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti -munaligned-access | FileCheck --check-prefix=SOFT-NOFP-PACBTI-UNALIGNED %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabi -march=armv8.1m.main+mve -mfpu=none -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti | FileCheck --check-prefix=SOFT-NOFP-PACBTI-UNALIGNED %s
+# RUN: %clang -print-multi-directory --target=armv8.1m.main-none-eabi -march=armv8.1m.main+mve -mfpu=none -fno-exceptions -fno-rtti -mbranch-protection=pac-ret+bti -munaligned-access | FileCheck --check-prefix=SOFT-NOFP-PACBTI-UNALIGNED %s
+# SOFT-NOFP-PACBTI-UNALIGNED: arm-none-eabi/armv8.1m.main_soft_nofp_nomve_pacret_bti_unaligned{{$}}
+# SOFT-NOFP-PACBTI-UNALIGNED-EMPTY:
+
 
 ### Fallback to Armv7-M ###
 


### PR DESCRIPTION
Two non-PACBTI variants needed a strictly aligned counterpart:

 - armv8.1m.main_hard_nofp_mve
 - armv8.1m.main_hard_nofp_mve_exn_rtti

because no suitable Armv7-M variant exists for these two as a fallback option. The combination of hard FP ABI and no FPU is not covered by our Armv7-M variants.

On the PACBTI side, all the existing variants needed their strictly aligned counterparts. This is because it's not safe to fallback to Armv7-M variants in this case, as these are not built for PACBTI.

This patch introduces new strictly aligned variants for Armv8.1-M Main. Two of them are for non-PACBTI + hard FP ABI + no FPU, while the rest is for all the PACBTI variants.