### PR TITLE
Add post-merge workflow for ATfE

### DIFF
--- a/.github/workflows/atfe_post_merge.yml
+++ b/.github/workflows/atfe_post_merge.yml
@@ -4,8 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # This workflow is triggered automatically after a pull request is merged into:
-#   - the `arm-toolchain` branch
-#   - any `release/arm-software/**` branch
+#   - arm-toolchain branch
+#   - any release/arm-software/** branch
+#
+# It also runs after the completion of the Automerge workflow.
 #
 # It builds and tests the Arm Toolchain for Embedded (ATfE) to validate that the
 # merged changes do not introduce regressions and that the build remains stable.
@@ -13,17 +15,24 @@
 name: ATfE Post-Merge
 
 on:
-  # Trigger only when a PR is merged against specific branches
-  push:
+  # Trigger when a pull request is closed
+  pull_request:
+    types: [closed]
     branches:
       - arm-toolchain
       - release/arm-software/**
 
+  # Trigger after the Automerge workflow completes
+  workflow_run:
+    workflows: [Automerge]
+    types: [completed]
+
 jobs:
   build-and-test:
     name: Post-Merge - Branch ${{ github.ref_name }} SHA ${{ github.sha }}
-    # Ensure the workflow only runs on the arm-toolchain repository and not on forks
-    if: github.repository == 'arm/arm-toolchain'
+    # Ensure the workflow only runs on the arm-toolchain repository and not on forks,
+    # and only when a PR was merged or Automerge has completed
+    if: github.repository == 'arm/arm-toolchain' && (github.event_name == 'workflow_run' || github.event.pull_request.merged == true)
     # Arm64 runner
     runs-on: ah-ubuntu_22_04-c7g_8x-100
 
@@ -48,17 +57,3 @@ jobs:
 
       - name: Test
         run: ./arm-software/embedded/scripts/test.sh
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: test-results
-          path: build/**/*.junit.xml
-
-      - name: Upload built packages
-        uses: actions/upload-artifact@v4
-        if: success()
-        with:
-          name: ATfE-packages
-          path: build*/ATfE-*.tar.xz

--- a/.github/workflows/atfe_post_merge.yml
+++ b/.github/workflows/atfe_post_merge.yml
@@ -56,4 +56,4 @@ jobs:
         run: ./arm-software/embedded/scripts/build.sh
 
       - name: Test
-        run: ./arm-software/embedded/scripts/test.sh
+        run: ./arm-software/embedded/scripts/test_post-merge.sh

--- a/.github/workflows/atfe_post_merge.yml
+++ b/.github/workflows/atfe_post_merge.yml
@@ -1,0 +1,64 @@
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This workflow is triggered automatically after a pull request is merged into:
+#   - the `arm-toolchain` branch
+#   - any `release/arm-software/**` branch
+#
+# It builds and tests the Arm Toolchain for Embedded (ATfE) to validate that the
+# merged changes do not introduce regressions and that the build remains stable.
+
+name: ATfE Post-Merge
+
+on:
+  # Trigger only when a PR is merged against specific branches
+  push:
+    branches:
+      - arm-toolchain
+      - release/arm-software/**
+
+jobs:
+  build-and-test:
+    name: Post-Merge - Branch ${{ github.ref_name }} SHA ${{ github.sha }}
+    # Ensure the workflow only runs on the arm-toolchain repository and not on forks
+    if: github.repository == 'arm/arm-toolchain'
+    # Arm64 runner
+    runs-on: ah-ubuntu_22_04-c7g_8x-100
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: ./arm-software/embedded/scripts/install_dependencies.sh
+
+      - name: Add ~/.local/bin to PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Apply llvm-project patches
+        run: python3 arm-software/embedded/cmake/patch_repo.py --method apply arm-software/embedded/patches/llvm-project
+
+      - name: Apply llvm-project-perf patches
+        run: python3 arm-software/embedded/cmake/patch_repo.py --method apply arm-software/embedded/patches/llvm-project-perf
+
+      - name: Build
+        run: ./arm-software/embedded/scripts/build.sh
+
+      - name: Test
+        run: ./arm-software/embedded/scripts/test.sh
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: build/**/*.junit.xml
+
+      - name: Upload built packages
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: ATfE-packages
+          path: build*/ATfE-*.tar.xz

--- a/arm-software/embedded/scripts/test_post-merge.sh
+++ b/arm-software/embedded/scripts/test_post-merge.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# A bash script to run post-merge tests for the Arm Toolchain for Embedded.
+#
+# It assumes that a successful build of the toolchain already exists
+# in the 'build' directory within the repository tree.
+
+set -ex
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
+
+cd "${REPO_ROOT}"/build
+
+# If a test fails, lit will ordinarily return a non-zero result,
+# which prevents further testing. Setting the --ignore-fail option
+# will cause testing to continue, so that CI systems can get a
+# full set of results.
+# The check-all target runs the upstream clang and LLVM tests,
+# which do not generate a junit xml results file by default.
+# Additionally setting the --xunit-xml-output option store the
+# results.
+export LIT_OPTS="--ignore-fail --xunit-xml-output=results.xml"
+ninja check-all
+
+# The llvm-toolchain targets already set --xunit-xml-output so
+# only the --ignore-fail option is needed.
+# The picolibc tests do not use lit so do not support this option.
+export LIT_OPTS="--ignore-fail"
+ninja check-picolibc-aarch64a_unaligned \
+      check-compiler-rt-aarch64a_unaligned \
+      check-cxxabi-aarch64a_unaligned \
+      check-unwind-aarch64a_unaligned


### PR DESCRIPTION
- This workflow runs after a PR is merged into arm-toolchain or release/arm-software/**
- It builds and tests ATfE