### PR TITLE
Add Osize.cfg

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -340,6 +340,7 @@ install(
     FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/Omax.cfg
     ${CMAKE_CURRENT_SOURCE_DIR}/OmaxLTO.cfg
+    ${CMAKE_CURRENT_SOURCE_DIR}/Osize.cfg
     DESTINATION bin
     COMPONENT llvm-toolchain-config-files
 )

--- a/arm-software/embedded/Osize.cfg
+++ b/arm-software/embedded/Osize.cfg
@@ -1,0 +1,2 @@
+-Oz \
+-ffunction-sections -fdata-sections -Wl,--gc-sections

--- a/arm-software/embedded/README.md
+++ b/arm-software/embedded/README.md
@@ -186,6 +186,9 @@ to find out more. Users are also encouraged to create their own configs and tune
 flag parameters.
 Information on Arm Toolchain for Embedded specific optimization flags is available in [Optimization Flags](docs/optimization-flags.md)
 
+To optimize for code size, use `Osize.cfg` or a relevant subset of flags
+provided there.
+
 Binary releases of the Arm Toolchain for Embedded are based on release
 branches of the upstream LLVM Project, thus can safely be used with all tools
 provided by LLVM [releases](https://github.com/llvm/llvm-project/releases)


### PR DESCRIPTION
Add Osize.cfg, similar to Omax.cfg, to list command line options to optimize for code size.