### PR TITLE
Add support to upload .zip build packages

### DIFF
--- a/.github/workflows/atfe_nightly_build_and_test.yml
+++ b/.github/workflows/atfe_nightly_build_and_test.yml
@@ -106,4 +106,6 @@ jobs:
         if: success()
         with:
           name: ATfE-packages-${{ matrix.build_script }}-${{ matrix.target_os }}
-          path: build*/ATfE-*.tar.xz
+          path: |
+            build*/ATfE-*.tar.xz
+            build*/ATfE-*.zip


### PR DESCRIPTION
- The Windows build step produces a build package with .zip extension