### PR TITLE
[ATfL] Restore the use of -DLLVM_ENABLE_LIBCXX=ON in build.sh

### DIFF
--- a/arm-software/linux/build.sh
+++ b/arm-software/linux/build.sh
@@ -72,9 +72,11 @@ PRODUCT_CMAKE_FLAGS=(
     -DCMAKE_CXX_COMPILER="${BUILD_DIR}/bootstrap_compiler/bin/clang++"
     -DCMAKE_INSTALL_PREFIX="${ATFL_DIR}"
     -DLLVM_ENABLE_LLD=ON
+    -DLLVM_ENABLE_LIBCXX=ON
 )
 COMPILER_CMAKE_FLAGS=(
-    -DCMAKE_CXX_FLAGS="-stdlib++-isystem ${ATFL_DIR}/include/c++/v1 -D_LIBCPP_VERBOSE_ABORT_NOT_NOEXCEPT"
+    -DCMAKE_C_FLAGS="-fPIC"
+    -DCMAKE_CXX_FLAGS="-fPIC -stdlib++-isystem ${ATFL_DIR}/include/c++/v1 -D_LIBCPP_VERBOSE_ABORT_NOT_NOEXCEPT"
     -DCMAKE_EXE_LINKER_FLAGS="-L${ATFL_DIR}/lib -rtlib=compiler-rt -unwindlib=libunwind -Wl,--as-needed -stdlib=libc++"
     -DCMAKE_MODULE_LINKER_FLAGS="-L${ATFL_DIR}/lib -rtlib=compiler-rt -unwindlib=libunwind -Wl,--as-needed -stdlib=libc++"
     -DCMAKE_SHARED_LINKER_FLAGS="-L${ATFL_DIR}/lib -rtlib=compiler-rt -unwindlib=libunwind -Wl,--as-needed -stdlib=libc++"


### PR DESCRIPTION
Recently we removed -DLLVM_ENABLE_LIBCXX=ON from build.sh to prevent compiler warnings and sudden relocation errors at the link time.

This move was not justified properly. With removal of this setting, there is no CMake-level governance and reassurance that the LLVM's libc++ is astually being used as the C++ standard library. Currently we are ensuring that by using the -stdlib++-isystem flag fed directly to the compiler flags, along with -stdlib=libc++ fed directly to the linker flags. Although this is the right thing to do, it does not effect in a proper awareness at CMake level that libc++ is being used.

An observation has been made that restoring -DLLVM_ENABLE_LIBCXX=ON with current set of compiler flags results in CMake dropping the use of -fPIC from the compiler invocations, this happens despide our explicit use of -DLLVM_ENABLE_PIC=ON. As a result, the following relocation error is occuring at the link time:

```
ld.lld: error: relocation R_AARCH64_TLSLE_ADD_TPREL_HI12 against CurrentThreadTaskGroups cannot be used with -shared
```

To address it, this patch adds explicit use of the -fPIC flag to the compiler flags.