### PR TITLE
Add feedback sections to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ the necessary libraries and tools for building C and C++ toolchains
 for:
 * Bare-metal: [Arm Toolchain for Embedded](https://github.com/arm/arm-toolchain/blob/arm-software/arm-software/embedded/README.md)
 * Native AArch64 Linux: [Arm Toolchain for Linux](https://github.com/arm/arm-toolchain/blob/arm-software/arm-software/linux/README.md)
+
+## Quick Links
+
+Getting binary [releases](https://github.com/arm/arm-toolchain/releases) • Getting started for [Embedded](arm-software/embedded/README.md#getting-started) and [Linux](arm-software/linux/README.md#usage) • Reporting [issues](CONTRIBUTING.md#report-an-issue) • [Contributing](CONTRIBUTING.md)

--- a/arm-software/embedded/README.md
+++ b/arm-software/embedded/README.md
@@ -204,7 +204,8 @@ guide for detailed instructions.
 
 ## Providing feedback and reporting issues
 
-Please raise an issue via [Github issues](https://github.com/arm/arm-toolchain/issues).
+Please raise an issue via [Github issues](https://github.com/arm/arm-toolchain/issues)
+and add the `ATfE` label if it is specific to the Arm Toolchain for Embedded.
 
 ## Contributions and Pull Requests
 

--- a/arm-software/linux/README.md
+++ b/arm-software/linux/README.md
@@ -306,8 +306,9 @@ $ chrpath -l ./example
 
 ## Providing feedback and reporting issues
 
-Please raise an issue via [Github issues](https://github.com/arm/arm-toolchain/issues).
+Please raise an issue via [Github issues](https://github.com/arm/arm-toolchain/issues)
+and add the `ATfL` label if it is specific to the Arm Toolchain for Linux.
 
 ## Contributions and Pull Requests
 
-Please see the [Contribution Guide](docs/contributing.md) for details.
+Please see the [Contribution Guide](../../CONTRIBUTING.md) for details.

--- a/arm-software/linux/README.md
+++ b/arm-software/linux/README.md
@@ -303,3 +303,11 @@ $ armclang -fopenmp -o example example.o `pkg-config armpl-dynamic-lp64-omp --li
 $ chrpath -l ./example
 ./example: RUNPATH=$HOME/armpl/armpl_24.10_flang-new/lib/pkgconfig/../../lib:$HOME/atfl/lib/clang/20/lib/aarch64-unknown-linux-gnu:$HOME/atfl/bin/../lib/aarch64-unknown-linux-gnu
 ```
+
+## Providing feedback and reporting issues
+
+Please raise an issue via [Github issues](https://github.com/arm/arm-toolchain/issues).
+
+## Contributions and Pull Requests
+
+Please see the [Contribution Guide](docs/contributing.md) for details.


### PR DESCRIPTION
Add Quick Links section (including ways to provide feedback) to the main README. 
Add feedback and contribution sections at the end of Linux toolchain README.