### PR TITLE
[ATfE] Enable aarch64 compiler-rt tests

### DIFF
--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_be.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_be.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_exn_rtti.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_soft_nofp.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_soft_nofp_exn_rtti.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_exn_rtti.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_exn_rtti_unaligned.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_soft_nofp.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_soft_nofp_exn_rtti.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_unaligned.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_be.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_be.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_exn_rtti.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_soft_nofp.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_soft_nofp_exn_rtti.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_exn_rtti.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_exn_rtti_unaligned.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_exn_rtti.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_exn_rtti_unaligned.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_unaligned.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_unaligned.json
@@ -21,7 +21,7 @@
             "PICOLIBC_BUILD_TYPE": "release",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {


### PR DESCRIPTION
After recent bug fixes, the AArch64 compiler-rt tests are passing, therefore we are able to enable them all.