### PR TITLE
[ATfE] Accept arm64 as well as aarch64 machine names in FVP scripts

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
+++ b/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
@@ -27,7 +27,7 @@ class FVP:
 uname_machine = uname().machine.lower()
 if uname_machine == "x86_64":
     platform_dir = "Linux64_GCC-9.3"
-elif uname_machine == "aarch64":
+elif uname_machine in ["aarch64", "arm64"]:
     platform_dir = "Linux64_armv8l_GCC-9.3"
 else:
     raise Exception(f"{uname_machine} is not a recognised uname machine")

--- a/arm-software/embedded/fvp/get_fvps.sh
+++ b/arm-software/embedded/fvp/get_fvps.sh
@@ -53,7 +53,7 @@ if [ "$MACHINE_HARDWARE" == 'x86_64' ]; then
     URL_BASE_AEM_A='https://developer.arm.com/-/cdn-downloads/permalink/FVPs-Architecture/FM-11.28/FVP_Base_RevC-2xAEMvA_11.28_23_Linux64.tgz'
     URL_BASE_AEM_R='https://developer.arm.com/-/cdn-downloads/permalink/FVPs-Architecture/FM-11.28/FVP_Base_AEMv8R_11.28_23_Linux64.tgz'
     URL_CRYPTO='https://developer.arm.com/-/cdn-downloads/permalink/Fast-Models-Crypto-Plug-in/FM-11.27/FastModels_crypto_11.27.019_Linux64.tgz'
-elif [ "$MACHINE_HARDWARE" == 'aarch64' ]; then
+elif [ "$MACHINE_HARDWARE" == 'aarch64' ] || [ "$MACHINE_HARDWARE" == 'arm64' ]; then
     URL_CORSTONE_310='https://developer.arm.com/-/cdn-downloads/permalink/FVPs-Corstone-IoT/Corstone-310/FVP_Corstone_SSE-310_11.27_42_Linux64_armv8l.tgz'
     URL_BASE_AEM_A='https://developer.arm.com/-/cdn-downloads/permalink/FVPs-Architecture/FM-11.28/FVP_Base_RevC-2xAEMvA_11.28_23_Linux64_armv8l.tgz'
     URL_BASE_AEM_R='https://developer.arm.com/-/cdn-downloads/permalink/FVPs-Architecture/FM-11.28/FVP_Base_AEMv8R_11.28_23_Linux64_armv8l.tgz'


### PR DESCRIPTION
The scripts to download and run the FVPs use `uname` to choose between the Linux x86 and AArch64 packages. These expect `aarch64` as a return, but `arm64` is also possible. The FVP platform should be the same for both.