### PR TITLE
[Automerge] Use App token when executing automerge script

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -43,4 +43,4 @@ jobs:
       - name: Run automerge
         run: python3 arm-software/ci/automerge.py --project-name ${{ github.repository }} --from-branch ${{ matrix.branches.from_branch }} --to-branch ${{ matrix.branches.to_branch }} --verbose
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
This updates the Automerge workflow to use a GitHub App token when
running the automerge.py script, instead of the regular GH_TOKEN. This
should allow the automerge scripts to create PRs in the
arm/arm-toolchain project when a merge conflict is encountered, as
workflows by default aren't allowed to do so.
