### PR TITLE
[ATfE] Fix and re-enable package test on MacOS

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -887,13 +887,23 @@ add_custom_target(
     COMMAND "${CMAKE_COMMAND}" -E rm -rf unpack
     COMMAND "${CMAKE_COMMAND}" -E make_directory unpack
 )
-add_custom_target(
-    unpack-llvm-toolchain
-    COMMAND "${CMAKE_COMMAND}" -E tar x ${package_filepath}
-    DEPENDS ${package_filepath}
-    USES_TERMINAL
-    WORKING_DIRECTORY unpack
-)
+if(package_filename_extension STREQUAL ".dmg")
+    add_custom_target(
+        unpack-llvm-toolchain
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/extract_dmg.sh ${package_filepath} ${PACKAGE_FILE_NAME}
+        DEPENDS ${package_filepath}
+        USES_TERMINAL
+        WORKING_DIRECTORY unpack
+    )
+else()
+    add_custom_target(
+        unpack-llvm-toolchain
+        COMMAND "${CMAKE_COMMAND}" -E tar x ${package_filepath}
+        DEPENDS ${package_filepath}
+        USES_TERMINAL
+        WORKING_DIRECTORY unpack
+    )
+endif()
 add_dependencies(
     unpack-llvm-toolchain
     clear-unpack-directory
@@ -905,16 +915,7 @@ add_dependencies(check-llvm-toolchain check-${LLVM_TOOLCHAIN_C_LIBRARY})
 add_dependencies(check-llvm-toolchain check-compiler-rt)
 add_subdirectory(test)
 add_dependencies(check-llvm-toolchain check-llvm-toolchain-lit)
-
-# The package tests currently only support tar and zip, so don't
-# attempt to run them on other formats, such as dmg with macOS.
-# A dummy check-package-llvm-toolchain target is still
-# required for the test.sh script.
-if(package_filename_extension STREQUAL ".tar.xz" OR package_filename_extension STREQUAL ".zip")
-    add_subdirectory(packagetest)
-else()
-    add_custom_target(check-package-llvm-toolchain)
-endif()
+add_subdirectory(packagetest)
 
 if(LLVM_TOOLCHAIN_CROSS_BUILD_MINGW)
     find_program(MINGW_C_EXECUTABLE x86_64-w64-mingw32-gcc-posix REQUIRED)

--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -888,6 +888,8 @@ add_custom_target(
     COMMAND "${CMAKE_COMMAND}" -E make_directory unpack
 )
 if(package_filename_extension STREQUAL ".dmg")
+    # Extract only the toolchain directory from the .dmg file in ${package_filepath},
+    # as the image also includes a symlink to the "Applications" directory.
     add_custom_target(
         unpack-llvm-toolchain
         COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/extract_dmg.sh ${package_filepath} ${PACKAGE_FILE_NAME}

--- a/arm-software/embedded/scripts/extract_dmg.sh
+++ b/arm-software/embedded/scripts/extract_dmg.sh
@@ -27,13 +27,19 @@ DST_DIR="${3:-"."}"
 
 if command -v hdiutil > /dev/null; then
     ATTACH_OUTPUT=$( hdiutil attach -nobrowse -readonly "${DMG_PATH}" )
-    MOUNT_PATH=$( echo "${ATTACH_OUTPUT}" | grep '/Volumes/' | sed -r 's/.*(\/Volumes\/.*)/\1/' )
+    # The output of `hdiutil attach` includes a description of the mounted
+    # volumes with their corresponding mount path. E.g.:
+    # /dev/disk4     GUID_partition_scheme
+    # /dev/disk4s1   EFI
+    # /dev/disk4s2   Apple_HFS              /Volumes/ATfE-21.0.0-pre-Darwin-universal
+    MOUNT_PATH=$( echo "${ATTACH_OUTPUT}" | grep '/Volumes/' | sed -r 's!.*(/Volumes/.*)!\1!' )
     if [[ -z "${MOUNT_PATH}" ]]; then
         >&2 echo "ERROR: Path to mounted volume not found."
         exit 1
     fi
     cp -R "${MOUNT_PATH}"/${PATTERN_TO_EXTRACT} .
-    hdiutil detach "${MOUNT_PATH}"
+    EXITCODE=$?
+    hdiutil detach "${MOUNT_PATH}" && exit $EXITCODE
 else
     >&2 echo "ERROR: No application capable of extracting .dmg contents found."
     exit 1

--- a/arm-software/embedded/scripts/extract_dmg.sh
+++ b/arm-software/embedded/scripts/extract_dmg.sh
@@ -28,7 +28,8 @@ DST_DIR="${3:-"."}"
 if command -v hdiutil > /dev/null; then
     ATTACH_OUTPUT=$( hdiutil attach -nobrowse -readonly "${DMG_PATH}" )
     # The output of `hdiutil attach` includes a description of the mounted
-    # volumes with their corresponding mount path. E.g.:
+    # volumes that correspond to the specified .dmg file, where one of them
+    # maps to a path in `/Volumes/`. E.g.:
     # /dev/disk4     GUID_partition_scheme
     # /dev/disk4s1   EFI
     # /dev/disk4s2   Apple_HFS              /Volumes/ATfE-21.0.0-pre-Darwin-universal

--- a/arm-software/embedded/scripts/extract_dmg.sh
+++ b/arm-software/embedded/scripts/extract_dmg.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# A bash script for extracting the contents of a MacOS .dmg image.
+
+# The script takes the following arguments:
+# extract_dmg.sh <path_to_dmg> [<glob_pattern_to_extract>] [<dst_dir>]
+# * path_to_dmg: The path to the .dmg image to extract contents from
+# * glob_pattern_to_extract (optional): A glob pattern to match the contents
+#   to be extracted. The default is "*".
+# * dst_dir (optional): The directory into which the contents should be
+#   extracted. The default is the current working dir.
+
+if [[ -z "${1}" ]]; then
+    >&2 echo "ERROR: Path to .dmg file not provided."
+    echo "usage: ${0} <path_to_dmg> [<glob_pattern_to_extract>] [<dst_dir>]"
+    exit 1
+fi
+
+DMG_PATH="${1}"
+PATTERN_TO_EXTRACT="${2:-"*"}"
+DST_DIR="${3:-"."}"
+
+if command -v hdiutil > /dev/null; then
+    ATTACH_OUTPUT=$( hdiutil attach -nobrowse -readonly "${DMG_PATH}" )
+    MOUNT_PATH=$( echo "${ATTACH_OUTPUT}" | grep '/Volumes/' | sed -r 's/.*(\/Volumes\/.*)/\1/' )
+    if [[ -z "${MOUNT_PATH}" ]]; then
+        >&2 echo "ERROR: Path to mounted volume not found."
+        exit 1
+    fi
+    cp -R "${MOUNT_PATH}"/${PATTERN_TO_EXTRACT} .
+    hdiutil detach "${MOUNT_PATH}"
+else
+    >&2 echo "ERROR: No application capable of extracting .dmg contents found."
+    exit 1
+fi


### PR DESCRIPTION
The package test implementation curretly relies on using the CMake `tar`
command to unpack the toolchain for testing. As this CMake command is
not able to handle .dmg image files, the package test was disabled
temporarily on MacOS platforms.
This change implements an alternative way to unpack the toolchain .dmg
file for testing on MacOS. It introduces a new `extract_dmg.sh` script
that makes use of the `hdiutil` program to extract the contents
correctly. With the fix in place, this change also re-enables the
package tests on MacOS platforms.
