### PR TITLE
Specify x86-64 target for the Windows ATfE build.

### DIFF
--- a/arm-software/embedded/scripts/build.ps1
+++ b/arm-software/embedded/scripts/build.ps1
@@ -10,7 +10,7 @@
 
 $installPath = &"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -version 16.0 -property installationpath
 Import-Module (Join-Path $installPath "Common7\Tools\Microsoft.VisualStudio.DevShell.dll")
-Enter-VsDevShell -VsInstallPath $installPath -SkipAutomaticLocation
+Enter-VsDevShell -VsInstallPath $installPath -SkipAutomaticLocation -DevCmdArguments "/arch=amd64"
 
 $repoRoot = git -C $PSScriptRoot rev-parse --show-toplevel
 $buildDir = (Join-Path $repoRoot build)


### PR DESCRIPTION
The Powershell `Enter-VsDevShell` cmdlet defaults to x86-32, so we were accidentally building 32-bit binaries of all the Windows tools.

Enter-VsDevShell doesn't have a target architecture option itself, according to its online help. But it lets you use -DevCmdArguments to pass options to the underlying thing it invokes (which I presume is one of the vsvars.bat files, from the output banner). It looks as if `/arch=amd64` is the way to select an x86-64 target.

My sources for this information are the following two snippets I found online:

* https://www.powershellgallery.com/packages/VisualStudioShell/0.2.0/Content/Enter-VisualStudioShell.ps1
* https://www.powershellgallery.com/packages/VisualStudioShell/0.2.0/Content/Format-VisualStudioShellArguments.ps1

The first of those is a wrapper around Enter-VsDevShell which accepts an architecture argument; the second is a subroutine it calls to construct the value to use with -DevCmdArguments. I haven't used the code itself, only examined it to see what the input architecture option ended up being translated into.