### PR TITLE
elf2bin: fix RTTI-related build failure under clang.

### DIFF
--- a/arm-software/shared/elf2bin/CMakeLists.txt
+++ b/arm-software/shared/elf2bin/CMakeLists.txt
@@ -7,6 +7,10 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
+set(CMAKE_MODULE_PATH
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../../llvm/cmake/modules ${CMAKE_MODULE_PATH})
+include(DetermineGCCCompatible)
+
 # Tell add_llvm_tool where to find tablegen to process Opts.td
 set(LLVM_TABLEGEN_EXE ${CMAKE_BINARY_DIR}/llvm/bin/llvm-tblgen)
 
@@ -29,7 +33,7 @@ include_directories(
 # Turn off RTTI: the LLVM libraries are compiled without it, so we
 # must compile without it too, or we'll get a link error trying to
 # find the RTTI for LLVM types such as llvm::opt::OptTable.
-if(CMAKE_COMPILER_IS_GNUCXX)
+if(LLVM_COMPILER_IS_GCC_COMPATIBLE)
   list(APPEND LLVM_COMPILE_FLAGS "-fno-rtti")
 elseif(MSVC)
   list(APPEND LLVM_COMPILE_FLAGS "/GR-")


### PR DESCRIPTION
elf2bin depends on the LLVM supporting libraries, which are built without RTTI. So it must also be built without RTTI, to avoid a link failure when the RTTI for `Elf2BinOptTable` tried to refer to the RTTI for its base classes in `libLLVMOption` and didn't find it.

I had intended to turn off RTTI in all our builds, by writing an if statement that knew the gcc option -fno-rtti and the MSVC option /GR-. But I put the wrong condition in the if, and only enabled -fno-rtti for gcc itself, not for all compilers with gcc-compatible command lines. So when building with clang, RTTI was enabled in elf2bin, and the link failed.