### PR TITLE
[ATfE] Allow for a user specified system name when packaging

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -479,7 +479,12 @@ endif()
 if(LLVM_TOOLCHAIN_CROSS_BUILD_MINGW)
     set(CPACK_SYSTEM_NAME "Windows-${processor_name}")
 else()
-    set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}-${processor_name}")
+    # If a specific system name is supplied, use that instead.
+    if (PACKAGE_SYSTEM_NAME)
+        set(CPACK_SYSTEM_NAME "${PACKAGE_SYSTEM_NAME}-${processor_name}")
+    else()
+        set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}-${processor_name}")
+    endif()
 endif()
 
 set(CPACK_PACKAGE_VERSION ${PACKAGE_VERSION})

--- a/arm-software/embedded/scripts/build.sh
+++ b/arm-software/embedded/scripts/build.sh
@@ -23,7 +23,6 @@ clang --version
 export CC=clang
 export CXX=clang++
 
-EXTRA_CMAKE_ARGS=""
 if [[ ! -z "${FVP_INSTALL_DIR}" ]]; then
     EXTRA_CMAKE_ARGS="${EXTRA_CMAKE_ARGS} -DENABLE_FVP_TESTING=ON -DFVP_INSTALL_DIR=${FVP_INSTALL_DIR}"
 fi


### PR DESCRIPTION
If a system name for the package other than the CMake default is required, this can now be set through the `PACKAGE_SYSTEM_NAME` option. If unset, the default remains the CMake system name.

Additionally, the `build.sh` script has been modified so that additional CMake arguments can be passed down to CMake during configuration. `EXTRA_CMAKE_ARGS` can now be read as an environment variable, which will be appended to the arguments in the script.