### PR TITLE
[ATfE] Disable package tests on macOS

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -905,7 +905,16 @@ add_dependencies(check-llvm-toolchain check-${LLVM_TOOLCHAIN_C_LIBRARY})
 add_dependencies(check-llvm-toolchain check-compiler-rt)
 add_subdirectory(test)
 add_dependencies(check-llvm-toolchain check-llvm-toolchain-lit)
-add_subdirectory(packagetest)
+
+# The package tests currently only support tar and zip, so don't
+# attempt to run them on other formats, such as dmg with macOS.
+# A dummy check-package-llvm-toolchain target is still
+# required for the test.sh script.
+if(package_filename_extension STREQUAL ".tar.xz" OR package_filename_extension STREQUAL ".zip")
+    add_subdirectory(packagetest)
+else()
+    add_custom_target(check-package-llvm-toolchain)
+endif()
 
 if(LLVM_TOOLCHAIN_CROSS_BUILD_MINGW)
     find_program(MINGW_C_EXECUTABLE x86_64-w64-mingw32-gcc-posix REQUIRED)


### PR DESCRIPTION
The package tests rely on CMake to extract the package, however the command used only supports tar and zip archives. Until an alternative solution is found to test the dmg archive produced on macOS, the package tests can instead be disabled to prevent a failure.

The `test.sh` script will still attempt to build the `check-package-llvm-toolchain` target, so a dummy target is created to avoid an unrecognized target error.