### PR TITLE
Fix build path for overlay builds

### DIFF
--- a/.github/workflows/atfe_nightly_build_and_test.yml
+++ b/.github/workflows/atfe_nightly_build_and_test.yml
@@ -76,13 +76,11 @@ jobs:
         if: always()
         with:
           name: test-results-${{ matrix.build_script }}
-          path: |
-            build/**/*results.xml
-            build/**/*.junit.xml
+          path: build/**/*.junit.xml
 
       - name: Upload built packages
         uses: actions/upload-artifact@v4
         if: success()
         with:
           name: ATfE-packages-${{ matrix.build_script }}
-          path: build/ATfE-*.tar.xz
+          path: build*/ATfE-*.tar.xz


### PR DESCRIPTION
- The overlay build packages were not found with the previous wildcard pattern
- Remove unused path for test results