### PR TITLE
Add elf2bin to the build via LLVM_EXTERNAL_PROJECTS

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -204,6 +204,7 @@ set(LLVM_DISTRIBUTION_COMPONENTS
     clang-resource-headers
     clang
     dsymutil
+    elf2bin
     lld
     llvm-ar
     llvm-config
@@ -349,12 +350,15 @@ set(LLVM_TOOLCHAIN_PROJECT_CODE "E")
 set(LLVM_TOOLCHAIN_VERSION_SUFFIX "pre")
 include(${CMAKE_CURRENT_SOURCE_DIR}/../shared/cmake/generate_toolchain_id.cmake)
 
+# Include elf2bin
+set(LLVM_EXTERNAL_PROJECTS elf2bin)
+set(LLVM_EXTERNAL_ELF2BIN_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../shared/elf2bin)
+
 set(llvmproject_src_dir ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 add_subdirectory(
     ${llvmproject_src_dir}/llvm llvm
 )
 
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../shared/elf2bin elf2bin)
 add_dependencies(check-all check-elf2bin)
 
 if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL llvmlibc)

--- a/arm-software/shared/elf2bin/CMakeLists.txt
+++ b/arm-software/shared/elf2bin/CMakeLists.txt
@@ -7,13 +7,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 
-set(CMAKE_MODULE_PATH
-  ${CMAKE_CURRENT_SOURCE_DIR}/../../../llvm/cmake/modules ${CMAKE_MODULE_PATH})
-include(DetermineGCCCompatible)
-
-# Tell add_llvm_tool where to find tablegen to process Opts.td
-set(LLVM_TABLEGEN_EXE ${CMAKE_BINARY_DIR}/llvm/bin/llvm-tblgen)
-
 # Specify which LLVM libraries we want to link with
 set(LLVM_LINK_COMPONENTS
   Object
@@ -43,6 +36,10 @@ endif()
 set(LLVM_TARGET_DEFINITIONS Opts.td)
 tablegen(LLVM Opts.inc -gen-opt-parser-defs)
 add_public_tablegen_target(Elf2BinOptsTableGen)
+
+# Append elf2bin to LLVM_TOOLCHAIN_TOOLS, which will cause
+# add_llvm_tool to set it as an installable target.
+list(APPEND LLVM_TOOLCHAIN_TOOLS elf2bin)
 
 # Build the elf2bin binary itself.
 add_llvm_tool(elf2bin


### PR DESCRIPTION
Adding it directly via `add_subdirectory` meant that it was built, but not installed as part of the overall toolchain package, because I hadn't manually included a cmake `install` command.

I'd expected that `add_llvm_tool` would set up installation automatically. But in fact it only does that if the tool is on the list in `LLVM_TOOLCHAIN_TOOLS`. Worse, if the installation targets aren't set up by the time the main LLVM cmake setup finishes running, then adding the tool to `LLVM_DISTRIBUTION_COMPONENTS` causes another error, because the end of the LLVM cmake setup tries to add dependencies to all those targets. So calling `add_subdirectory` after LLVM installation finishes is simply too late. You need to arrange that elf2bin's `CMakeLists.txt` is invoked _during_ LLVM configuration.

`LLVM_EXTERNAL_PROJECTS` seems to be the LLVM cmake setup's escape hatch for downstreams to add extra things that aren't in the upstream tree. Configuring elf2bin in that before involving LLVM's cmake setup, instead of using `add_subdirectory` afterwards, does the right thing.

We still need to add elf2bin to `LLVM_TOOLCHAIN_TOOLS` to make the install targets exist, and add it to `LLVM_DISTRIBUTION_COMPONENTS` to make it one of the tools ATfE includes in the distribution package.

A nice side effect is that now that `elf2bin/CMakeLists.txt` is called _from_ the LLVM main cmake setup, we don't have to manually import as many of LLVM's cmake definitions – they're already in scope automatically.