### PR TITLE
Update path to build package

### DIFF
--- a/.github/workflows/atfe_nightly_build_and_test.yml
+++ b/.github/workflows/atfe_nightly_build_and_test.yml
@@ -84,8 +84,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: success()
         with:
-          name: built-packages-${{ matrix.build_script }}
+          name: ATfE-packages-${{ matrix.build_script }}
           path: |
-            build/**/*.dmg
-            build/**/*.tar.xz
-            build/**/*.zip
+            build/ATfE-*.tar.xz
+            build/ATfE-*.zip


### PR DESCRIPTION
- The artifact folder contained two .tar.xz packages and some other directories not needed
- Change name of the artifact folder
- Remove .dmg package path ultil we have macOS runners