### PR TITLE
Set newlib optimization level to -Os

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -523,6 +523,7 @@ if(C_LIBRARY MATCHES "^newlib")
                 --enable-newlib-global-atexit)
         endif()
     else()
+        set(newlib_optim_flags "-Os")
         set(newlib_flags
             --enable-newlib-io-long-long
             --enable-newlib-register-fini


### PR DESCRIPTION
After -O2 optimization was removed in https://github.com/arm/arm-toolchain/pull/349 it was reported that memory usage increased a lot https://github.com/arm/arm-toolchain/issues/352

The proposed solution is to use -Os which is based on -O2, but takes care of code size that is important in embedded applications.