### PR TITLE
Update test script for sanitizers, reducing the list of covered tests to only M-profile coverage.

### DIFF
--- a/arm-software/embedded/scripts/test_atfe_sanitizer.sh
+++ b/arm-software/embedded/scripts/test_atfe_sanitizer.sh
@@ -26,11 +26,6 @@ cd "${REPO_ROOT}"/build
 # The picolibc tests do not use lit so do not support this option.
 export LIT_OPTS="--ignore-fail"
 ninja -j$PROCESSOR_COUNT check-all \
-    check-compiler-rt-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-picolibc-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-cxx-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-cxxabi-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-unwind-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
     check-compiler-rt-armv7m_hard_fpv5_d16_exn_rtti_unaligned \
     check-picolibc-armv7m_hard_fpv5_d16_exn_rtti_unaligned \
     check-cxx-armv7m_hard_fpv5_d16_exn_rtti_unaligned \


### PR DESCRIPTION
Update test script for sanitizers, reducing the list of covered tests to only M-profile coverage.