### PR TITLE
[Automerge] Add workflow permissions for creating PRs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   Run-Automerge:
     runs-on: ubuntu-24.04-arm
+    permissions:
+      pull-requests: write
     if: github.repository == 'arm/arm-toolchain'
     strategy:
       matrix:


### PR DESCRIPTION
This adds the workflow permissions required for creating Pull Requests
to the Automerge workflow. This is required as the automerge script
needs to create new Pull Requests for merge conflicts that must be
resolved manually.
