### PR TITLE
Test large runners for Linux x86_64

### DIFF
--- a/.github/workflows/atfe_nightly_build_and_test.yml
+++ b/.github/workflows/atfe_nightly_build_and_test.yml
@@ -31,7 +31,7 @@ jobs:
         include:
           - build_script: build.sh
             test_script: test.sh
-            runner: ah-ubuntu_22_04-c7g_8x-100
+            runner: ToolchainGroup_LargeRunner_Linux-x64
           - build_script: build_llvmlibc_overlay.sh
             test_script: ''
             runner: ah-ubuntu_22_04-c7g_8x-100


### PR DESCRIPTION
Extend the nightly build-and-test workflow to run on both arm64 and x86_64 platforms. This change adds support for GitHub-hosted large runners targeting Linux x86_64, allowing us to validate toolchain builds across architectures.

This is part of an evaluation of GitHub’s large runners for Linux workloads.