### PR TITLE
Enable address sanitizer in Github Action for ATfE.

### DIFF
--- a/.github/workflows/atfe_address_sanitizer_build_and_test.yml
+++ b/.github/workflows/atfe_address_sanitizer_build_and_test.yml
@@ -3,14 +3,12 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# This workflow runs all build scripts in parallel for multiple operating
-# systems and architectures.
-# It is intended to be triggered as part of a **nightly build** to
-# validate all build configurations and test them automatically.
+# This workflow runs build script for address sanitizer for
+# Linux x86-64 architecture.
+# It is intended to be triggered as part of a **once a week build** to
+# validate build configurations and test them automatically.
 #
-# Each build script is paired with a corresponding test script using
-# a matrix strategy. Each build+test pair runs as a separate job,
-# allowing for concurrency and clear traceability of failures.
+# Build script is paired with a test script.
 
 name: ATfE Address Sanitizer Build and Test
 
@@ -20,7 +18,7 @@ on:
     - cron: '0 18 * * 0'  # Every Sunday at 6:00pm UTC
 
 jobs:
-  build-and-test-toolchain:
+  atfe-address-sanitizer-build-and-test-toolchain:
     name: Build ${{ matrix.build_script }} for ${{ matrix.target_os }} on ${{ matrix.runner }}
     runs-on: ${{ matrix.runner }}
     # Ensure the workflow only runs on the arm-toolchain repository and not on forks
@@ -35,7 +33,7 @@ jobs:
             test_script: test_atfe_sanitizer.sh
             install_script: install_dependencies.sh
             target_os: Ubuntu-22.04-x86_64
-            runner: ToolchainGroup_LargeRunner_Linux-x64
+            runner: ubuntu-22.04  
 
     steps:
       - name: Checkout

--- a/.github/workflows/atfe_address_sanitizer_build_and_test.yml
+++ b/.github/workflows/atfe_address_sanitizer_build_and_test.yml
@@ -1,0 +1,63 @@
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This workflow runs all build scripts in parallel for multiple operating
+# systems and architectures.
+# It is intended to be triggered as part of a **nightly build** to
+# validate all build configurations and test them automatically.
+#
+# Each build script is paired with a corresponding test script using
+# a matrix strategy. Each build+test pair runs as a separate job,
+# allowing for concurrency and clear traceability of failures.
+
+name: ATfE Address Sanitizer Build and Test
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 18 * * 0'  # Every Sunday at 6:00pm UTC
+
+jobs:
+  build-and-test-toolchain:
+    name: Build ${{ matrix.build_script }} for ${{ matrix.target_os }} on ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
+    # Ensure the workflow only runs on the arm-toolchain repository and not on forks
+    if: github.repository == 'arm/arm-toolchain'
+
+    strategy:
+      fail-fast: false  # Prevents one job failure from cancelling all
+      matrix:
+        include:
+          # Complete Toolchain Build & Test
+          - build_script: build_atfe_address_sanitizer.sh
+            test_script: test_atfe_sanitizer.sh
+            install_script: install_dependencies.sh
+            target_os: Ubuntu-22.04-x86_64
+            runner: ToolchainGroup_LargeRunner_Linux-x64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: ./arm-software/embedded/scripts/${{ matrix.install_script }}
+
+      - name: Add ~/.local/bin to PATH
+        if: runner.os != 'Windows'
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Apply llvm-project patches
+        run: python3 arm-software/embedded/cmake/patch_repo.py --method apply arm-software/embedded/patches/llvm-project
+
+      - name: Apply llvm-project-perf patches
+        run: python3 arm-software/embedded/cmake/patch_repo.py --method apply arm-software/embedded/patches/llvm-project-perf
+
+      - name: Build ${{ matrix.build_script }}
+        run: ./arm-software/embedded/scripts/${{ matrix.build_script }}
+
+      - name: Test ${{ matrix.test_script }}
+        if: matrix.test_script != ''
+        run: ./arm-software/embedded/scripts/${{ matrix.test_script }}
+

--- a/arm-software/embedded/scripts/build_atfe_address_sanitizer.sh
+++ b/arm-software/embedded/scripts/build_atfe_address_sanitizer.sh
@@ -5,7 +5,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# A bash script to build the Arm Toolchain for Embedded
+# A bash script to build the Arm Toolchain for Embedded, with address sanitizer enabled.
 
 # The script creates a build of the toolchain in the 'build' directory, inside
 # the repository tree.

--- a/arm-software/embedded/scripts/build_atfe_address_sanitizer.sh
+++ b/arm-software/embedded/scripts/build_atfe_address_sanitizer.sh
@@ -23,6 +23,9 @@ clang --version
 export CC=clang
 export CXX=clang++
 
+# Get processor count, to execute job in parallel threads
+PROCESSOR_COUNT=$(getconf _NPROCESSORS_ONLN)
+
 # Disable memory leaks detection of LeakSanitizer
 export ASAN_OPTIONS=detect_leaks=0
 
@@ -35,4 +38,4 @@ cd "${REPO_ROOT}"/build
 
 cmake ../arm-software/embedded -GNinja -DFETCHCONTENT_QUIET=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_USE_SANITIZER="Address" -DLLVM_ENABLE_ASSERTIONS=ON ${EXTRA_CMAKE_ARGS}
 
-ninja package-llvm-toolchain
+ninja -j$PROCESSOR_COUNT package-llvm-toolchain

--- a/arm-software/embedded/scripts/build_atfe_address_sanitizer.sh
+++ b/arm-software/embedded/scripts/build_atfe_address_sanitizer.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# A bash script to build the Arm Toolchain for Embedded
+
+# The script creates a build of the toolchain in the 'build' directory, inside
+# the repository tree.
+
+# If FVPs have been installed, the environment variable `FVP_INSTALL_DIR`
+# should be set to their install location to enable their use in tests.
+
+set -ex
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
+
+clang --version
+
+export CC=clang
+export CXX=clang++
+
+# Disable memory leaks detection of LeakSanitizer
+export ASAN_OPTIONS=detect_leaks=0
+
+if [[ ! -z "${FVP_INSTALL_DIR}" ]]; then
+    EXTRA_CMAKE_ARGS="${EXTRA_CMAKE_ARGS} -DENABLE_FVP_TESTING=ON -DFVP_INSTALL_DIR=${FVP_INSTALL_DIR}"
+fi
+
+mkdir -p "${REPO_ROOT}"/build
+cd "${REPO_ROOT}"/build
+
+cmake ../arm-software/embedded -GNinja -DFETCHCONTENT_QUIET=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_USE_SANITIZER="Address" -DLLVM_ENABLE_ASSERTIONS=ON ${EXTRA_CMAKE_ARGS}
+
+ninja package-llvm-toolchain

--- a/arm-software/embedded/scripts/test_atfe_sanitizer.sh
+++ b/arm-software/embedded/scripts/test_atfe_sanitizer.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# A bash script to run the tests from the Arm Toolchain for Embedded.
+
+# The script assumes a successful build of the toolchain exists in the 'build'
+# directory inside the repository tree.
+
+set -ex
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
+
+cd "${REPO_ROOT}"/build
+
+# The llvm-toolchain targets already set --xunit-xml-output so
+# only the --ignore-fail option is needed.
+# The picolibc tests do not use lit so do not support this option.
+export LIT_OPTS="--ignore-fail"
+ninja check-llvm-toolchain check-cxxabi check-unwind check-package-llvm-toolchain

--- a/arm-software/embedded/scripts/test_atfe_sanitizer.sh
+++ b/arm-software/embedded/scripts/test_atfe_sanitizer.sh
@@ -16,10 +16,13 @@ set -ex
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
 
+# Get processor count, to execute job in parallel threads
+PROCESSOR_COUNT=$(getconf _NPROCESSORS_ONLN)
+
 cd "${REPO_ROOT}"/build
 
 # The llvm-toolchain targets already set --xunit-xml-output so
 # only the --ignore-fail option is needed.
 # The picolibc tests do not use lit so do not support this option.
 export LIT_OPTS="--ignore-fail"
-ninja check-llvm-toolchain check-cxxabi check-unwind check-package-llvm-toolchain
+ninja -j$PROCESSOR_COUNT check-llvm-toolchain check-cxxabi check-unwind check-package-llvm-toolchain

--- a/arm-software/embedded/scripts/test_atfe_sanitizer.sh
+++ b/arm-software/embedded/scripts/test_atfe_sanitizer.sh
@@ -5,7 +5,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# A bash script to run the tests from the Arm Toolchain for Embedded.
+# A bash script to run the tests from the Arm Toolchain for Embedded, when sanitizers
+# are enabled.
 
 # The script assumes a successful build of the toolchain exists in the 'build'
 # directory inside the repository tree.


### PR DESCRIPTION
Enable address sanitizer in Github Action for ATfE. Job executes only once a week, on 6pm on Sunday. It executes limited tests on the compiled binaries and results are NOT uploaded.