### PR TITLE
Re-enable automerge for the 20.x release branch

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -19,6 +19,8 @@ jobs:
         branches:
           - from_branch: main
             to_branch: arm-software
+          - from_branch: release/20.x
+            to_branch: release/arm-software/20.x
     steps:
       - name: Configure Access Token
         uses: actions/create-github-app-token@v1


### PR DESCRIPTION
Now that the releases of version 20.1.0 of ATfE and ATfE are complete,
this patch re-enables the runs of the Automerge workflow targeting the
`release/arm-software/20.x` branch to ensure the code is up to date with
upstream LLVM.
