### PR TITLE
Add an `elf2bin` utility.

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -354,6 +354,9 @@ add_subdirectory(
     ${llvmproject_src_dir}/llvm llvm
 )
 
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../shared/elf2bin elf2bin)
+add_dependencies(check-all check-elf2bin)
+
 if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL llvmlibc)
     install(
         FILES

--- a/arm-software/shared/elf2bin/CMakeLists.txt
+++ b/arm-software/shared/elf2bin/CMakeLists.txt
@@ -1,0 +1,57 @@
+# cmake build script for elf2bin
+#
+# Copyright (c) 2022-2025, Arm Limited and affiliates.
+#
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+# Tell add_llvm_tool where to find tablegen to process Opts.td
+set(LLVM_TABLEGEN_EXE ${CMAKE_BINARY_DIR}/llvm/bin/llvm-tblgen)
+
+# Specify which LLVM libraries we want to link with
+set(LLVM_LINK_COMPONENTS
+  Object
+  Option
+  Support
+)
+
+# Add the LLVM include directories (in both source and build dirs),
+# and the elf2bin directory in the build dir where tablegen will write
+# Opts.inc to.
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../../llvm/include
+  ${CMAKE_BINARY_DIR}/llvm/include
+  ${CMAKE_BINARY_DIR}/elf2bin
+)
+
+# Turn off RTTI: the LLVM libraries are compiled without it, so we
+# must compile without it too, or we'll get a link error trying to
+# find the RTTI for LLVM types such as llvm::opt::OptTable.
+if(CMAKE_COMPILER_IS_GNUCXX)
+  list(APPEND LLVM_COMPILE_FLAGS "-fno-rtti")
+elseif(MSVC)
+  list(APPEND LLVM_COMPILE_FLAGS "/GR-")
+endif()
+
+# Process Opts.td into a list of command-line options.
+set(LLVM_TARGET_DEFINITIONS Opts.td)
+tablegen(LLVM Opts.inc -gen-opt-parser-defs)
+add_public_tablegen_target(Elf2BinOptsTableGen)
+
+# Build the elf2bin binary itself.
+add_llvm_tool(elf2bin
+  elf2bin.cpp
+  elf.cpp
+  bin.cpp
+  hex.cpp
+  DEPENDS
+  Elf2BinOptsTableGen
+)
+
+# And run its Python-based test suite.
+add_custom_target(check-elf2bin
+  DEPENDS elf2bin
+  COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/test.py
+    $<TARGET_FILE:elf2bin>)

--- a/arm-software/shared/elf2bin/Opts.td
+++ b/arm-software/shared/elf2bin/Opts.td
@@ -1,0 +1,64 @@
+// Command-line option definitions for elf2bin
+//
+// Copyright (c) 2022-2025, Arm Limited and affiliates.
+//
+// Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+include "llvm/Option/OptParser.td"
+
+multiclass Value<string longname, string shortname, string metavar,
+                 string help, OptionGroup group> {
+  def NAME # _EQ : Joined<["--"], longname # "=">,
+                   HelpText<help>,
+                   MetaVarName<metavar>,
+                   Group<group>;
+  def : Separate<["--"], longname>,
+        Alias<!cast<Joined>(NAME # "_EQ")>;
+
+  if !not(!empty(shortname)) then {
+    def : JoinedOrSeparate<["-"], shortname>,
+          Alias<!cast<Joined>(NAME # "_EQ")>,
+          HelpText<"Alias for --" # longname>, Group<group>;
+  }
+}
+
+multiclass NoValue<string longname, string shortname, string help,
+                   OptionGroup group> {
+  def NAME : Flag<["--"], longname>,
+             HelpText<help>,
+             Group<group>;
+
+  if !not(!empty(shortname)) then {
+    def : Flag<["-"], shortname>,
+          Alias<!cast<Flag>(NAME)>,
+          HelpText<"Alias for --" # longname>;
+  }
+}
+
+def grp_mode: OptionGroup<"mode">, HelpText<"FORMAT OF OUTPUT">;
+def grp_file: OptionGroup<"output">, HelpText<"LOCATION OF OUTPUT">;
+def grp_opts: OptionGroup<"options">, HelpText<"OPTIONS">;
+
+defm output_file: Value<"output-file", "o", "FILENAME", "Name of the output file. Invalid if more than one output file is to be generated.", grp_file>;
+defm output_pattern: Value<"output-pattern", "O", "PATTERN", "Schema for naming all output files. May contain %f for base name of input file; %F for full name of input file; %a or %A for base address of ELF segment, in hex or in HEX; %b for bank number, if using --banks; %% for a literal % sign.", grp_file>;
+
+defm ihex: NoValue<"ihex", "", "Output Intel Hex files (\":108000\" style)", grp_mode>;
+defm srec: NoValue<"srec", "", "Output Motorola Hex files (\"S3150800\" style)", grp_mode>;
+defm bin: NoValue<"bin", "", "Output a binary file per ELF segment", grp_mode>;
+defm bincombined: NoValue<"bincombined", "", "Output a single binary file, containing all segments, with padding to place them at the correct relative positions", grp_mode>;
+defm vhx: NoValue<"vhx", "", "Output a Verilog Hex file per ELF segment", grp_mode>;
+defm vhxcombined: NoValue<"vhxcombined", "", "Output a single Verilog Hex file, containing all segments, with padding to place them at the correct relative positions", grp_mode>;
+
+defm base: Value<"base", "", "ADDRESS", "Base address of the whole output file, for --bincombined or --vhxcombined", grp_opts>;
+defm banks: Value<"banks", "", "WIDTHxNUM", "Partition the output into subfiles by writing WIDTH bytes in turn to each of NUM files in cyclic order, for binary or Verilog Hex output", grp_opts>;
+defm datareclen: Value<"datareclen", "", "LENGTH", "Number of data bytes to put into each record, for Intel Hex or Motorola Hex output", grp_opts>;
+defm segments: Value<"segments", "", "ADDRESS,ADDRESS,...", "Select only the ELF segments of the input which start at the specified addresses", grp_opts>;
+defm zi: NoValue<"zi", "", "Include the zero-initialized padding at the end of each ELF segment", grp_opts>;
+defm physical: NoValue<"physical", "", "Use the physical addresses (p_paddr) of ELF segments", grp_opts>;
+defm virtual: NoValue<"virtual", "", "Use the virtual addresses (p_vaddr) of ELF segments", grp_opts>;
+
+defm help: NoValue<"help", "", "Display this help", grp_opts>;
+defm version: NoValue<"version", "", "Display the version", grp_opts>;

--- a/arm-software/shared/elf2bin/bin.cpp
+++ b/arm-software/shared/elf2bin/bin.cpp
@@ -1,0 +1,330 @@
+// Code to write binary and VHX output for elf2bin
+//
+// Copyright (c) 2022-2025, Arm Limited and affiliates.
+//
+// Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+#include "elf2bin.h"
+
+#include <algorithm>
+#include <cassert>
+#include <memory>
+#include <queue>
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/bit.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+
+// For classes below that process input data in manageably-sized chunks
+constexpr size_t CHUNKSIZE = 65536;
+
+/*
+ * Abstraction that provides a means of getting binary data from
+ * somewhere. In the simple case this will involve reading data from a
+ * segment in an ELF file. In more complex cases there might also be
+ * zero-byte padding, or one of these stream objects filtering out the
+ * even-index bytes of another.
+ */
+class BinaryDataStream {
+public:
+  // Returns a string of data, in whatever size is convenient. (But
+  // the size should be bounded, so that other streams filtering this
+  // one don't have to swallow a whole file in one go.)
+  //
+  // An empty returned string means EOF.
+  virtual StringRef read() = 0;
+  virtual ~BinaryDataStream() = default;
+};
+
+/*
+ * BinaryDataStream implementation that reads data from an ELF image.
+ */
+class ElfSegment : public BinaryDataStream {
+  InputObject &inobj;
+  size_t position, remaining;
+
+  StringRef read() override {
+    size_t readlen = std::min<size_t>(remaining, CHUNKSIZE);
+    size_t readpos = position;
+    position += readlen;
+    remaining -= readlen;
+    return inobj.membuf->getBuffer().substr(readpos, readlen);
+  }
+
+public:
+  ElfSegment(InputObject &inobj, size_t offset, size_t size)
+      : inobj(inobj), position(offset), remaining(size) {}
+};
+
+/*
+ * BinaryDataStream implementation that generates zero padding.
+ */
+class Padding : public BinaryDataStream {
+  size_t remaining;
+  char buffer[CHUNKSIZE];
+
+  StringRef read() override {
+    size_t readlen = std::min<size_t>(remaining, CHUNKSIZE);
+    remaining -= readlen;
+    return StringRef(buffer, readlen);
+  }
+
+public:
+  Padding(size_t size) : remaining(size) { memset(buffer, 0, sizeof(buffer)); }
+};
+
+/*
+ * BinaryDataStream implementation that chains other BinaryDataStreams
+ * together.
+ */
+class Chain : public BinaryDataStream {
+  std::queue<std::unique_ptr<BinaryDataStream>> queue;
+
+  StringRef read() override {
+    while (!queue.empty()) {
+      StringRef data = queue.front()->read();
+      if (!data.empty())
+        return data;
+
+      queue.pop();
+    }
+
+    // If we get here, everything in our queue has finished.
+    return "";
+  }
+
+public:
+  Chain() = default;
+  void push(std::unique_ptr<BinaryDataStream> &&st) {
+    queue.push(std::move(st));
+  }
+};
+
+/*
+ * BinaryDataStream implementation that filters the output of another
+ * BinaryDataStream so as to return only a subset of the bytes,
+ * defined by a modulus and a range of residues. Specifically, a range
+ * of 'nres' consecutive bytes from the underlying stream is passed
+ * on, beginning at each byte whose index is congruent to 'firstres'
+ * mod 'modulus' (regarding the first byte of the underlying stream as
+ * having index 0).
+ *
+ * 'modulus' has to be a power of 2.
+ */
+class ModFilter : public BinaryDataStream {
+  std::unique_ptr<BinaryDataStream> st;
+  // Internal representation: 'mask' is the bitmask that reduces mod
+  // 'modulus'. 'pos' iterates cyclically over 0,...,modulus-1 with
+  // each byte we consume, and we return the byte if pos < nres.
+  uint64_t mask, nres, pos;
+  std::string outstring;
+
+  StringRef read() override {
+    outstring.clear();
+    llvm::raw_string_ostream outstream(outstring);
+
+    while (true) {
+      StringRef data = st->read();
+      if (data.empty())
+        break;
+
+      for (char c : data) {
+        if (pos < nres)
+          outstream << c;
+        pos = (pos + 1) & mask;
+      }
+
+      // If that batch of input contributed no bytes to our
+      // output, go round again. Otherwise, we have something to
+      // return.
+      if (!outstring.empty())
+        break;
+    }
+    return outstring;
+  }
+
+public:
+  ModFilter(std::unique_ptr<BinaryDataStream> &&st, uint64_t modulus,
+            uint64_t firstres, uint64_t nres)
+      : st(std::move(st)), nres(nres) {
+    // Check input values are reasonable.
+    assert(llvm::has_single_bit(modulus));
+    assert(nres > 0);
+    assert(nres < modulus);
+
+    mask = modulus - 1;
+
+    // Set pos to be (-firstres), so that we'll skip the right
+    // number of bytes before the first one we return.
+    //
+    // Written as (1 + ~firstres) to avoid Visual Studio
+    // complaining about negating an unsigned.
+    pos = (1 + ~firstres) & mask;
+  }
+};
+
+static void bin_write(BinaryDataStream &st, const std::string &outfile) {
+  std::error_code error;
+  llvm::raw_fd_ostream ofs(outfile, error);
+  if (error)
+    fatal(outfile, "unable to open", errorCodeToError(error));
+
+  while (true) {
+    StringRef data = st.read();
+    if (data.empty())
+      return;
+    ofs << data;
+  }
+}
+
+static void vhx_write(BinaryDataStream &st, const std::string &outfile) {
+  std::error_code error;
+  llvm::raw_fd_ostream ofs(outfile, error);
+  if (error)
+    fatal(outfile, "unable to open", errorCodeToError(error));
+
+  while (true) {
+    StringRef data = st.read();
+    if (data.empty())
+      return;
+    for (uint8_t c : data) {
+      static const char hexdigits[] = "0123456789ABCDEF";
+      ofs << hexdigits[c >> 4] << hexdigits[c & 0xF] << '\n';
+    }
+  }
+}
+
+static std::unique_ptr<BinaryDataStream> onesegment_prepare(InputObject &inobj,
+                                                            uint64_t fileoffset,
+                                                            uint64_t size,
+                                                            uint64_t zi_size) {
+  auto base_stream = std::make_unique<ElfSegment>(inobj, fileoffset, size);
+
+  if (!zi_size)
+    return base_stream;
+
+  auto chain = std::make_unique<Chain>();
+  chain->push(std::move(base_stream));
+  chain->push(std::make_unique<Padding>(zi_size));
+  return chain;
+}
+
+static std::unique_ptr<BinaryDataStream>
+combined_prepare(InputObject &inobj, const std::vector<Segment> &segments_orig,
+                 bool include_zi, std::optional<uint64_t> baseaddr) {
+  // Sort the segments by base address, in case they weren't already.
+  struct {
+    bool operator()(const Segment &a, const Segment &b) {
+      return a.baseaddr < b.baseaddr;
+    }
+  } comparator;
+  std::vector<Segment> sorted = segments_orig;
+  std::sort(sorted.begin(), sorted.end(), comparator);
+
+  // Spot and reject overlapping segments.
+  //
+  // (WIBNI: we _could_ tolerate these if they also agreed on what
+  // part of the ELF file corresponded to the overlapping range of
+  // address space. I don't see a reason to implement that in
+  // advance of someone actually having a good use for it, but
+  // that's why I'm leaving this overlap check as a separate pass
+  // rather than folding it into the next one - this way, we could
+  // write a modified set of segments into 'nonoverlapping'.)
+  std::vector<Segment> nonoverlapping;
+  if (!sorted.empty()) {
+    auto it = sorted.begin(), end = sorted.end();
+
+    if (baseaddr && it->baseaddr < baseaddr.value())
+      fatal(inobj, Twine("first segment is at address 0x") +
+                       Twine::utohexstr(it->baseaddr) +
+                       ", below the specified base address 0x" +
+                       Twine::utohexstr(baseaddr.value()));
+
+    nonoverlapping.push_back(*it++);
+    for (; it != end; ++it) {
+      const auto &prev = nonoverlapping.back(), curr = *it;
+      if (curr.baseaddr - prev.baseaddr < prev.memsize)
+        fatal(inobj, Twine("segments at addresses 0x") +
+                         Twine::utohexstr(prev.baseaddr) + " and 0x" +
+                         Twine::utohexstr(curr.baseaddr) + " overlap");
+      nonoverlapping.push_back(curr);
+    }
+  }
+
+  // Make a chained output stream that inserts the right padding
+  // between all those segments.
+  auto chain = std::make_unique<Chain>();
+  if (!nonoverlapping.empty()) {
+    uint64_t addr =
+        (baseaddr ? baseaddr.value() : nonoverlapping.begin()->baseaddr);
+
+    for (const auto &seg : nonoverlapping) {
+      if (addr < seg.baseaddr)
+        chain->push(std::make_unique<Padding>(seg.baseaddr - addr));
+      chain->push(
+          std::make_unique<ElfSegment>(inobj, seg.fileoffset, seg.filesize));
+      addr = seg.baseaddr + seg.filesize;
+
+      if (include_zi && seg.memsize > seg.filesize) {
+        chain->push(std::make_unique<Padding>(seg.memsize - seg.filesize));
+        addr = seg.baseaddr + seg.memsize;
+      }
+    }
+  }
+  return chain;
+}
+
+static std::unique_ptr<BinaryDataStream>
+bank_prepare(std::unique_ptr<BinaryDataStream> stream, uint64_t bank_modulus,
+             uint64_t bank_firstres, uint64_t bank_nres) {
+  if (bank_modulus == 1)
+    return stream;
+
+  return std::make_unique<ModFilter>(std::move(stream), bank_modulus,
+                                     bank_firstres, bank_nres);
+}
+
+void bin_write(InputObject &inobj, const std::string &outfile,
+               uint64_t fileoffset, uint64_t size, uint64_t zi_size,
+               uint64_t bank_modulus, uint64_t bank_firstres,
+               uint64_t bank_nres) {
+  auto streamp = onesegment_prepare(inobj, fileoffset, size, zi_size);
+  streamp =
+      bank_prepare(std::move(streamp), bank_modulus, bank_firstres, bank_nres);
+  bin_write(*streamp, outfile);
+}
+
+void bincombined_write(InputObject &inobj, const std::string &outfile,
+                       const std::vector<Segment> &segments, bool include_zi,
+                       std::optional<uint64_t> baseaddr, uint64_t bank_modulus,
+                       uint64_t bank_firstres, uint64_t bank_nres) {
+  auto streamp = combined_prepare(inobj, segments, include_zi, baseaddr);
+  streamp =
+      bank_prepare(std::move(streamp), bank_modulus, bank_firstres, bank_nres);
+  bin_write(*streamp, outfile);
+}
+
+void vhx_write(InputObject &inobj, const std::string &outfile,
+               uint64_t fileoffset, uint64_t size, uint64_t zi_size,
+               uint64_t bank_modulus, uint64_t bank_firstres,
+               uint64_t bank_nres) {
+  auto streamp = onesegment_prepare(inobj, fileoffset, size, zi_size);
+  streamp =
+      bank_prepare(std::move(streamp), bank_modulus, bank_firstres, bank_nres);
+  vhx_write(*streamp, outfile);
+}
+
+void vhxcombined_write(InputObject &inobj, const std::string &outfile,
+                       const std::vector<Segment> &segments, bool include_zi,
+                       std::optional<uint64_t> baseaddr, uint64_t bank_modulus,
+                       uint64_t bank_firstres, uint64_t bank_nres) {
+  auto streamp = combined_prepare(inobj, segments, include_zi, baseaddr);
+  streamp =
+      bank_prepare(std::move(streamp), bank_modulus, bank_firstres, bank_nres);
+  vhx_write(*streamp, outfile);
+}

--- a/arm-software/shared/elf2bin/elf.cpp
+++ b/arm-software/shared/elf2bin/elf.cpp
@@ -1,0 +1,69 @@
+// Code to read ELF data structures for elf2bin
+//
+// Copyright (c) 2022-2025, Arm Limited and affiliates.
+//
+// Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+#include "elf2bin.h"
+
+using namespace llvm;
+using namespace llvm::object;
+
+template <typename ELFT>
+static std::vector<Segment>
+get_segments(InputObject &inobj, ELFObjectFile<ELFT> &elfobj, bool physical) {
+  std::vector<Segment> segments;
+
+  Expected<ArrayRef<typename ELFT::Phdr>> phdrs_or_err =
+      elfobj.getELFFile().program_headers();
+  if (!phdrs_or_err) {
+    fatal(inobj, "unable to read program header table",
+          phdrs_or_err.takeError());
+    return segments;
+  }
+
+  for (const typename ELFT::Phdr &phdr : *phdrs_or_err) {
+    if (phdr.p_type != llvm::ELF::PT_LOAD)
+      continue;
+    Segment seg;
+    seg.fileoffset = phdr.p_offset;
+    seg.baseaddr = physical ? phdr.p_paddr : phdr.p_vaddr;
+    seg.filesize = phdr.p_filesz;
+    seg.memsize = phdr.p_memsz;
+    segments.push_back(seg);
+  }
+
+  return segments;
+}
+
+template <typename ELFT>
+static uint64_t get_entry_point(ELFObjectFile<ELFT> &obj) {
+  return obj.getELFFile().getHeader().e_entry;
+}
+
+std::vector<Segment> InputObject::segments(bool physical) {
+  if (auto *specific = dyn_cast<ELF32LEObjectFile>(elf.get()))
+    return get_segments(*this, *specific, physical);
+  if (auto *specific = dyn_cast<ELF32BEObjectFile>(elf.get()))
+    return get_segments(*this, *specific, physical);
+  if (auto *specific = dyn_cast<ELF64LEObjectFile>(elf.get()))
+    return get_segments(*this, *specific, physical);
+  if (auto *specific = dyn_cast<ELF64BEObjectFile>(elf.get()))
+    return get_segments(*this, *specific, physical);
+  llvm_unreachable("unexpected subclass of ELFOBjectFileBase");
+}
+
+uint64_t InputObject::entry_point() {
+  if (auto *specific = dyn_cast<ELF32LEObjectFile>(elf.get()))
+    return get_entry_point(*specific);
+  if (auto *specific = dyn_cast<ELF32BEObjectFile>(elf.get()))
+    return get_entry_point(*specific);
+  if (auto *specific = dyn_cast<ELF64LEObjectFile>(elf.get()))
+    return get_entry_point(*specific);
+  if (auto *specific = dyn_cast<ELF64BEObjectFile>(elf.get()))
+    return get_entry_point(*specific);
+  llvm_unreachable("unexpected subclass of ELFOBjectFileBase");
+}

--- a/arm-software/shared/elf2bin/elf2bin.cpp
+++ b/arm-software/shared/elf2bin/elf2bin.cpp
@@ -1,0 +1,468 @@
+// Main program for elf2bin
+//
+// Copyright (c) 2022-2025, Arm Limited and affiliates.
+//
+// Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+// This is a tool that converts images into binary and hex formats, similar to
+// some of llvm-objcopy's functionality, but specialized to ELF, using only the
+// 'load view' of an ELF image, that is, the PT_LOAD segments in the program
+// header table. The output can be written to plain binary files or various hex
+// formats. An additional option allows the output to be split into multiple
+// 'banks' to be loaded into separate ROMs, e.g. with the first 2 bytes out of
+// every 4 going into one ROM and the other 2 bytes going into another.
+
+#include "elf2bin.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/bit.h"
+#include "llvm/Object/ELFObjectFile.h"
+#include "llvm/Option/Arg.h"
+#include "llvm/Option/ArgList.h"
+#include "llvm/Option/OptTable.h"
+#include "llvm/Option/Option.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/LLVMDriver.h"
+
+using namespace llvm;
+using llvm::object::ELFObjectFileBase;
+
+[[noreturn]] static void fatal_common(std::optional<StringRef> filename,
+                                      Twine message,
+                                      std::optional<llvm::Error> err,
+                                      bool suggest_help) {
+  llvm::errs() << "elf2bin: ";
+  if (filename)
+    llvm::errs() << *filename << ": ";
+  llvm::errs() << message;
+  if (err) {
+    handleAllErrors(std::move(*err), [](const ErrorInfoBase &einfo) {
+      llvm::errs() << ": " << einfo.message();
+    });
+  }
+  llvm::errs() << "\n";
+  if (suggest_help)
+    llvm::errs() << "(try 'elf2bin --help' for help)\n";
+  exit(1);
+}
+
+[[noreturn]] void fatal(InputObject &inobj, Twine message, llvm::Error err) {
+  fatal_common(inobj.filename, message, std::move(err), false);
+}
+[[noreturn]] void fatal(InputObject &inobj, Twine message) {
+  fatal_common(inobj.filename, message, std::nullopt, false);
+}
+[[noreturn]] void fatal(StringRef filename, Twine message, llvm::Error err) {
+  fatal_common(filename, message, std::move(err), false);
+}
+[[noreturn]] void fatal(StringRef filename, Twine message) {
+  fatal_common(filename, message, std::nullopt, false);
+}
+[[noreturn]] void fatal(Twine message) {
+  fatal_common(std::nullopt, message, std::nullopt, false);
+}
+// Just like fatal() but also suggests --help
+[[noreturn]] void fatal_suggest_help(Twine message) {
+  fatal_common(std::nullopt, message, std::nullopt, true);
+}
+
+/*
+ * Format an output file name, according to the format string
+ * description provided by the user and documented in the help above.
+ *
+ * (So, unlike sprintf, this function doesn't take an arbitrary
+ * variadic argument list. Its input data consists of the details of
+ * an output file that's about to be written, and the format
+ * directives refer to particular pieces of data like 'input file
+ * name' and 'bank number' rather than to data types.)
+ */
+std::string format_outfile(std::string pattern, std::string inpath,
+                           std::optional<uint64_t> baseaddr, uint64_t bank) {
+  std::string infile;
+  size_t slash = inpath.find_last_of("/"
+#ifdef _WIN32
+                                     "\\:"
+#endif
+  );
+  infile = inpath.substr(slash == std::string::npos ? 0 : slash + 1);
+
+  std::string outstring;
+  llvm::raw_string_ostream outstream(outstring);
+
+  for (auto it = pattern.begin(); it != pattern.end();) {
+    char c = *it++;
+    if (c == '%') {
+      if (it == pattern.end())
+        fatal(Twine("output pattern '") + pattern +
+              "' ends with incomplete % escape");
+      char d = *it++;
+      switch (d) {
+      case 'F':
+        outstream << infile;
+        break;
+      case 'f':
+        outstream << infile.substr(
+            0, std::min(infile.size(), infile.find_last_of('.')));
+        break;
+      case 'a':
+      case 'A': {
+        if (!baseaddr)
+          fatal(Twine("output pattern '") + pattern + "' contains '%" +
+                Twine(d) + "' but no base address is available");
+        Twine hex = Twine::utohexstr(baseaddr.value());
+        if (d == 'a') {
+          outstream << hex;
+        } else {
+          SmallVector<char, 16> hexdata;
+          outstream << hex.toStringRef(hexdata).upper();
+        }
+        break;
+      }
+      case 'b':
+        outstream << bank;
+        break;
+      case '%':
+        outstream << '%';
+        break;
+      default:
+        fatal(Twine("output pattern '") + pattern +
+              "' contains unrecognized % escape '%" + Twine(d) + "'");
+      }
+    } else {
+      outstream << c;
+    }
+  }
+
+  return outstring;
+}
+
+enum class Format {
+  IHex,
+  SRec,
+  BinMultifile,
+  BinCombined,
+  VhxMultifile,
+  VhxCombined
+};
+
+namespace {
+
+using namespace llvm::opt; // for HelpHidden in Opts.inc
+
+enum ID {
+  OPT_INVALID = 0, // This is not an option ID.
+#define OPTION(...) LLVM_MAKE_OPT_ID(__VA_ARGS__),
+#include "Opts.inc"
+#undef OPTION
+};
+
+#define OPTTABLE_STR_TABLE_CODE
+#include "Opts.inc"
+#undef OPTTABLE_STR_TABLE_CODE
+
+#define OPTTABLE_PREFIXES_TABLE_CODE
+#include "Opts.inc"
+#undef OPTTABLE_PREFIXES_TABLE_CODE
+
+static constexpr opt::OptTable::Info InfoTable[] = {
+#define OPTION(...) LLVM_CONSTRUCT_OPT_INFO(__VA_ARGS__),
+#include "Opts.inc"
+#undef OPTION
+};
+
+class Elf2BinOptTable : public opt::GenericOptTable {
+public:
+  Elf2BinOptTable()
+      : opt::GenericOptTable(OptionStrTable, OptionPrefixesTable, InfoTable,
+                             true) {}
+};
+
+} // namespace
+
+int main(int argc, char **argv) {
+  InitLLVM X(argc, argv);
+  BumpPtrAllocator A;
+  StringSaver Saver(A);
+  Elf2BinOptTable table;
+  opt::InputArgList Args =
+      table.parseArgs(argc, argv, OPT_UNKNOWN, Saver, fatal_suggest_help);
+
+  if (Args.hasArg(OPT_help)) {
+    table.printHelp(outs(), "elf2bin [options] <input ELF images>",
+                    "ELF-to-binary converter");
+    return 0;
+  }
+  if (Args.hasArg(OPT_version)) {
+    llvm::outs() << "elf2bin, from Arm Toolchain, based on:\n";
+    llvm::cl::PrintVersionMessage();
+    return 0;
+  }
+
+  std::vector<std::string> infiles = Args.getAllArgValues(OPT_INPUT);
+
+  std::optional<std::string> outfile, outpattern;
+  if (Arg *A = Args.getLastArg(OPT_output_file_EQ))
+    outfile = A->getValue();
+  if (Arg *A = Args.getLastArg(OPT_output_pattern_EQ))
+    outpattern = A->getValue();
+
+  std::optional<Format> format;
+  if (Arg *A = Args.getLastArg(OPT_ihex, OPT_srec, OPT_bin, OPT_bincombined,
+                               OPT_vhx, OPT_vhxcombined)) {
+    auto Option = A->getOption();
+    if (Option.matches(OPT_ihex))
+      format = Format::IHex;
+    if (Option.matches(OPT_srec))
+      format = Format::SRec;
+    if (Option.matches(OPT_bin))
+      format = Format::BinMultifile;
+    if (Option.matches(OPT_bincombined))
+      format = Format::BinCombined;
+    if (Option.matches(OPT_vhx))
+      format = Format::VhxMultifile;
+    if (Option.matches(OPT_vhxcombined))
+      format = Format::VhxCombined;
+  }
+
+  std::optional<uint64_t> baseaddr;
+  if (Arg *A = Args.getLastArg(OPT_base_EQ)) {
+    uint64_t value;
+    StringRef str = A->getValue();
+    if (str.getAsInteger(0, value))
+      fatal(Twine("cannot parse base address '") + str + "'");
+    baseaddr = value;
+  }
+
+  std::optional<std::set<uint64_t>> segments_wanted;
+  if (Arg *A = Args.getLastArg(OPT_segments_EQ)) {
+    std::set<uint64_t> bases;
+    SmallVector<StringRef, 4> fields;
+    SplitString(A->getValue(), fields, ",");
+    for (auto field : fields) {
+      uint64_t base;
+      if (field.getAsInteger(0, base))
+        fatal(Twine("cannot parse segment base address '") + field + "'");
+      bases.insert(base);
+    }
+    segments_wanted = bases;
+  }
+
+  uint64_t bankwidth = 1, nbanks = 1;
+  if (Arg *A = Args.getLastArg(OPT_banks_EQ)) {
+    StringRef str = A->getValue();
+    size_t xpos = str.find_first_of("x");
+    size_t xpos2 = str.find_last_of("x");
+    if (!(xpos == xpos2 && !str.substr(0, xpos).getAsInteger(0, bankwidth) &&
+          !str.substr(xpos + 1).getAsInteger(0, nbanks) &&
+          llvm::has_single_bit(bankwidth) && llvm::has_single_bit(nbanks) &&
+          bankwidth * nbanks != 0))
+      fatal(Twine("cannot parse bank specification '") + str + "'");
+  }
+
+  uint64_t datareclen = 16;
+  if (Arg *A = Args.getLastArg(OPT_datareclen_EQ)) {
+    StringRef str = A->getValue();
+    if (str.getAsInteger(0, datareclen))
+      fatal(Twine("cannot parse data record length '") + str + "'");
+  }
+
+  bool include_zi = Args.hasArg(OPT_zi);
+  bool physical = true;
+  if (Arg *A = Args.getLastArg(OPT_physical, OPT_virtual))
+    physical = A->getOption().matches(OPT_physical);
+
+  if (infiles.empty())
+    fatal_suggest_help("no input file specified");
+  if (!outfile && !outpattern)
+    fatal_suggest_help("no output filename or pattern specified");
+  if (!format)
+    fatal_suggest_help("no output format specified");
+  if (outfile && outpattern)
+    fatal_suggest_help("output filename and pattern both specified");
+
+  if ((format != Format::BinCombined && format != Format::VhxCombined) &&
+      baseaddr)
+    fatal("--base only applies to --bincombined and --vhxcombined");
+
+  if ((format != Format::BinMultifile && format != Format::BinCombined &&
+       format != Format::VhxMultifile && format != Format::VhxCombined) &&
+      (bankwidth != 1 || nbanks != 1))
+    fatal("--banks only applies to binary and VHX output");
+
+  /*
+   * Open the input files.
+   */
+  std::vector<InputObject> objects;
+
+  for (const std::string &infile : infiles) {
+    objects.emplace_back();
+    InputObject &inobj = objects.back();
+    inobj.filename = infile;
+
+    ErrorOr<std::unique_ptr<MemoryBuffer>> membuf_or_err =
+        MemoryBuffer::getFileOrSTDIN(infile, false, false);
+    if (std::error_code error = membuf_or_err.getError())
+      fatal(infile, "unable to open", errorCodeToError(error));
+    inobj.membuf = std::move(membuf_or_err.get());
+
+    Expected<std::unique_ptr<llvm::object::Binary>> binary_or_err =
+        llvm::object::createBinary(inobj.membuf->getMemBufferRef(), nullptr,
+                                   false);
+    if (!binary_or_err)
+      fatal(infile, "unable to process", binary_or_err.takeError());
+
+    std::unique_ptr<ELFObjectFileBase> elf =
+        dyn_cast<ELFObjectFileBase>(*binary_or_err);
+    if (!elf)
+      fatal(infile, "unable to process: not an ELF file");
+    inobj.elf = std::move(elf);
+  }
+
+  /*
+   * Helper function for listing the segments of a file, paying
+   * attention to the --segments option to restrict to a subset.
+   */
+  auto segments = [&](InputObject &inobj) {
+    std::vector<Segment> allsegs = inobj.segments(physical);
+    if (!segments_wanted)
+      return allsegs;
+
+    std::vector<Segment> segs;
+    auto &keep = segments_wanted.value();
+    for (auto seg : allsegs)
+      if (keep.find(seg.baseaddr) != keep.end())
+        segs.push_back(seg);
+    return segs;
+  };
+
+  /*
+   * Make a list of all the conversions we want to do.
+   */
+
+  struct Conversion {
+    InputObject *inobj;
+    std::string outfile;
+    std::optional<uint64_t> baseaddr, fileoffset, size, zisize;
+    uint64_t bank;
+  };
+  std::vector<Conversion> convs;
+
+  for (auto &inobj : objects) {
+    // Helper function to fill in infile and outfile
+    auto add_conv = [&](Conversion conv) {
+      conv.inobj = &inobj;
+      if (outfile)
+        conv.outfile = outfile.value();
+      else
+        conv.outfile = format_outfile(outpattern.value(), conv.inobj->filename,
+                                      conv.baseaddr, conv.bank);
+      convs.push_back(conv);
+    };
+
+    switch (format.value()) {
+    case Format::BinMultifile:
+    case Format::VhxMultifile:
+      /*
+       * Separate output file per segment and per bank, so go
+       * through this input file and list its segments.
+       */
+      for (auto seg : segments(inobj)) {
+        for (uint64_t bank = 0; bank < nbanks; bank++) {
+          Conversion conv;
+          conv.baseaddr = seg.baseaddr;
+          conv.fileoffset = seg.fileoffset;
+          conv.size = seg.filesize;
+          conv.bank = bank;
+          if (include_zi && seg.memsize > seg.filesize)
+            conv.zisize = seg.memsize - seg.filesize;
+          else
+            conv.zisize = 0;
+          add_conv(conv);
+        }
+      }
+      break;
+    case Format::BinCombined:
+    case Format::VhxCombined:
+      /*
+       * Separate output file per bank, but each one contains
+       * the whole input file.
+       */
+      for (uint64_t bank = 0; bank < nbanks; bank++) {
+        Conversion conv;
+        conv.bank = bank;
+        add_conv(conv);
+      }
+      break;
+    default:
+      /*
+       * One output file per input file.
+       */
+      add_conv(Conversion{});
+      break;
+    }
+  }
+
+  std::set<std::string> outfiles;
+  for (const auto &conv : convs) {
+    if (outfiles.find(conv.outfile) != outfiles.end()) {
+      fatal(Twine("output file '") + conv.outfile +
+            "' would be written more than once by this command");
+      std::exit(1);
+    }
+    outfiles.insert(conv.outfile);
+  }
+
+  uint64_t bankmod = nbanks * bankwidth;
+
+  for (const auto &conv : convs) {
+    switch (format.value()) {
+    case Format::BinMultifile:
+      bin_write(*conv.inobj, conv.outfile, conv.fileoffset.value(),
+                conv.size.value(), conv.zisize.value(), bankmod,
+                conv.bank * bankwidth, bankwidth);
+      break;
+
+    case Format::BinCombined:
+      bincombined_write(*conv.inobj, conv.outfile, segments(*conv.inobj),
+                        include_zi, baseaddr, bankmod, conv.bank * bankwidth,
+                        bankwidth);
+      break;
+
+    case Format::VhxMultifile:
+      vhx_write(*conv.inobj, conv.outfile, conv.fileoffset.value(),
+                conv.size.value(), conv.zisize.value(), bankmod,
+                conv.bank * bankwidth, bankwidth);
+      break;
+
+    case Format::VhxCombined:
+      vhxcombined_write(*conv.inobj, conv.outfile, segments(*conv.inobj),
+                        include_zi, baseaddr, bankmod, conv.bank * bankwidth,
+                        bankwidth);
+      break;
+
+    case Format::IHex:
+      ihex_write(*conv.inobj, conv.outfile, segments(*conv.inobj), include_zi,
+                 datareclen);
+      break;
+
+    case Format::SRec:
+      srec_write(*conv.inobj, conv.outfile, segments(*conv.inobj), include_zi,
+                 datareclen);
+      break;
+    }
+  }
+
+  return 0;
+}

--- a/arm-software/shared/elf2bin/elf2bin.h
+++ b/arm-software/shared/elf2bin/elf2bin.h
@@ -1,0 +1,172 @@
+// Header file declaring the inter-file interfaces in elf2bin
+//
+// Copyright (c) 2022-2025, Arm Limited and affiliates.
+//
+// Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+#include <cstdint>
+#include <istream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "llvm/ADT/Twine.h"
+#include "llvm/Object/ELFObjectFile.h"
+#include "llvm/Support/Error.h"
+
+/*
+ * A structure that describes a single loadable segment in an ELF
+ * image. 'fileoffset' and 'filesize' designate a region of bytes in
+ * the file; 'baseaddr' specifies the memory address that region is
+ * expected to be loaded at.
+ *
+ * 'memsize' indicates how many bytes the region will occupy once it's
+ * loaded. This should never be less than 'filesize'. If it's more
+ * than 'filesize', it indicates that zero padding should be appended
+ * by the loader to pad to the full size.
+ */
+struct Segment {
+  uint64_t baseaddr, fileoffset, filesize, memsize;
+};
+
+/*
+ * A structure containing the name of an input file to the program,
+ * and the result of loading it into an ELFObjectFile.
+ */
+struct InputObject {
+  std::string filename;
+  std::unique_ptr<llvm::MemoryBuffer> membuf;
+  std::unique_ptr<llvm::object::ELFObjectFileBase> elf;
+
+  /*
+   * List the loadable segments in the file.
+   *
+   * The flag 'physical' indicates that the 'baseaddr' value for each
+   * returned segment should be the physical address of that segment,
+   * i.e. the p_paddr field in its program header table entry. If it's
+   * false, the virtual address will be used instead, i.e. the p_vaddr
+   * field.
+   */
+  std::vector<Segment> segments(bool physical);
+
+  uint64_t entry_point();
+};
+
+/*
+ * Write a single binary or Verilog hex file. (A Verilog hex file is
+ * just the plain binary data, represented as a sequence of text lines
+ * each containing a hex-encoded byte).
+ *
+ * Input data comes from the file 'infile', at offset 'fileoffset',
+ * 'size' bytes long. 'zi_size' zero bytes are appended after that.
+ *
+ * Bank switching is supported by the bank_* parameters, which select
+ * a subset of the input bytes to be written to the output.
+ * Specifically, each input byte is included or excluded depending on
+ * the residue of its position in the input, mod 'bank_modulus'.
+ * 'bank_nres' consecutive residues are kept, starting at
+ * 'bank_firstres'. For example:
+ *
+ * modulus=8, firstres=0, nres=1: keep only the bytes whose positions
+ * are congruent to 0 mod 8. (Just one residue, namely 0.) That is,
+ * divide the input into 8-byte blocks and only write the initial byte
+ * of each block.
+ *
+ * modulus=8, firstres=0, nres=2: keep the bytes whose positions are
+ * congruent to {0,1} mod 8. (Two consecutive residues, starting at 0.)
+ *
+ * modulus=8, firstres=4, nres=2: keep the bytes whose positions are
+ * congruent to {4,5} mod 8. (Still two residues, but now starting at 4.)
+ *
+ * If no bank switching is needed, then modulus=1, firstres=0, nres=1
+ * is a combination that indicates 'write all input bytes to the output'.
+ *
+ * The output is written to the file 'outfile'.
+ *
+ * These functions will exit the entire program with an error message if
+ * anything goes wrong. So callers need not handle the failure case.
+ */
+void bin_write(InputObject &inobj, const std::string &outfile,
+               uint64_t fileoffset, uint64_t size, uint64_t zi_size,
+               uint64_t bank_modulus, uint64_t bank_firstres,
+               uint64_t bank_nres);
+void vhx_write(InputObject &inobj, const std::string &outfile,
+               uint64_t fileoffset, uint64_t size, uint64_t zi_size,
+               uint64_t bank_modulus, uint64_t bank_firstres,
+               uint64_t bank_nres);
+
+/*
+ * Write a combined binary or Verilog hex file, including multiple
+ * segments from an ELF file, at their correct relative offsets.
+ *
+ * 'segments' gives the list of segments from the ELF file to include.
+ * Each Segment structure includes the file offset, base address and
+ * size, so these functions can work out the padding required in
+ * between.
+ *
+ * 'baseaddr' gives the address corresponding to the start of the
+ * file. (So if this is lower than the base address of the first
+ * segment, then padding must be inserted at the very start of the
+ * file.)
+ *
+ * If 'include_zi' is set, then the ZI padding specified in the ELF
+ * file after each segment will be reliably included in the output
+ * file. (This is likely only relevant to the final segment, because
+ * if there are two segments with space between them, then the ZI
+ * padding for the first segment will occupy some of that space, and
+ * will be included in the file anyway.) If 'include_zi' is false, the
+ * output file will end as soon as the last byte of actual file data
+ * has been written.
+ *
+ * The bank_* parameters are interpreted identically to the previous
+ * pair of functions. So is 'outfile'.
+ *
+ * These functions too will exit with an error in case of failure.
+ */
+void bincombined_write(InputObject &inobj, const std::string &outfile,
+                       const std::vector<Segment> &segments, bool include_zi,
+                       std::optional<uint64_t> baseaddr, uint64_t bank_modulus,
+                       uint64_t bank_firstres, uint64_t bank_nres);
+void vhxcombined_write(InputObject &inobj, const std::string &outfile,
+                       const std::vector<Segment> &segments, bool include_zi,
+                       std::optional<uint64_t> baseaddr, uint64_t bank_modulus,
+                       uint64_t bank_firstres, uint64_t bank_nres);
+
+/*
+ * Write a structured hex file (Intel Hex or Motorola S-records)
+ * describing an ELF image.
+ *
+ * 'segments' lists the loadable segments that should be included
+ * (which may not be all the segments in the file, if the command line
+ * specified only a subset of them).
+ *
+ * 'include_zi' indicates whether the ZI padding at the end of each
+ * segment should be explicitly represented in the hex file.
+ *
+ * 'datareclen' indicates how many bytes of data should appear in each
+ * hex record. (Fewer bytes per record mean more file size overhead,
+ * but also less likelihood of overflowing a reader's size limit.
+ *
+ * These functions will exit the entire program with an error message if
+ * anything goes wrong. So callers need not handle the failure case.
+ */
+void ihex_write(InputObject &inobj, const std::string &outfile,
+                const std::vector<Segment> &segments, bool include_zi,
+                uint64_t datareclen);
+void srec_write(InputObject &inobj, const std::string &outfile,
+                const std::vector<Segment> &segments, bool include_zi,
+                uint64_t datareclen);
+
+/*
+ * Error-reporting functions. These are all fatal.
+ */
+[[noreturn]] void fatal(llvm::StringRef filename, llvm::Twine message,
+                        llvm::Error err);
+[[noreturn]] void fatal(llvm::StringRef filename, llvm::Twine message);
+[[noreturn]] void fatal(InputObject &inobj, llvm::Twine message,
+                        llvm::Error err);
+[[noreturn]] void fatal(InputObject &inobj, llvm::Twine message);
+[[noreturn]] void fatal(llvm::Twine message);

--- a/arm-software/shared/elf2bin/hex.cpp
+++ b/arm-software/shared/elf2bin/hex.cpp
@@ -1,0 +1,203 @@
+// Code to write Intel and Motorola Hex formats for elf2bin
+//
+// Copyright (c) 2022-2025, Arm Limited and affiliates.
+//
+// Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+#include "elf2bin.h"
+
+#include <assert.h>
+
+#include "llvm/Support/Endian.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+
+class Hex {
+protected:
+  static void hex_to_ostream(llvm::raw_ostream &os,
+                             const std::string &binstring);
+
+public:
+  virtual void data(uint64_t addr, const std::string &data) = 0;
+  virtual void trailer(uint64_t entry) = 0;
+  virtual ~Hex() = default;
+};
+
+template <typename Integer> std::string bigend(Integer i, size_t bytes_wanted) {
+  assert(bytes_wanted <= sizeof(i));
+  char buf[sizeof(i)];
+  llvm::support::endian::write(buf, i, llvm::endianness::big);
+  return std::string(buf + sizeof(i) - bytes_wanted, bytes_wanted);
+}
+
+void Hex::hex_to_ostream(llvm::raw_ostream &os, const std::string &binstring) {
+  for (uint8_t c : binstring) {
+    static const char hexdigits[] = "0123456789ABCDEF";
+    os << hexdigits[c >> 4] << hexdigits[c & 0xF];
+  }
+}
+
+class IHex : public Hex {
+  static std::string record(uint8_t type, uint16_t addr,
+                            const std::string &data) {
+    std::string binstring;
+    llvm::raw_string_ostream binstream(binstring);
+
+    binstream << (char)data.size() << bigend(addr, 2) << (char)type << data;
+
+    uint8_t checksum = 0;
+    for (uint8_t c : binstring)
+      checksum -= c;
+    binstream << (char)checksum;
+
+    std::string hexstring;
+    llvm::raw_string_ostream hexstream(hexstring);
+    hexstream << ':';
+    hex_to_ostream(hexstream, binstring);
+    hexstream << '\n';
+    return hexstring;
+  }
+
+  InputObject &inobj;
+  llvm::raw_ostream &os;
+  uint64_t curr_offset = 0;
+
+  void data(uint64_t addr, const std::string &data) override {
+    uint64_t offset = addr >> 16;
+    if (offset != curr_offset) {
+      if (offset >= 0x10000)
+        fatal(inobj, "data address does not fit in 32 bits");
+      curr_offset = offset;
+      os << record(4, 0, bigend(curr_offset, 2));
+    }
+    os << record(0, addr & 0xFFFF, data);
+  }
+
+  void trailer(uint64_t entry) override {
+    if (entry >= 0x100000000)
+      fatal(inobj, "entry point does not fit in 32 bits");
+    os << record(5, 0, bigend(entry, 4)); // entry point
+    os << record(1, 0, "");               // EOF
+  }
+
+public:
+  static constexpr uint64_t max_datalen = 0xFF;
+  IHex(InputObject &inobj, llvm::raw_ostream &os) : inobj(inobj), os(os) {}
+};
+
+class SRec : public Hex {
+  static std::string record(uint8_t type, uint32_t addr,
+                            const std::string &data) {
+    std::string binstring;
+    llvm::raw_string_ostream binstream(binstring);
+
+    size_t addrsize = (type == 2 || type == 8   ? 3
+                       : type == 3 || type == 7 ? 4
+                                                : 2);
+
+    binstream << (char)(data.size() + addrsize + 1) << bigend(addr, addrsize)
+              << data;
+
+    uint8_t checksum = -1;
+    for (uint8_t c : binstring)
+      checksum -= c;
+    binstream << (char)checksum;
+
+    std::string hexstring;
+    llvm::raw_string_ostream hexstream(hexstring);
+    hexstream << 'S' << static_cast<char>('0' + type);
+    hex_to_ostream(hexstream, binstring);
+    hexstream << '\n';
+    return hexstring;
+  }
+
+  InputObject &inobj;
+  llvm::raw_ostream &os;
+
+  void data(uint64_t addr, const std::string &data) override {
+    if (addr >= 0x100000000)
+      fatal(inobj, "data address does not fit in 32 bits");
+    os << record(3, static_cast<uint32_t>(addr), data);
+  }
+
+  void trailer(uint64_t entry) override {
+    if (entry >= 0x100000000)
+      fatal(inobj, "entry point does not fit in 32 bits");
+
+    // We could also write an S5 or S6 record here, containing the total number
+    // of data records in the file. However, srec_motorola(5) says one of these
+    // is optional, and I'm unaware of anyone depending on it existing. Also,
+    // we'd have to decide what to do if the file were so huge that the number
+    // wouldn't fit.
+
+    os << record(7, static_cast<uint32_t>(entry), "");
+  }
+
+public:
+  // In S-records, the length field includes the address and checksum,
+  // so we can have fewer data bytes in a record than 0xFF
+  static constexpr uint64_t max_datalen = 0xFF - 5;
+
+  SRec(InputObject &inobj, llvm::raw_ostream &os) : inobj(inobj), os(os) {}
+};
+
+static void hex_write(InputObject &inobj, Hex &hex,
+                      const std::vector<Segment> &segments, bool include_zi,
+                      uint64_t datareclen) {
+  for (auto seg : segments) {
+    uint64_t segsize = include_zi ? seg.memsize : seg.filesize;
+
+    for (uint64_t pos = 0; pos < segsize; pos += datareclen) {
+      size_t thisreclen = std::min<size_t>(datareclen, segsize - pos);
+      size_t readlen = pos >= seg.filesize
+                           ? 0
+                           : std::min<size_t>(thisreclen, seg.filesize - pos);
+
+      std::string data;
+      if (readlen)
+        data = std::string(
+            inobj.membuf->getBuffer().substr(seg.fileoffset + pos, readlen));
+      if (thisreclen > readlen)
+        data += std::string(thisreclen - readlen, '\0');
+      hex.data(seg.baseaddr + pos, data);
+    }
+  }
+
+  hex.trailer(inobj.entry_point());
+}
+
+template <typename HexFormat>
+static void hex_write(InputObject &inobj, const std::string &outfile,
+                      const std::vector<Segment> &segments, bool include_zi,
+                      uint64_t datareclen) {
+  if (datareclen > HexFormat::max_datalen)
+    fatal(inobj, "data record length must be at most " +
+                     Twine(unsigned(HexFormat::max_datalen)));
+
+  if (datareclen < 1)
+    fatal(inobj, "data record length must be at least 1");
+
+  std::error_code error;
+  llvm::raw_fd_ostream outstream(outfile, error);
+  if (error)
+    fatal(outfile, "unable to open", errorCodeToError(error));
+
+  HexFormat hex(inobj, outstream);
+  hex_write(inobj, hex, segments, include_zi, datareclen);
+}
+
+void ihex_write(InputObject &inobj, const std::string &outfile,
+                const std::vector<Segment> &segments, bool include_zi,
+                uint64_t datareclen) {
+  hex_write<IHex>(inobj, outfile, segments, include_zi, datareclen);
+}
+
+void srec_write(InputObject &inobj, const std::string &outfile,
+                const std::vector<Segment> &segments, bool include_zi,
+                uint64_t datareclen) {
+  hex_write<SRec>(inobj, outfile, segments, include_zi, datareclen);
+}

--- a/arm-software/shared/elf2bin/test/makeelf.py
+++ b/arm-software/shared/elf2bin/test/makeelf.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (c) 2022-2025, Arm Limited and affiliates.
+#
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+"""Library code to make ELF files suitable for testing elf2bin.
+
+The main exported function is makeelf(), which constructs an ELF file
+based on its parameters and writes it to disk given a filename.
+
+"""
+
+import argparse
+import binascii
+import collections
+import struct
+
+
+class ElfHdr:
+    def __init__(self, bigend):
+        self.e_ident = list(b"\x7FELF") + [0] * 12
+        self.e_ident[5] = 2 if bigend else 1
+        self.e_type = 2  # ET_EXEC
+        self.e_machine = 0
+        self.e_version = self.e_ident[6] = 1  # EV_CURRENT
+        self.e_entry = 0
+        self.e_phoff = 0
+        self.e_shoff = 0
+        self.e_flags = 0
+        self.e_ehsize = 0
+        self.e_phentsize = 0
+        self.e_phnum = 0
+        self.e_shentsize = 0
+        self.e_shnum = 0
+        self.e_shstrndx = 0
+
+    def size(self):
+        return struct.calcsize(self.fmt)
+
+    def format(self):
+        return struct.pack(
+            self.fmt,
+            bytes(self.e_ident),
+            self.e_type,
+            self.e_machine,
+            self.e_version,
+            self.e_entry,
+            self.e_phoff,
+            self.e_shoff,
+            self.e_flags,
+            self.e_ehsize,
+            self.e_phentsize,
+            self.e_phnum,
+            self.e_shentsize,
+            self.e_shnum,
+            self.e_shstrndx,
+        )
+
+
+class ElfHdr32(ElfHdr):
+    def __init__(self, bigend):
+        super().__init__(bigend)
+        self.e_ident[4] = 1  # 32-bit
+        self.e_machine = 40  # EM_ARM
+        self.fmt = (">" if bigend else "<") + "16sHHLLLLLHHHHHH"
+        self.e_ehsize = self.size()
+
+
+class ElfHdr64(ElfHdr):
+    def __init__(self, bigend):
+        super().__init__(bigend)
+        self.e_ident[4] = 2  # 64-bit
+        self.e_machine = 183  # EM_AARCH64
+        self.fmt = (">" if bigend else "<") + "16sHHLQQQLHHHHHH"
+        self.e_ehsize = self.size()
+
+
+class ProgHdr:
+    def __init__(self, bigend):
+        self.p_type = 0
+        self.p_offset = 0
+        self.p_vaddr = 0
+        self.p_paddr = 0
+        self.p_filesz = 0
+        self.p_memsz = 0
+        self.p_flags = 0
+        self.p_align = 0
+
+    def size(self):
+        return struct.calcsize(self.fmt)
+
+
+class ProgHdr32(ProgHdr):
+    def __init__(self, bigend):
+        super().__init__(bigend)
+        self.fmt = (">" if bigend else "<") + "LLLLLLLL"
+
+    def format(self):
+        return struct.pack(
+            self.fmt,
+            self.p_type,
+            self.p_offset,
+            self.p_vaddr,
+            self.p_paddr,
+            self.p_filesz,
+            self.p_memsz,
+            self.p_flags,
+            self.p_align,
+        )
+
+
+class ProgHdr64(ProgHdr):
+    def __init__(self, bigend):
+        super().__init__(bigend)
+        self.fmt = (">" if bigend else "<") + "LLQQQQQQ"
+
+    def format(self):
+        return struct.pack(
+            self.fmt,
+            self.p_type,
+            self.p_flags,
+            self.p_offset,
+            self.p_vaddr,
+            self.p_paddr,
+            self.p_filesz,
+            self.p_memsz,
+            self.p_align,
+        )
+
+
+class Segment:
+    def __init__(self, data, pad):
+        self.data = data
+
+    def size(self):
+        return len(self.data)
+
+    def format(self):
+        return self.data
+
+
+pt_names = {
+    "PT_NULL": 0,
+    "PT_LOAD": 1,
+    "PT_DYNAMIC": 2,
+    "PT_INTERP": 3,
+    "PT_NOTE": 4,
+    "PT_SHLIB": 5,
+    "PT_PHDR": 6,
+    "PT_TLS": 7,
+}
+
+
+class SegmentDesc:
+    """Description of an ELF segment, used as a parameter to makeelf()."""
+
+    def __init__(self, segtype, paddr, data, pad=0, vaddr=None):
+        """Constructor for SegmentDesc.
+
+        `segtype` is the numeric value of the type of the segment,
+        e.g. 1 for PT_LOAD. `paddr` is the segment's physical address.
+        `vaddr` is its virtual address; you can leave it out (or pass
+        it as None) to make that the same as `paddr`. `data` is a
+        bytes-like object giving the initialized data of the segment;
+        `pad` is the length in bytes of uninitialized padding
+        following that data.
+
+        """
+        if vaddr is None:
+            vaddr = paddr
+        self.segtype = segtype
+        self.paddr = paddr
+        self.data = data
+        self.pad = pad
+        self.vaddr = vaddr
+
+    def __repr__(self):
+        return (
+            f"SegmentDesc(segtype={self.segtype!r}, "
+            f"paddr={self.paddr:#x}, data={self.data!r}, "
+            f"pad={self.pad!r}, vaddr={self.vaddr:#x})"
+        )
+
+
+def read_description_file(fh):
+    """Read an image description in the format described above."""
+
+    entry = 0
+    segments = []
+
+    for line in fh:
+        # Strip trailing newlines (forgiving Windows line endings if
+        # found), and discard empty lines and comments.
+        line = line.rstrip("\r\n")
+        if len(line) == 0 or line.startswith("#"):
+            continue
+
+        # Split line into words.
+        words = line.split(" ")
+
+        # Handle "entry" line, setting the entry point.
+        if words[0] == "entry":
+            entry = int(words[1], 0)
+            continue
+
+        # Otherwise, we expect that the line has at least three words:
+        # segment type, start address and hex-encoded data.
+        pt, addr, data = words[:3]
+        try:
+            pt = pt_names[pt]  # is the segment type a symbolic name?
+        except KeyError:
+            pt = int(pt)  # otherwise, parse it as an integer
+        if "/" in addr:
+            paddr, vaddr = (int(part, 0) for part in addr.split("/"))
+        else:
+            paddr = vaddr = int(addr, 0)
+        data = binascii.unhexlify(data)  # and decode the hex data
+
+        # If a fourth word appears on the line, interpret it as the
+        # size of zero padding after the segment data. Otherwise that's zero.
+        pad = 0 if len(words) == 3 else int(words[3], 0)
+
+        # Done. Append the segment description to the array we'll return.
+        segments.append(SegmentDesc(pt, paddr, data, pad, vaddr))
+
+    return segments, entry
+
+
+def makeelf(outfile, bigend, sixtyfour, segments, entry=None):
+    """Make an ELF image with no section header table and write it to `outfile`.
+
+    The ELF file is little-endian if `bigend` is False, or big-endian
+    if it is `True`. It is 32-bit if `sixtyfour` is False, or 64-bit
+    if it is `True`. `segments` gives the list of desired segments,
+    and `entry` gives the image's entry point address, if it is not None.
+
+    """
+    ehclass = ElfHdr64 if sixtyfour else ElfHdr32
+    phclass = ProgHdr64 if sixtyfour else ProgHdr32
+
+    fileitems = []
+
+    offset = 0
+
+    header = ehclass(bigend)
+    fileitems.append(header)
+    offset += header.size()
+
+    header.e_phoff = offset
+    header.e_phnum = len(segments)
+    header.e_phentsize = phclass(bigend).size()
+    header.e_entry = entry if entry else 0
+    offset += header.e_phnum * header.e_phentsize
+    ph = []
+    segs = []
+    for desc in segments:
+        seg = Segment(desc.data, desc.pad)
+        phent = phclass(bigend)
+        phent.p_type = desc.segtype
+        phent.p_offset = offset
+        phent.p_vaddr = desc.vaddr
+        phent.p_paddr = desc.paddr
+        phent.p_filesz = len(desc.data)
+        phent.p_memsz = len(desc.data) + desc.pad
+        ph.append(phent)
+        segs.append(seg)
+        offset += seg.size()
+
+    fileitems.extend(ph)
+    fileitems.extend(segs)
+
+    def write_to(fh):
+        for item in fileitems:
+            fh.write(item.format())
+
+    # Allow outfile to be a file name or a file handle
+    if isinstance(outfile, str):
+        with open(outfile, "wb") as fh:
+            write_to(fh)
+    else:
+        write_to(outfile)
+
+
+def main():
+    explanation = """\
+Make a minimal segment-only ELF file from a text description.
+
+This program expects an input text file describing one segment per
+line, such as this example:
+
+entry 0x1238
+PT_LOAD 0x1234 000102030405060708090A0B0C0D0E0F
+PT_LOAD 0x12345678 101112131415161718191A1B1C1D1E1F 32
+PT_LOAD 0x12345678/0xABCDEF00 101112131415161718191A1B1C1D1E1F 32
+
+Each segment line contains the segment type (symbolic or numeric), the
+base address, and the hex data to be stored in the file.
+
+If the base address field contains '/' then it will be treated as two
+different addresses, to be put in the p_paddr and p_vaddr fields
+respectively.
+
+An optional fourth field indicates the number of zero bytes of padding
+to specify after the segment data, by making its p_memsz bigger than
+p_filesz.
+
+A line beginning 'entry' specifies the entry point of the file.
+
+"""
+
+    opener = lambda mode: lambda fname: lambda: argparse.FileType(mode)(fname)
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=explanation,
+    )
+    parser.add_argument(
+        "infile",
+        type=opener("r"),
+        nargs="?",
+        default=opener("r")("-"),
+        help="Input file.",
+    )
+    parser.add_argument(
+        "-o", "--output", type=opener("wb"), required=True, help="Output file."
+    )
+    parser.add_argument("-b", "--bi", action="store_true", help="Big-endian")
+    parser.add_argument(
+        "-s", "--sixtyfour", action="store_true", help="64-bit"
+    )
+    args = parser.parse_args()
+
+    with args.infile() as fh:
+        segments, entry = read_description_file(fh)
+
+    with args.output() as fh:
+        makeelf(fh, args.bi, args.sixtyfour, segments, entry)
+
+
+if __name__ == "__main__":
+    main()

--- a/arm-software/shared/elf2bin/test/test.py
+++ b/arm-software/shared/elf2bin/test/test.py
@@ -1,0 +1,1339 @@
+#!/usr/bin/env python3
+
+# Test suite for elf2bin
+#
+# Copyright (c) 2022-2025, Arm Limited and affiliates.
+#
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+import argparse
+import contextlib
+import inspect
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from binascii import unhexlify
+
+from makeelf import makeelf, SegmentDesc
+
+elf2bin_path = None
+
+
+def to_vhx(data):
+    return "".join("{:02X}\n".format(byte) for byte in data)
+
+
+class Base(unittest.TestCase):
+    def __init__(self, *args, **kws):
+        super().__init__(*args, **kws)
+        self.next_index = {}
+
+    @contextlib.contextmanager
+    def tempsubdir(self):
+        """Return a subdirectory of the main tempdir, named after the calling
+        method so that it's easy to inspect the temp files."""
+        st = inspect.stack()
+        methodname = st[2].function
+        classname = type(self).__name__
+        dirbase = f"{classname}.{methodname}"
+        index = self.next_index.get(dirbase, 0)
+        self.next_index[dirbase] = index + 1
+        dirname = f"{dirbase}.{index:d}"
+        path = os.path.join(tempdir, dirname)
+        os.mkdir(path)
+
+        # Temporarily change directory to the subdir, yield to run the
+        # code wrapped in this context, and change back to the
+        # original directory after the code finishes.
+        if hasattr(os, "fchdir") and hasattr(os, "O_PATH"):
+            # On Unix, we can do this in a way that doesn't depend on
+            # string-based pathnames, and therefore is robust against
+            # the path structure of the filesystem changing while
+            # we're in the middle of working.
+            #
+            # For example, if an overzealous cleanup of /tmp (either
+            # manual or automatic) were to delete our whole working
+            # directory and someone else were to create a new one
+            # under the same name, then storing os.getcwd() as a
+            # string and os.chdir()ing to it afterwards would land us
+            # in the _new_ directory, and we'd start overwriting files
+            # belonging to some other process.
+            #
+            # A race-safe approach is to make a file descriptor
+            # pointing at the inode of our cwd, and use fchdir() to
+            # change back to it. Then we get back to the directory we
+            # were really in, even if it's not linked from the same
+            # place any more (or even at all).
+            here = os.open(".", os.O_PATH)
+            try:
+                os.chdir(path)
+                yield
+            finally:
+                os.fchdir(here)
+                os.close(here)
+        else:
+            # Fallback for Windows: if O_PATH and fchdir aren't
+            # available, do this the pedestrian way. On Windows that's
+            # probably safe anyway, because the more aggressive file
+            # locking policy means that as long as this process is in
+            # a subdir of our original tempdir, other processes
+            # _can't_ mess about with the pathname leading to it.
+            here = os.getcwd()
+            try:
+                os.chdir(path)
+                yield
+            finally:
+                os.chdir(here)
+
+    def elf2bin(self, *args, expect_error=False):
+        cmd = [elf2bin_path] + list(args)
+        with open("commands.txt", "a") as fh:
+            print(" ".join(map(shlex.quote, cmd)), file=fh)
+        p = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        out, err = p.communicate(b"")
+        p.wait()
+        if not expect_error:
+            self.assertEqual(err.decode("UTF-8"), "")
+            self.assertEqual(p.returncode, 0)
+        else:
+            self.assertNotEqual(p.returncode, 0)
+            return err.decode("UTF-8").rstrip("\r\n")
+
+
+class ihex(Base):
+    def testBasic(self):
+        """Test basic ihex output, with two widely separated segments, and
+        also demonstrate the 16-byte limit in each hex line.
+        """
+        for bigend in False, True:
+            for sixtyfour in False, True:
+                with self.tempsubdir():
+                    makeelf(
+                        "input.elf",
+                        bigend,
+                        sixtyfour,
+                        [
+                            SegmentDesc(1, 0x1234, bytes(range(20))),
+                            SegmentDesc(1, 0x123456, bytes(range(20, 24))),
+                        ],
+                        0x1238,
+                    )
+                    self.elf2bin("--ihex", "-o", "output.hex", "input.elf")
+                    with open("output.hex") as fh:
+                        hexdata = fh.read()
+                    self.assertEqual(
+                        hexdata,
+                        """\
+:10123400000102030405060708090A0B0C0D0E0F32
+:041244001011121360
+:020000040012E8
+:04345600141516171C
+:0400000500001238AD
+:00000001FF
+""",
+                    )
+
+    def testOffsetWrap(self):
+        "Check what happens when we wrap from one 16-bit top half to the next."
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                False,
+                [SegmentDesc(1, 0xFFF0, bytes(range(32)))],
+            )
+            self.elf2bin("--ihex", "-o", "output.hex", "input.elf")
+            with open("output.hex") as fh:
+                hexdata = fh.read()
+            self.assertEqual(
+                hexdata,
+                """\
+:10FFF000000102030405060708090A0B0C0D0E0F89
+:020000040001F9
+:10000000101112131415161718191A1B1C1D1E1F78
+:0400000500000000F7
+:00000001FF
+""",
+            )
+
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                True,
+                True,
+                [SegmentDesc(1, 0xFFF5, bytes(range(32)))],
+            )
+            self.elf2bin("--ihex", "-o", "output.hex", "input.elf")
+            with open("output.hex") as fh:
+                hexdata = fh.read()
+            self.assertEqual(
+                hexdata,
+                """\
+:10FFF500000102030405060708090A0B0C0D0E0F84
+:020000040001F9
+:10000500101112131415161718191A1B1C1D1E1F73
+:0400000500000000F7
+:00000001FF
+""",
+            )
+
+    def testDataRange(self):
+        "Test range checking of data addresses."
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [SegmentDesc(1, 0xFFFFFFFF, bytes(range(16)))],
+            )
+            self.elf2bin("--ihex", "-o", "output.hex", "input.elf")
+
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [SegmentDesc(1, 0x100000000, bytes(range(16)))],
+            )
+            err = self.elf2bin(
+                "--ihex", "-o", "output.hex", "input.elf", expect_error=True
+            )
+            self.assertEqual(
+                err,
+                "elf2bin: input.elf: data address does not " "fit in 32 bits",
+            )
+
+    def testEntryPointRange(self):
+        "Test range checking of data addresses."
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [SegmentDesc(1, 0, bytes(range(16)))],
+                0xFFFFFFFF,
+            )
+            self.elf2bin("--ihex", "-o", "output.hex", "input.elf")
+
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [SegmentDesc(1, 0, bytes(range(16)))],
+                0x100000000,
+            )
+            err = self.elf2bin(
+                "--ihex", "-o", "output.hex", "input.elf", expect_error=True
+            )
+            self.assertEqual(
+                err,
+                "elf2bin: input.elf: entry point does not " "fit in 32 bits",
+            )
+
+
+class srec(Base):
+    def testBasic(self):
+        "Test basic srec output, using the same test case as ihex."
+        for bigend in False, True:
+            for sixtyfour in False, True:
+                with self.tempsubdir():
+                    makeelf(
+                        "input.elf",
+                        bigend,
+                        sixtyfour,
+                        [
+                            SegmentDesc(1, 0x1234, bytes(range(20))),
+                            SegmentDesc(1, 0x123456, bytes(range(20, 24))),
+                        ],
+                        0x1238,
+                    )
+                    self.elf2bin("--srec", "-o", "output.hex", "input.elf")
+                    with open("output.hex") as fh:
+                        hexdata = fh.read()
+                    self.assertEqual(
+                        hexdata,
+                        """\
+S31500001234000102030405060708090A0B0C0D0E0F2C
+S30900001244101112135A
+S309001234561415161704
+S70500001238B0
+""",
+                    )
+
+    def testDataRange(self):
+        "Test range checking of data addresses."
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [SegmentDesc(1, 0xFFFFFFFF, bytes(range(16)))],
+            )
+            self.elf2bin("--srec", "-o", "output.hex", "input.elf")
+
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [SegmentDesc(1, 0x100000000, bytes(range(16)))],
+            )
+            err = self.elf2bin(
+                "--srec", "-o", "output.hex", "input.elf", expect_error=True
+            )
+            self.assertEqual(
+                err,
+                "elf2bin: input.elf: data address does not " "fit in 32 bits",
+            )
+
+    def testEntryPointRange(self):
+        "Test range checking of data addresses."
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [SegmentDesc(1, 0, bytes(range(16)))],
+                0xFFFFFFFF,
+            )
+            self.elf2bin("--srec", "-o", "output.hex", "input.elf")
+
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [SegmentDesc(1, 0, bytes(range(16)))],
+                0x100000000,
+            )
+            err = self.elf2bin(
+                "--srec", "-o", "output.hex", "input.elf", expect_error=True
+            )
+            self.assertEqual(
+                err,
+                "elf2bin: input.elf: entry point does not " "fit in 32 bits",
+            )
+
+
+class bin(Base):
+    def testOneSegment(self):
+        "Test basic binary output with a single segment."
+        segment_contents = bytes(range(20))
+
+        for bigend in False, True:
+            for sixtyfour in False, True:
+                with self.tempsubdir():
+                    makeelf(
+                        "input.elf",
+                        bigend,
+                        sixtyfour,
+                        [SegmentDesc(1, 0x1234, segment_contents)],
+                    )
+                    self.elf2bin("--bin", "-o", "output.bin", "input.elf")
+                    with open("output.bin", "rb") as fh:
+                        bindata = fh.read()
+                    self.assertEqual(bindata, segment_contents)
+
+    def testMultiSegments(self):
+        "Test multiple segments via -O."
+        segment1_contents = bytes(range(20))
+        segment2_contents = bytes(range(20, 32))
+
+        for bigend in False, True:
+            for sixtyfour in False, True:
+                with self.tempsubdir():
+                    makeelf(
+                        "input.elf",
+                        bigend,
+                        sixtyfour,
+                        [
+                            SegmentDesc(1, 0x1234, segment1_contents),
+                            SegmentDesc(1, 0x123456, segment2_contents),
+                        ],
+                    )
+
+                    self.elf2bin("--bin", "-O", "output-%a.bin", "input.elf")
+                    with open("output-1234.bin", "rb") as fh:
+                        bindata = fh.read()
+                    self.assertEqual(bindata, segment1_contents)
+                    with open("output-123456.bin", "rb") as fh:
+                        bindata = fh.read()
+                    self.assertEqual(bindata, segment2_contents)
+
+
+class bincombined(Base):
+    def testBasic(self):
+        "Test basic bincombined output."
+        segment1_contents = bytes(range(0x10))
+        segment2_contents = bytes(range(0x10, 0x20))
+
+        for bigend in False, True:
+            for sixtyfour in False, True:
+                with self.tempsubdir():
+                    makeelf(
+                        "input.elf",
+                        bigend,
+                        sixtyfour,
+                        [
+                            SegmentDesc(1, 0x1234, segment1_contents),
+                            SegmentDesc(1, 0x1264, segment2_contents),
+                        ],
+                    )
+
+                    self.elf2bin(
+                        "--bincombined", "-o", "output.bin", "input.elf"
+                    )
+                    with open("output.bin", "rb") as fh:
+                        bindata = fh.read()
+                    self.assertEqual(
+                        bindata,
+                        segment1_contents + b"\0" * 0x20 + segment2_contents,
+                    )
+
+    def testReversed(self):
+        "Test having the segments in the wrong order."
+        segment1_contents = bytes(range(0x10))
+        segment2_contents = bytes(range(0x10, 0x20))
+
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [
+                    SegmentDesc(1, 0x1264, segment2_contents),
+                    SegmentDesc(1, 0x1234, segment1_contents),
+                ],
+            )
+
+            self.elf2bin("--bincombined", "-o", "output.bin", "input.elf")
+            with open("output.bin", "rb") as fh:
+                bindata = fh.read()
+            self.assertEqual(
+                bindata, segment1_contents + b"\0" * 0x20 + segment2_contents
+            )
+
+    def testOverlapOK(self):
+        "Test overlap detection doesn't trigger on exactly-abutting segments."
+
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [
+                    SegmentDesc(1, 0x1000, b"\x00" * 0x100),
+                    SegmentDesc(1, 0x1100, b"\x01" * 0x100),
+                ],
+            )
+            self.elf2bin("--bincombined", "-o", "output.bin", "input.elf")
+
+    def testOverlapFail(self):
+        "Test overlap detection does trigger when segments overlap."
+
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [
+                    SegmentDesc(1, 0x1000, b"\x00" * 0x100),
+                    SegmentDesc(1, 0x10FF, b"\x01" * 0x100),
+                ],
+            )
+            err = self.elf2bin(
+                "--bincombined",
+                "-o",
+                "output.bin",
+                "input.elf",
+                expect_error=True,
+            )
+            self.assertEqual(
+                err,
+                "elf2bin: input.elf: segments at addresses "
+                "0x1000 and 0x10ff overlap",
+            )
+
+    def testOverlapMemsz(self):
+        "Test overlap detection also spots overlap of the p_memsz padding."
+
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [
+                    SegmentDesc(1, 0x1000, b"\x00" * 0x80, 0x80),
+                    SegmentDesc(1, 0x10FF, b"\x01" * 0x100),
+                ],
+            )
+            err = self.elf2bin(
+                "--bincombined",
+                "-o",
+                "output.bin",
+                "input.elf",
+                expect_error=True,
+            )
+            self.assertEqual(
+                err,
+                "elf2bin: input.elf: segments at addresses "
+                "0x1000 and 0x10ff overlap",
+            )
+
+    def testBaseAddr(self):
+        "Test the ability to specify a lower base address."
+        segment1_contents = bytes(range(0x10))
+        segment2_contents = bytes(range(0x10, 0x20))
+
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                False,
+                [
+                    SegmentDesc(1, 0x1234, segment1_contents),
+                    SegmentDesc(1, 0x1264, segment2_contents),
+                ],
+            )
+            self.elf2bin(
+                "--bincombined",
+                "--base",
+                "0x1200",
+                "-o",
+                "output.bin",
+                "input.elf",
+            )
+            with open("output.bin", "rb") as fh:
+                bindata = fh.read()
+            self.assertEqual(
+                bindata,
+                b"\0" * 0x34
+                + segment1_contents
+                + b"\0" * 0x20
+                + segment2_contents,
+            )
+
+            # Should be OK to restate the base address we were going
+            # to use anyway
+            self.elf2bin(
+                "--bincombined",
+                "--base",
+                "0x1234",
+                "-o",
+                "output.bin",
+                "input.elf",
+            )
+            with open("output.bin", "rb") as fh:
+                bindata = fh.read()
+            self.assertEqual(
+                bindata, segment1_contents + b"\0" * 0x20 + segment2_contents
+            )
+
+            # But even one byte higher is an error
+            err = self.elf2bin(
+                "--bincombined",
+                "--base",
+                "0x1235",
+                "-o",
+                "output.bin",
+                "input.elf",
+                expect_error=True,
+            )
+            self.assertEqual(
+                err,
+                "elf2bin: input.elf: first segment is at "
+                "address 0x1234, below the specified base address "
+                "0x1235",
+            )
+
+
+class vhx(Base):
+    def testOneSegment(self):
+        "Test basic vhx output with a single segment."
+        segment_contents = bytes(range(20))
+
+        for bigend in False, True:
+            for sixtyfour in False, True:
+                with self.tempsubdir():
+                    makeelf(
+                        "input.elf",
+                        bigend,
+                        sixtyfour,
+                        [SegmentDesc(1, 0x1234, segment_contents)],
+                    )
+                    self.elf2bin("--vhx", "-o", "output.hex", "input.elf")
+                    with open("output.hex") as fh:
+                        hexdata = fh.read()
+                    self.assertEqual(hexdata, to_vhx(segment_contents))
+
+    def testMultiSegments(self):
+        "Test multiple segments via -O."
+        segment1_contents = bytes(range(20))
+        segment2_contents = bytes(range(20, 32))
+
+        for bigend in False, True:
+            for sixtyfour in False, True:
+                with self.tempsubdir():
+                    makeelf(
+                        "input.elf",
+                        bigend,
+                        sixtyfour,
+                        [
+                            SegmentDesc(1, 0x1234, segment1_contents),
+                            SegmentDesc(1, 0x123456, segment2_contents),
+                        ],
+                    )
+
+                    self.elf2bin("--vhx", "-O", "output-%a.hex", "input.elf")
+                    with open("output-1234.hex") as fh:
+                        hexdata = fh.read()
+                    self.assertEqual(hexdata, to_vhx(segment1_contents))
+                    with open("output-123456.hex") as fh:
+                        hexdata = fh.read()
+                    self.assertEqual(hexdata, to_vhx(segment2_contents))
+
+    def testCombined(self):
+        "Test basic vhxcombined output."
+        segment1_contents = bytes(range(0x10))
+        segment2_contents = bytes(range(0x10, 0x20))
+
+        for bigend in False, True:
+            for sixtyfour in False, True:
+                with self.tempsubdir():
+                    makeelf(
+                        "input.elf",
+                        bigend,
+                        sixtyfour,
+                        [
+                            SegmentDesc(1, 0x1234, segment1_contents),
+                            SegmentDesc(1, 0x1264, segment2_contents),
+                        ],
+                    )
+
+                    self.elf2bin(
+                        "--vhxcombined", "-o", "output.hex", "input.elf"
+                    )
+                    with open("output.hex") as fh:
+                        hexdata = fh.read()
+                    self.assertEqual(
+                        hexdata,
+                        to_vhx(
+                            segment1_contents
+                            + b"\0" * 0x20
+                            + segment2_contents
+                        ),
+                    )
+
+
+class banks(Base):
+    def testParameters(self):
+        "Test the 'width' and 'banks' parameters."
+        input_data = bytes(range(32))
+
+        for mod in [2, 4, 8, 16]:
+            for width in [1, 2, 4, 8]:
+                if width >= mod:
+                    continue
+                banks = mod // width
+
+                with self.tempsubdir():
+                    makeelf(
+                        "input.elf",
+                        False,
+                        True,
+                        [SegmentDesc(1, 0x1000, input_data)],
+                    )
+                    self.elf2bin(
+                        "--bin",
+                        "-O",
+                        "output-%b.bin",
+                        "input.elf",
+                        "--banks",
+                        f"{width}x{banks}",
+                    )
+
+                    for bank in range(banks):
+                        with open(f"output-{bank}.bin", "rb") as fh:
+                            bindata = fh.read()
+                        self.assertEqual(
+                            bindata,
+                            bytes(
+                                b
+                                for i, b in enumerate(input_data)
+                                if (b % mod)
+                                in range(bank * width, (bank + 1) * width)
+                            ),
+                        )
+
+    def testFormats(self):
+        "Test that bank interleaving works for all four bin/vhx formats."
+        segment_contents1 = bytes(range(0x10))
+        segment_contents2 = bytes(range(0x10, 0x20))
+
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [
+                    SegmentDesc(1, 0x1000, segment_contents1),
+                    SegmentDesc(1, 0x1020, segment_contents2),
+                ],
+            )
+
+            self.elf2bin(
+                "--bin",
+                "-O",
+                "binmulti-%a-%b.bin",
+                "input.elf",
+                "--banks",
+                f"4x2",
+            )
+            with open(f"binmulti-1000-0.bin", "rb") as fh:
+                bindata = fh.read()
+                self.assertEqual(bindata, b"\x00\x01\x02\x03\x08\x09\x0a\x0b")
+            with open(f"binmulti-1000-1.bin", "rb") as fh:
+                bindata = fh.read()
+                self.assertEqual(bindata, b"\x04\x05\x06\x07\x0c\x0d\x0e\x0f")
+            with open(f"binmulti-1020-0.bin", "rb") as fh:
+                bindata = fh.read()
+                self.assertEqual(bindata, b"\x10\x11\x12\x13\x18\x19\x1a\x1b")
+            with open(f"binmulti-1020-1.bin", "rb") as fh:
+                bindata = fh.read()
+                self.assertEqual(bindata, b"\x14\x15\x16\x17\x1c\x1d\x1e\x1f")
+
+            self.elf2bin(
+                "--bincombined",
+                "-O",
+                "bincombined-%b.bin",
+                "input.elf",
+                "--banks",
+                f"4x2",
+            )
+            with open(f"bincombined-0.bin", "rb") as fh:
+                bindata = fh.read()
+                self.assertEqual(
+                    bindata,
+                    b"\x00\x01\x02\x03\x08\x09\x0a\x0b"
+                    b"\x00\x00\x00\x00\x00\x00\x00\x00"
+                    b"\x10\x11\x12\x13\x18\x19\x1a\x1b",
+                )
+            with open(f"bincombined-1.bin", "rb") as fh:
+                bindata = fh.read()
+                self.assertEqual(
+                    bindata,
+                    b"\x04\x05\x06\x07\x0c\x0d\x0e\x0f"
+                    b"\x00\x00\x00\x00\x00\x00\x00\x00"
+                    b"\x14\x15\x16\x17\x1c\x1d\x1e\x1f",
+                )
+
+            self.elf2bin(
+                "--vhx",
+                "-O",
+                "vhxmulti-%a-%b.hex",
+                "input.elf",
+                "--banks",
+                f"4x2",
+            )
+            with open(f"vhxmulti-1000-0.hex", "r") as fh:
+                hexdata = fh.read()
+                self.assertEqual(hexdata, "00\n01\n02\n03\n08\n09\n0A\n0B\n")
+            with open(f"vhxmulti-1000-1.hex", "r") as fh:
+                hexdata = fh.read()
+                self.assertEqual(hexdata, "04\n05\n06\n07\n0C\n0D\n0E\n0F\n")
+            with open(f"vhxmulti-1020-0.hex", "r") as fh:
+                hexdata = fh.read()
+                self.assertEqual(hexdata, "10\n11\n12\n13\n18\n19\n1A\n1B\n")
+            with open(f"vhxmulti-1020-1.hex", "r") as fh:
+                hexdata = fh.read()
+                self.assertEqual(hexdata, "14\n15\n16\n17\n1C\n1D\n1E\n1F\n")
+
+            self.elf2bin(
+                "--vhxcombined",
+                "-O",
+                "vhxcombined-%b.hex",
+                "input.elf",
+                "--banks",
+                f"4x2",
+            )
+            with open(f"vhxcombined-0.hex", "r") as fh:
+                hexdata = fh.read()
+                self.assertEqual(
+                    hexdata,
+                    "00\n01\n02\n03\n08\n09\n0A\n0B\n"
+                    "00\n00\n00\n00\n00\n00\n00\n00\n"
+                    "10\n11\n12\n13\n18\n19\n1A\n1B\n",
+                )
+            with open(f"vhxcombined-1.hex", "r") as fh:
+                hexdata = fh.read()
+                self.assertEqual(
+                    hexdata,
+                    "04\n05\n06\n07\n0C\n0D\n0E\n0F\n"
+                    "00\n00\n00\n00\n00\n00\n00\n00\n"
+                    "14\n15\n16\n17\n1C\n1D\n1E\n1F\n",
+                )
+
+
+class format(Base):
+    def testMultiFile(self):
+        "Test detection of file-written-multiple-times errors."
+        with self.tempsubdir():
+            makeelf(
+                "one.elf",
+                False,
+                False,
+                [SegmentDesc(1, 0x1234, b"a"), SegmentDesc(1, 0x123456, b"b")],
+            )
+            makeelf(
+                "two.elf",
+                True,
+                True,
+                [SegmentDesc(1, 0x1234, b"c"), SegmentDesc(1, 0x234567, b"d")],
+            )
+
+            # Expect that we can't give an output specification that
+            # lands both segments of one object in the same output file
+            err = self.elf2bin(
+                "--bin", "-o", "output.bin", "one.elf", expect_error=True
+            )
+            self.assertEqual(
+                err,
+                "elf2bin: output file 'output.bin' "
+                "would be written more than once by this command",
+            )
+
+            # Same for two files and a single output
+            err = self.elf2bin(
+                "--ihex",
+                "-o",
+                "output.hex",
+                "one.elf",
+                "two.elf",
+                expect_error=True,
+            )
+            self.assertEqual(
+                err,
+                "elf2bin: output file 'output.hex' "
+                "would be written more than once by this command",
+            )
+
+            # Or for binary files that overlap a base address
+            err = self.elf2bin(
+                "--bin",
+                "-O",
+                "%a.bin",
+                "one.elf",
+                "two.elf",
+                expect_error=True,
+            )
+            self.assertEqual(
+                err,
+                "elf2bin: output file '1234.bin' "
+                "would be written more than once by this command",
+            )
+
+            # But it's OK to generate two hex files using just %f
+            self.elf2bin("--ihex", "-O", "%f.hex", "one.elf", "two.elf")
+
+            # And it's OK to generate two bin files from one object
+            # using just %a
+            self.elf2bin("--bin", "-O", "%a.hex", "one.elf")
+
+    def testHex(self):
+        "Test formatting of hex numbers."
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [SegmentDesc(1, 0x0123456789ABCDEF, b"a")],
+            )
+            self.elf2bin("--bin", "-O", "output-%a.bin", "input.elf")
+            self.assertTrue(os.path.exists("output-123456789abcdef.bin"))
+
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [SegmentDesc(1, 0x0123456789ABCDEF, b"a")],
+            )
+            self.elf2bin("--bin", "-O", "output-%A.bin", "input.elf")
+            self.assertTrue(os.path.exists("output-123456789ABCDEF.bin"))
+
+        with self.tempsubdir():
+            makeelf("input.elf", False, True, [SegmentDesc(1, 0, b"a")])
+            self.elf2bin("--bin", "-O", "output-%a.bin", "input.elf")
+            self.assertTrue(os.path.exists("output-0.bin"))
+
+    def testFilename(self):
+        "Test formatting of parts of the input file name."
+        with self.tempsubdir():
+            makeelf("input.elf", False, True, [SegmentDesc(1, 0, b"a")])
+            self.elf2bin("--bin", "-O", "out-%f.bin", "./input.elf")
+            self.assertTrue(os.path.exists("out-input.bin"))
+
+        with self.tempsubdir():
+            makeelf("input.elf", False, True, [SegmentDesc(1, 0, b"a")])
+            self.elf2bin("--bin", "-O", "out-%F.bin", "./input.elf")
+            self.assertTrue(os.path.exists("out-input.elf.bin"))
+
+        if os.name == "nt":
+            # Also check backslash as a path separator
+            with self.tempsubdir():
+                makeelf("input.elf", False, True, [SegmentDesc(1, 0, b"a")])
+                self.elf2bin("--bin", "-O", "out-%f.bin", ".\\input.elf")
+                self.assertTrue(os.path.exists("out-input.bin"))
+
+            # And a plain drive-letter prefix
+            with self.tempsubdir():
+                makeelf("input.elf", False, True, [SegmentDesc(1, 0, b"a")])
+                fullpath = os.path.abspath("input.elf")
+                assert fullpath[1] == ":"  # expect this to start with a drive
+                testpath = fullpath[:2] + "input.elf"
+                self.elf2bin("--bin", "-O", "out-%f.bin", testpath)
+                self.assertTrue(os.path.exists("out-input.bin"))
+
+            # And make sure those work with %F as well
+            with self.tempsubdir():
+                makeelf("input.elf", False, True, [SegmentDesc(1, 0, b"a")])
+                self.elf2bin("--bin", "-O", "out-%F.bin", ".\\input.elf")
+                self.assertTrue(os.path.exists("out-input.elf.bin"))
+            with self.tempsubdir():
+                makeelf("input.elf", False, True, [SegmentDesc(1, 0, b"a")])
+                fullpath = os.path.abspath("input.elf")
+                assert fullpath[1] == ":"  # expect this to start with a drive
+                testpath = fullpath[:2] + "input.elf"
+                self.elf2bin("--bin", "-O", "out-%F.bin", testpath)
+                self.assertTrue(os.path.exists("out-input.elf.bin"))
+
+        else:
+            # If we're _not_ on Windows, make sure \ and : are treated
+            # as ordinary filename characters
+            with self.tempsubdir():
+                makeelf("i\\p:t.elf", False, True, [SegmentDesc(1, 0, b"a")])
+                self.elf2bin("--bin", "-O", "out-%f.bin", "i\\p:t.elf")
+                self.assertTrue(os.path.exists("out-i\\p:t.bin"))
+            with self.tempsubdir():
+                makeelf("i\\p:t.elf", False, True, [SegmentDesc(1, 0, b"a")])
+                self.elf2bin("--bin", "-O", "out-%F.bin", "i\\p:t.elf")
+                self.assertTrue(os.path.exists("out-i\\p:t.elf.bin"))
+
+    def testPercent(self):
+        "Test the %% escape to generate a single %."
+        with self.tempsubdir():
+            makeelf("input.elf", False, True, [SegmentDesc(1, 0, b"a")])
+            self.elf2bin("--bin", "-O", "%%.bin", "input.elf")
+            self.assertTrue(os.path.exists("%.bin"))
+
+
+class segselect(Base):
+    def testBin(self):
+        "Test --segments with multi-file binary output."
+        segment_contents1 = bytes(range(0x10))
+        segment_contents2 = bytes(range(0x10, 0x20))
+        segment_contents3 = bytes(range(0x20, 0x30))
+
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [
+                    SegmentDesc(1, 0x1000, segment_contents1),
+                    SegmentDesc(1, 0x1020, segment_contents2),
+                    SegmentDesc(1, 0x1040, segment_contents3),
+                ],
+            )
+
+            self.elf2bin(
+                "--bin",
+                "--segments",
+                "0x1000,0x1040",
+                "-O",
+                "output-%a.bin",
+                "input.elf",
+            )
+            with open(f"output-1000.bin", "rb") as fh:
+                bindata = fh.read()
+                self.assertEqual(bindata, segment_contents1)
+            with open(f"output-1040.bin", "rb") as fh:
+                bindata = fh.read()
+                self.assertEqual(bindata, segment_contents3)
+            self.assertFalse(os.path.exists("output-1020.bin"))
+
+    def testBinOne(self):
+        "Test --segments with binary output, selecting just one segment."
+        segment_contents1 = bytes(range(0x10))
+        segment_contents2 = bytes(range(0x10, 0x20))
+        segment_contents3 = bytes(range(0x20, 0x30))
+
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [
+                    SegmentDesc(1, 0x1000, segment_contents1),
+                    SegmentDesc(1, 0x1020, segment_contents2),
+                    SegmentDesc(1, 0x1040, segment_contents3),
+                ],
+            )
+
+            # The point is to check that now we can just use -o,
+            # because we're writing only one file.
+            self.elf2bin(
+                "--bin",
+                "--segments",
+                "0x1020",
+                "-o",
+                "output.bin",
+                "input.elf",
+            )
+            with open(f"output.bin", "rb") as fh:
+                bindata = fh.read()
+                self.assertEqual(bindata, segment_contents2)
+
+    def testVhxCombined(self):
+        "Test --segments with single-file VHX output."
+        segment_contents1 = bytes(range(0x10))
+        segment_contents2 = bytes(range(0x10, 0x20))
+        segment_contents3 = bytes(range(0x20, 0x30))
+
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [
+                    SegmentDesc(1, 0x1000, segment_contents1),
+                    SegmentDesc(1, 0x1020, segment_contents2),
+                    SegmentDesc(1, 0x1040, segment_contents3),
+                ],
+            )
+
+            self.elf2bin(
+                "--vhxcombined",
+                "--segments",
+                "0x1000,0x1040",
+                "-o",
+                "output.hex",
+                "input.elf",
+            )
+            with open(f"output.hex") as fh:
+                hexdata = fh.read()
+                self.assertEqual(
+                    hexdata,
+                    to_vhx(
+                        segment_contents1 + b"\0" * 0x30 + segment_contents3
+                    ),
+                )
+
+    def testIHex(self):
+        "Test --segments with ihex mode."
+        segment_contents1 = bytes(range(0x10))
+        segment_contents2 = bytes(range(0x10, 0x20))
+        segment_contents3 = bytes(range(0x20, 0x30))
+
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [
+                    SegmentDesc(1, 0x1000, segment_contents1),
+                    SegmentDesc(1, 0x1020, segment_contents2),
+                    SegmentDesc(1, 0x1040, segment_contents3),
+                ],
+            )
+
+            self.elf2bin(
+                "--ihex",
+                "--segments",
+                "0x1000,0x1040",
+                "-o",
+                "output.hex",
+                "input.elf",
+            )
+            with open(f"output.hex") as fh:
+                hexdata = fh.read()
+            self.assertEqual(
+                hexdata,
+                """\
+:10100000000102030405060708090A0B0C0D0E0F68
+:10104000202122232425262728292A2B2C2D2E2F28
+:0400000500000000F7
+:00000001FF
+""",
+            )
+
+    def testSRec(self):
+        "Test --segments with srec mode."
+        segment_contents1 = bytes(range(0x10))
+        segment_contents2 = bytes(range(0x10, 0x20))
+        segment_contents3 = bytes(range(0x20, 0x30))
+
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [
+                    SegmentDesc(1, 0x1000, segment_contents1),
+                    SegmentDesc(1, 0x1020, segment_contents2),
+                    SegmentDesc(1, 0x1040, segment_contents3),
+                ],
+            )
+
+            self.elf2bin(
+                "--srec",
+                "--segments",
+                "0x1000,0x1040",
+                "-o",
+                "output.hex",
+                "input.elf",
+            )
+            with open(f"output.hex") as fh:
+                hexdata = fh.read()
+            self.assertEqual(
+                hexdata,
+                """\
+S31500001000000102030405060708090A0B0C0D0E0F62
+S31500001040202122232425262728292A2B2C2D2E2F22
+S70500000000FA
+""",
+            )
+
+
+class zi(Base):
+    def testHex(self):
+        "Test --zi with the complex hex output modes."
+        segment_contents1 = bytes(range(19))
+        segment_contents2 = bytes(range(23))
+
+        # No need to test ihex and srec separately, since they share
+        # the code in question anyway
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [
+                    SegmentDesc(1, 0x1000, segment_contents1, 43),
+                    SegmentDesc(1, 0x1040, segment_contents2, 37),
+                ],
+            )
+
+            self.elf2bin("--srec", "--zi", "-o", "output.hex", "input.elf")
+            with open(f"output.hex") as fh:
+                hexdata = fh.read()
+            self.assertEqual(
+                hexdata,
+                """\
+S31500001000000102030405060708090A0B0C0D0E0F62
+S315000010101011120000000000000000000000000097
+S3150000102000000000000000000000000000000000BA
+S313000010300000000000000000000000000000AC
+S31500001040000102030405060708090A0B0C0D0E0F22
+S315000010501011121314151600000000000000000005
+S31500001060000000000000000000000000000000007A
+S311000010700000000000000000000000006E
+S70500000000FA
+""",
+            )
+
+    def testBinMulti(self):
+        "Test --zi with multiple-file binary output."
+        segment_contents1 = bytes(range(19))
+        segment_contents2 = bytes(range(23))
+
+        # No need to test bincombined and vhxcombined separately,
+        # since they share the code in question anyway
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [
+                    SegmentDesc(1, 0x1000, segment_contents1, 43),
+                    SegmentDesc(1, 0x1040, segment_contents2, 37),
+                ],
+            )
+
+            self.elf2bin("--bin", "--zi", "-O", "output-%a.bin", "input.elf")
+            with open(f"output-1000.bin", "rb") as fh:
+                bindata = fh.read()
+            self.assertEqual(bindata, segment_contents1 + b"\0" * 43)
+            with open(f"output-1040.bin", "rb") as fh:
+                bindata = fh.read()
+            self.assertEqual(bindata, segment_contents2 + b"\0" * 37)
+
+    def testBinCombined(self):
+        "Test --zi with single-file binary output."
+        segment_contents1 = bytes(range(19))
+        segment_contents2 = bytes(range(23))
+
+        # No need to test bincombined and vhxcombined separately,
+        # since they share the code in question anyway
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                True,
+                [
+                    SegmentDesc(1, 0x1000, segment_contents1, 43),
+                    SegmentDesc(1, 0x1040, segment_contents2, 37),
+                ],
+            )
+
+            self.elf2bin(
+                "--bincombined", "--zi", "-o", "output.bin", "input.elf"
+            )
+            with open(f"output.bin", "rb") as fh:
+                bindata = fh.read()
+            self.assertEqual(
+                bindata,
+                segment_contents1
+                + b"\0" * (0x40 - len(segment_contents1))
+                + segment_contents2
+                + b"\0" * 37,
+            )
+
+    def testBinCombined32(self):
+        "Test --zi in a 32-bit file."
+        segment_contents1 = bytes(range(19))
+        segment_contents2 = bytes(range(23))
+
+        # This just checks that p_memsz is correctly extracted from
+        # the other form of ELF program header table entry; there's no
+        # need to re-test every mode that uses it
+        with self.tempsubdir():
+            makeelf(
+                "input.elf",
+                False,
+                False,
+                [
+                    SegmentDesc(1, 0x1000, segment_contents1, 43),
+                    SegmentDesc(1, 0x1040, segment_contents2, 37),
+                ],
+            )
+
+            self.elf2bin(
+                "--bincombined", "--zi", "-o", "output.bin", "input.elf"
+            )
+            with open(f"output.bin", "rb") as fh:
+                bindata = fh.read()
+            self.assertEqual(
+                bindata,
+                segment_contents1
+                + b"\0" * (0x40 - len(segment_contents1))
+                + segment_contents2
+                + b"\0" * 37,
+            )
+
+
+class vaddr(Base):
+    def testVirtual(self):
+        "Test --virtual and --physical."
+        for sixtyfour in False, True:
+            with self.tempsubdir():
+                # Input file whose single segment has different physical
+                # and virtual addresses
+                makeelf(
+                    "input.elf",
+                    False,
+                    sixtyfour,
+                    [
+                        SegmentDesc(
+                            segtype=1, paddr=0x1234, vaddr=0x5678, data=b"a"
+                        )
+                    ],
+                )
+
+                # Expected Intel Hex output if the segment's physical
+                # address 0x1234 is used
+                expected_physical = """\
+:011234006158
+:0400000500000000F7
+:00000001FF
+"""
+
+                # Expected Intel Hex output if the segment's virtual
+                # address 0x5678 is used
+                expected_virtual = """\
+:0156780061D0
+:0400000500000000F7
+:00000001FF
+"""
+
+                # Explicitly select --physical
+                self.elf2bin(
+                    "--physical", "--ihex", "-o", "output.hex", "input.elf"
+                )
+                with open("output.hex") as fh:
+                    hexdata = fh.read()
+                self.assertEqual(hexdata, expected_physical)
+
+                # Explicitly select --virtual
+                self.elf2bin(
+                    "--virtual", "--ihex", "-o", "output.hex", "input.elf"
+                )
+                with open("output.hex") as fh:
+                    hexdata = fh.read()
+                self.assertEqual(hexdata, expected_virtual)
+
+                # Use the default, which we expect to match -- physical
+                self.elf2bin("--ihex", "-o", "output.hex", "input.elf")
+                with open("output.hex") as fh:
+                    hexdata = fh.read()
+                self.assertEqual(hexdata, expected_physical)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run tests.")
+    parser.add_argument("elf2bin", help="Path to elf2bin binary under test")
+    parser.add_argument(
+        "-d",
+        "--directory",
+        help="Store test files here rather than in a temporary directory. "
+        "This allows you to examine them afterwards and re-run the test "
+        "commands outside the test harness.",
+    )
+    parser.add_argument(
+        "testargs",
+        nargs=argparse.REMAINDER,
+        help="Arguments for unittest.main()",
+    )
+    args = parser.parse_args()
+
+    global elf2bin_path
+    elf2bin_path = os.path.abspath(args.elf2bin)
+
+    main = lambda: unittest.main(argv=[sys.argv[0]] + args.testargs)
+
+    global tempdir
+    if args.directory:
+        tempdir = args.directory
+        try:
+            os.mkdir(tempdir)
+        except FileExistsError:
+            pass
+        main()
+    else:
+        with tempfile.TemporaryDirectory() as td:
+            tempdir = td
+            main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This tool reads ELF image files, paying attention only to the 'segment' view of the file presented by the program header table, and ignoring the section header table completely (including not even noticing whether one exists).

It extracts the contents of the loadable segments of the file, and outputs them in various simple forms: plain binary files, two well-known hex file formats (Intel Hex and Motorola S-records), and the much simpler 'Verilog hex' format which is just a binary file with each byte translated into a two-digit hex number.

Additional features include the ability to restrict which segments are extracted; the choice of whether to output one binary file per segment or a single one that combines all segments at their correct relative offsets with padding in between; and the ability to distribute the output bytes across multiple output files suitable for loading into a banked ROM setup in which (for example) each of four ROMs holds only the bytes living at addresses with a particular residue mod 4.

In other words, this tool provides essentially all the same functionality that Arm Compiler's `fromelf` did, in its binary and hex output modes.