### PR TITLE
Enable fstream independently of filesystem

### DIFF
--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -191,7 +191,8 @@ typedef basic_fstream<wchar_t> wfstream;
 #else
 #  include <__config>
 
-#  if _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
+// Downstream issue: #375 (Enable fstream independently of filesystem)
+//#  if _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
 
 #    include <__algorithm/max.h>
 #    include <__assert>
@@ -1573,7 +1574,8 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  endif // _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
+// Downstream issue: #375 (Enable fstream independently of filesystem)
+//#  endif // _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
 
 #  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #    include <atomic>

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -192,7 +192,7 @@ typedef basic_fstream<wchar_t> wfstream;
 #  include <__config>
 
 // Downstream issue: #375 (Enable fstream independently of filesystem)
-//#  if _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
+#  if _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION || defined(_NEWLIB_VERSION)
 
 #    include <__algorithm/max.h>
 #    include <__assert>
@@ -1574,8 +1574,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-// Downstream issue: #375 (Enable fstream independently of filesystem)
-//#  endif // _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
+#  endif // _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
 
 #  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #    include <atomic>

--- a/libcxx/src/ios.instantiations.cpp
+++ b/libcxx/src/ios.instantiations.cpp
@@ -38,12 +38,11 @@ template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ostringstream<char
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_istringstream<char>;
 
 // Downstream issue: #375 (Enable fstream independently of filesystem)
-//#if _LIBCPP_HAS_FILESYSTEM
+#if _LIBCPP_HAS_FILESYSTEM || defined(_NEWLIB_VERSION)
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ifstream<char>;
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ofstream<char>;
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_filebuf<char>;
-// Downstream issue: #375 (Enable fstream independently of filesystem)
-//#endif
+#endif
 
 // Add more here if needed...
 

--- a/libcxx/src/ios.instantiations.cpp
+++ b/libcxx/src/ios.instantiations.cpp
@@ -37,11 +37,13 @@ template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_stringstream<char>
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ostringstream<char>;
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_istringstream<char>;
 
-#if _LIBCPP_HAS_FILESYSTEM
+// Downstream issue: #375 (Enable fstream independently of filesystem)
+//#if _LIBCPP_HAS_FILESYSTEM
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ifstream<char>;
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ofstream<char>;
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_filebuf<char>;
-#endif
+// Downstream issue: #375 (Enable fstream independently of filesystem)
+//#endif
 
 // Add more here if needed...
 

--- a/libcxx/src/ostream.cpp
+++ b/libcxx/src/ostream.cpp
@@ -7,9 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include <__config>
-#if _LIBCPP_HAS_FILESYSTEM
+
+// Downstream issue: #375 (Enable fstream independently of filesystem)
+//#if _LIBCPP_HAS_FILESYSTEM
 #  include <fstream>
-#endif
+// Downstream issue: #375 (Enable fstream independently of filesystem)
+//#endif
 #include <ostream>
 
 #include "std_stream.h"

--- a/libcxx/src/ostream.cpp
+++ b/libcxx/src/ostream.cpp
@@ -9,10 +9,9 @@
 #include <__config>
 
 // Downstream issue: #375 (Enable fstream independently of filesystem)
-//#if _LIBCPP_HAS_FILESYSTEM
+#if _LIBCPP_HAS_FILESYSTEM || defined(_NEWLIB_VERSION)
 #  include <fstream>
-// Downstream issue: #375 (Enable fstream independently of filesystem)
-//#endif
+#endif
 #include <ostream>
 
 #include "std_stream.h"

--- a/libcxx/test/std/input.output/file.streams/fstreams/filebuf.members/native_handle.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/filebuf.members/native_handle.pass.cpp
@@ -13,6 +13,8 @@
 // class basic_filebuf;
 
 // native_handle_type native_handle() const noexcept;
+// Downstream issue: #375 (Enable fstream independently of filesystem)
+// UNSUPPORTED: baremetal
 
 #include <cassert>
 #include <fstream>

--- a/libcxx/test/std/input.output/file.streams/fstreams/filebuf.members/open_pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/filebuf.members/open_pointer.pass.cpp
@@ -14,6 +14,8 @@
 // XFAIL: (!c++03 && !c++11 && !c++14 && !c++17 && !c++20) && using-built-library-before-llvm-18
 
 // XFAIL: LIBCXX-AIX-FIXME
+// Downstream issue: #375 (Enable fstream independently of filesystem)
+// UNSUPPORTED: baremetal
 
 #include <fstream>
 #include <cassert>

--- a/libcxx/test/std/input.output/file.streams/fstreams/fstream.cons/pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/fstream.cons/pointer.pass.cpp
@@ -19,6 +19,8 @@
 // XFAIL: LIBCXX-AIX-FIXME
 
 // XFAIL: FROZEN-CXX03-HEADERS-FIXME
+// Downstream issue: #375 (Enable fstream independently of filesystem)
+// UNSUPPORTED: baremetal
 
 #include <fstream>
 #include <cassert>

--- a/libcxx/test/std/input.output/file.streams/fstreams/fstream.members/native_handle.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/fstream.members/native_handle.pass.cpp
@@ -13,6 +13,8 @@
 // class basic_fstream;
 
 // native_handle_type native_handle() const noexcept;
+// Downstream issue: #375 (Enable fstream independently of filesystem)
+// UNSUPPORTED: baremetal
 
 #include "test_macros.h"
 #include "../native_handle_test_helpers.h"

--- a/libcxx/test/std/input.output/file.streams/fstreams/fstream.members/open_pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/fstream.members/open_pointer.pass.cpp
@@ -17,6 +17,8 @@
 // XFAIL: (!c++03 && !c++11 && !c++14 && !c++17 && !c++20) && using-built-library-before-llvm-18
 
 // XFAIL: LIBCXX-AIX-FIXME
+// Downstream issue: #375 (Enable fstream independently of filesystem)
+// UNSUPPORTED: baremetal
 
 #include <fstream>
 #include <cassert>

--- a/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/native_handle.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/native_handle.pass.cpp
@@ -13,6 +13,8 @@
 // class basic_ifstream;
 
 // native_handle_type native_handle() const noexcept;
+// Downstream issue: #375 (Enable fstream independently of filesystem)
+// UNSUPPORTED: baremetal
 
 #include "test_macros.h"
 #include "../native_handle_test_helpers.h"

--- a/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
@@ -26,6 +26,9 @@
 // meaning it can represent file sizes up to 2GB (2^31 bytes) only.
 //
 // UNSUPPORTED: target=armv7-unknown-linux-gnueabihf
+// Downstream issue: #375 (Enable fstream independently of filesystem)
+// UNSUPPORTED: baremetal
+
 
 #include <fstream>
 #include <iostream>

--- a/libcxx/test/std/input.output/file.streams/fstreams/ofstream.cons/pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ofstream.cons/pointer.pass.cpp
@@ -19,6 +19,8 @@
 // XFAIL: LIBCXX-AIX-FIXME
 
 // XFAIL: FROZEN-CXX03-HEADERS-FIXME
+// Downstream issue: #375 (Enable fstream independently of filesystem)
+// UNSUPPORTED: baremetal
 
 #include <fstream>
 #include <cassert>

--- a/libcxx/test/std/input.output/file.streams/fstreams/ofstream.members/native_handle.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ofstream.members/native_handle.pass.cpp
@@ -13,6 +13,8 @@
 // class basic_ofstream;
 
 // native_handle_type native_handle() const noexcept;
+// Downstream issue: #375 (Enable fstream independently of filesystem)
+// UNSUPPORTED: baremetal
 
 #include "test_macros.h"
 #include "../native_handle_test_helpers.h"

--- a/libcxx/test/std/input.output/file.streams/fstreams/ofstream.members/open_pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ofstream.members/open_pointer.pass.cpp
@@ -17,6 +17,8 @@
 // XFAIL: (!c++03 && !c++11 && !c++14 && !c++17 && !c++20) && using-built-library-before-llvm-18
 
 // XFAIL: LIBCXX-AIX-FIXME
+// Downstream issue: #375 (Enable fstream independently of filesystem)
+// UNSUPPORTED: baremetal
 
 #include <fstream>
 #include <cassert>

--- a/libcxx/test/std/input.output/file.streams/lit.local.cfg
+++ b/libcxx/test/std/input.output/file.streams/lit.local.cfg
@@ -2,5 +2,6 @@
 if "no-localization" in config.available_features:
     config.unsupported = True
 
-if "no-filesystem" in config.available_features:
-    config.unsupported = True
+# Downstream issue: #375 (Enable fstream independently of filesystem)
+#if "no-filesystem" in config.available_features:
+#    config.unsupported = True

--- a/libcxx/test/std/input.output/file.streams/lit.local.cfg
+++ b/libcxx/test/std/input.output/file.streams/lit.local.cfg
@@ -5,3 +5,7 @@ if "no-localization" in config.available_features:
 # Downstream issue: #375 (Enable fstream independently of filesystem)
 #if "no-filesystem" in config.available_features:
 #    config.unsupported = True
+
+# Downstream issue: #375 (Enable fstream independently of filesystem)
+if 'none' in config.target_triple:
+    config.available_features.add('baremetal')

--- a/libcxx/test/support/platform_support.h
+++ b/libcxx/test/support/platform_support.h
@@ -40,6 +40,10 @@
 #   include <io.h> // _mktemp_s
 #   include <fcntl.h> // _O_EXCL, ...
 #   include <sys/stat.h> // _S_IREAD, ...
+// Downstream issue: #375 (Enable fstream independently of filesystem)
+#elif defined(_NEWLIB_VERSION)
+// No need to include extra headers for the get_temp_file_name() implementation
+// below: tmpnam() is defined in <stdio.h>
 #elif __has_include(<unistd.h>)
 #  include <unistd.h> // close
 #endif
@@ -70,6 +74,15 @@ inline std::string get_temp_file_name() {
       continue;
     abort();
   }
+// Downstream issue: #375 (Enable fstream independently of filesystem)
+#elif defined(_NEWLIB_VERSION)
+  char tmp_name[L_tmpnam];
+  char *ret = tmpnam(tmp_name);
+  if (ret == NULL) {
+    perror("tmpnam");
+    abort();
+  }
+  return std::string(ret);
 #elif !__has_include(<unistd.h>)
   // Without `unistd.h` we cannot guarantee that the file is unused, however we
   // can simply generate a good guess in the temporary folder and create it.


### PR DESCRIPTION
Downstream issue: #375

This enables fstream for embedded systems where basic file operations are available via semihosting, but not additional filesystem operations like managing directories.