### PR TITLE
Remove tests for Windows 

### DIFF
--- a/.github/workflows/atfe_nightly_build_and_test.yml
+++ b/.github/workflows/atfe_nightly_build_and_test.yml
@@ -112,6 +112,4 @@ jobs:
         if: success()
         with:
           name: ATfE-packages-${{ matrix.build_script }}-${{ matrix.target_os }}
-          path: |
-            build*/ATfE-*.tar.xz
-            build*/ATfE-*.zip
+          path: build*/ATfE-*.tar.xz

--- a/.github/workflows/atfe_nightly_build_and_test.yml
+++ b/.github/workflows/atfe_nightly_build_and_test.yml
@@ -44,7 +44,7 @@ jobs:
             runner: ah-ubuntu_22_04-c7g_8x-100
 
           - build_script: build.ps1
-            test_script: test.ps1
+            test_script: ''
             install_script: install_dependencies.ps1
             target_os: Windows-2022-x86_64
             runner: ToolchainGroup_LargeRunner_Windows-x64
@@ -112,4 +112,6 @@ jobs:
         if: success()
         with:
           name: ATfE-packages-${{ matrix.build_script }}-${{ matrix.target_os }}
-          path: build*/ATfE-*.tar.xz
+          path: |
+            build*/ATfE-*.tar.xz
+            build*/ATfE-*.zip

--- a/arm-software/embedded/scripts/build.ps1
+++ b/arm-software/embedded/scripts/build.ps1
@@ -18,5 +18,5 @@ $buildDir = (Join-Path $repoRoot build)
 mkdir $buildDir
 cd $buildDir
 
-cmake ..\arm-software\embedded -GNinja -DFETCHCONTENT_QUIET=OFF
+cmake ..\arm-software\embedded -GNinja -DFETCHCONTENT_QUIET=OFF -DENABLE_QEMU_TESTING=OFF
 ninja package-llvm-toolchain

--- a/arm-software/embedded/scripts/install_dependencies.ps1
+++ b/arm-software/embedded/scripts/install_dependencies.ps1
@@ -5,18 +5,6 @@
 #
 # This script installs the essential build dependencies for ATfE.
 
-# Fail on error
-$ErrorActionPreference = "Stop"
-
-# Ensure Chocolatey is available
-if (-not (Get-Command choco -ErrorAction SilentlyContinue)) {
-    Write-Error "Chocolatey is not installed!"
-    exit 1
-}
-
-# Install packages via Chocolatey
-choco install -y qemu --version=2024.12.20
-
 # Upgrade pip and install meson
 python -m pip install --upgrade pip
 python -m pip install meson==1.2.3


### PR DESCRIPTION
- Qemu is a requirement to run Windows tests. Therefore, not needed for now
- Disable qemu testing