### PR TITLE
Enable additional passes in OmaxLTO.cfg

### DIFF
--- a/arm-software/embedded/OmaxLTO.cfg
+++ b/arm-software/embedded/OmaxLTO.cfg
@@ -9,4 +9,7 @@
 -Wl,-plugin-opt=-unroll-max-iteration-count-to-analyze=20 \
 -Wl,-plugin-opt=-lsr-complexity-limit=1073741823 \
 -Wl,-plugin-opt=-force-attribute=main:norecurse \
-
+-Wl,-plugin-opt=-enable-dfa-jump-thread \
+-Wl,-plugin-opt=-enable-loop-flatten \
+-Wl,-plugin-opt=-enable-unroll-and-jam \
+-Wl,-plugin-opt=-enable-inline-memcpy-ld-st


### PR DESCRIPTION
Omax.cfg includes several options to enable additional passes, but we don't have the equivalent in OmaxLTO.cfg. Fix this, so that when using LTO these passes are enabled both in the initial compile step and in the LTO step.