### PR TITLE
[ATfE] Build AArch64 libraries with -fPIC

### DIFF
--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a",
-            "COMPILE_FLAGS": "-march=armv8-a -mno-unaligned-access",
+            "COMPILE_FLAGS": "-march=armv8-a -mno-unaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_be.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_be.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_be",
-            "COMPILE_FLAGS": "-march=armv8-a -mbig-endian -mno-unaligned-access",
+            "COMPILE_FLAGS": "-march=armv8-a -mbig-endian -mno-unaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_be_exn_rtti",
-            "COMPILE_FLAGS": "-march=armv8-a -mbig-endian -mno-unaligned-access",
+            "COMPILE_FLAGS": "-march=armv8-a -mbig-endian -mno-unaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_soft_nofp.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_be_soft_nofp",
-            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mbig-endian -mabi=aapcs-soft -mno-unaligned-access",
+            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mbig-endian -mabi=aapcs-soft -mno-unaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_soft_nofp_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_be_soft_nofp_exn_rtti",
-            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mbig-endian -mabi=aapcs-soft -mno-unaligned-access",
+            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mbig-endian -mabi=aapcs-soft -mno-unaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_exn_rtti",
-            "COMPILE_FLAGS": "-march=armv8-a -mno-unaligned-access",
+            "COMPILE_FLAGS": "-march=armv8-a -mno-unaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_exn_rtti_unaligned.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_exn_rtti_unaligned",
-            "COMPILE_FLAGS": "-march=armv8-a",
+            "COMPILE_FLAGS": "-march=armv8-a -fPIC",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "qemu",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_soft_nofp.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_soft_nofp",
-            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access",
+            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_soft_nofp_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_soft_nofp_exn_rtti",
-            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access",
+            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "qemu",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_unaligned.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_unaligned",
-            "COMPILE_FLAGS": "-march=armv8-a",
+            "COMPILE_FLAGS": "-march=armv8-a -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r",
-            "COMPILE_FLAGS": "-march=armv8-r -mno-unaligned-access",
+            "COMPILE_FLAGS": "-march=armv8-r -mno-unaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_be.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_be.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_be",
-            "COMPILE_FLAGS": "-march=armv8-r -mbig-endian -mno-unaligned-access",
+            "COMPILE_FLAGS": "-march=armv8-r -mbig-endian -mno-unaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_be_exn_rtti",
-            "COMPILE_FLAGS": "-march=armv8-r -mbig-endian -mno-unaligned-access",
+            "COMPILE_FLAGS": "-march=armv8-r -mbig-endian -mno-unaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_soft_nofp.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_be_soft_nofp",
-            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mbig-endian -mabi=aapcs-soft -mno-unaligned-access",
+            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mbig-endian -mabi=aapcs-soft -mno-unaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_soft_nofp_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_be_soft_nofp_exn_rtti",
-            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mbig-endian -mabi=aapcs-soft -mno-unaligned-access",
+            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mbig-endian -mabi=aapcs-soft -mno-unaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_exn_rtti",
-            "COMPILE_FLAGS": "-march=armv8-r -mno-unaligned-access",
+            "COMPILE_FLAGS": "-march=armv8-r -mno-unaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_exn_rtti_unaligned.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_exn_rtti_unaligned",
-            "COMPILE_FLAGS": "-march=armv8-r",
+            "COMPILE_FLAGS": "-march=armv8-r -fPIC",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_soft_nofp",
-            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access",
+            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_soft_nofp_exn_rtti",
-            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access",
+            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_exn_rtti_unaligned.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_soft_nofp_exn_rtti_unaligned",
-            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mabi=aapcs-soft",
+            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mabi=aapcs-soft -fPIC",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_unaligned.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_soft_nofp_unaligned",
-            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mabi=aapcs-soft",
+            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mabi=aapcs-soft -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_unaligned.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_unaligned",
-            "COMPILE_FLAGS": "-march=armv8-r",
+            "COMPILE_FLAGS": "-march=armv8-r -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",


### PR DESCRIPTION
We have the need to support client code built with Position Independent Code (PIC) for AArch64.

Since PIC libraries are compatible with either PIC and non-PIC code, instead of duplicating all AArch64 libraries for PIC, we decided to transform the existing libraries into PIC.