### PR TITLE
Add crt0-none variant to llvmlibc-support

### DIFF
--- a/arm-software/embedded/llvmlibc-support/CMakeLists.txt
+++ b/arm-software/embedded/llvmlibc-support/CMakeLists.txt
@@ -22,7 +22,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 project(llvmlibc-support LANGUAGES C ASM)
 
-add_subdirectory(crt0) # crt0 and crt0-semihost
+add_subdirectory(crt0) # crt0, crt0-none and crt0-semihost
 add_subdirectory(semihost)
 
-install(TARGETS crt0 crt0-semihost semihost)
+install(TARGETS crt0 crt0-none crt0-semihost semihost)

--- a/arm-software/embedded/llvmlibc-support/crt0/CMakeLists.txt
+++ b/arm-software/embedded/llvmlibc-support/crt0/CMakeLists.txt
@@ -24,3 +24,7 @@ target_include_directories(crt0-semihost PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
+
+add_library(crt0-none STATIC
+  crt0-none.c
+)

--- a/arm-software/embedded/llvmlibc-support/crt0/crt0-none.c
+++ b/arm-software/embedded/llvmlibc-support/crt0/crt0-none.c
@@ -1,0 +1,9 @@
+//
+// Copyright (c) 2025, Arm Limited and affiliates.
+//
+// Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+// Intentionally left blank


### PR DESCRIPTION
For backwards compatibility in some testing, we need an empty variant to link with.