### PR TITLE
[ATFE] Add -enable-loop-versioning-licm to Omax.cfg and OmaxLTO.cfg

### DIFF
--- a/arm-software/embedded/Omax.cfg
+++ b/arm-software/embedded/Omax.cfg
@@ -8,4 +8,5 @@
 -mllvm -enable-dfa-jump-thread \
 -mllvm -enable-loop-flatten \
 -mllvm -enable-unroll-and-jam \
--mllvm -enable-inline-memcpy-ld-st
+-mllvm -enable-inline-memcpy-ld-st \
+-mllvm -enable-loop-versioning-licm

--- a/arm-software/embedded/OmaxLTO.cfg
+++ b/arm-software/embedded/OmaxLTO.cfg
@@ -12,4 +12,5 @@
 -Wl,-plugin-opt=-enable-dfa-jump-thread \
 -Wl,-plugin-opt=-enable-loop-flatten \
 -Wl,-plugin-opt=-enable-unroll-and-jam \
--Wl,-plugin-opt=-enable-inline-memcpy-ld-st
+-Wl,-plugin-opt=-enable-inline-memcpy-ld-st \
+-Wl,-plugin-opt=-enable-loop-versioning-licm


### PR DESCRIPTION
Enabling this improves performance on a couple of embedded benchmarks.