### PR TITLE
Add .local/bin to PATH

### DIFF
--- a/.github/workflows/atfe_nightly_build_and_test.yml
+++ b/.github/workflows/atfe_nightly_build_and_test.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Install dependencies
         run: bash ./arm-software/embedded/scripts/install_dependencies.sh
 
+      - name: Add ~/.local/bin to PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
       - name: Apply llvm-project patches
         run: |
           python3 arm-software/embedded/cmake/patch_repo.py \


### PR DESCRIPTION
- Meson is installed in ~/.local/bin
- We need to add the directory to the env PATH so that GitHub actions can use Meson