### PR TITLE
Check and include newlib.h

### DIFF
--- a/libcxx/include/__configuration/platform.h
+++ b/libcxx/include/__configuration/platform.h
@@ -49,6 +49,11 @@
 #  include <picolibc.h>
 #endif
 
+// Downstream issue: 378 (Include newlib.h to define _NEWLIB_VERSION)
+#if __has_include(<newlib.h>)
+#  include <newlib.h>
+#endif
+
 #ifndef __BYTE_ORDER__
 #  error                                                                                                               \
       "Your compiler doesn't seem to define __BYTE_ORDER__, which is required by libc++ to know the endianness of your target platform"


### PR DESCRIPTION
Downstream issue: #378

Add a check if newlib.h is available and include it, if yes, to get the definition of _NEWLIB_VERSION similar to picolibc.h