### PR TITLE
[ATfE] Use the runtimes project to build compiler-rt

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -253,14 +253,17 @@ endif()
 
 if(ENABLE_COMPILER_RT_TESTS)
     set(compiler_rt_test_flags "${lib_compile_flags} ${test_link_flags}")
-    set(compiler_rt_lit_args "${LLVM_LIT_ARGS} --xunit-xml-output=results.junit.xml")
+    set(compiler_rt_lit_args "${LLVM_LIT_ARGS} --path=${LLVM_BINARY_DIR}/bin --xunit-xml-output=results.junit.xml")
+    set(external_lit_path "${LLVM_BINARY_DIR}/bin/llvm-lit")
     set(
         compiler_rt_test_cmake_args
         -DCOMPILER_RT_INCLUDE_TESTS=ON
         -DCOMPILER_RT_EMULATOR=${lit_test_executor}
         -DCOMPILER_RT_TEST_COMPILER=${LLVM_BINARY_DIR}/bin/clang
         -DCOMPILER_RT_TEST_COMPILER_CFLAGS=${compiler_rt_test_flags}
+        -DLLVM_INCLUDE_TESTS=ON
         -DLLVM_LIT_ARGS=${compiler_rt_lit_args}
+        -DLLVM_EXTERNAL_LIT=${external_lit_path}
     )
 endif()
 
@@ -272,11 +275,11 @@ endif()
 
 ExternalProject_Add(
     compiler_rt
-    SOURCE_DIR ${llvmproject_src_dir}/compiler-rt
     STAMP_DIR ${PROJECT_PREFIX}/compiler_rt/${VARIANT_BUILD_ID}/stamp
     BINARY_DIR ${PROJECT_PREFIX}/compiler_rt/${VARIANT_BUILD_ID}/build
     DOWNLOAD_DIR ${PROJECT_PREFIX}/compiler_rt/${VARIANT_BUILD_ID}/dl
     TMP_DIR ${PROJECT_PREFIX}/compiler_rt/${VARIANT_BUILD_ID}/tmp
+    SOURCE_DIR ${llvmproject_src_dir}/runtimes
     INSTALL_DIR compiler-rt/install
     CMAKE_ARGS
     ${compiler_launcher_cmake_args}
@@ -303,7 +306,8 @@ ExternalProject_Add(
     -DCOMPILER_RT_BUILD_SANITIZERS=OFF
     -DCOMPILER_RT_BUILD_XRAY=OFF
     -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON
-    -DLLVM_CMAKE_DIR=${LLVM_BINARY_DIR}
+    -DLLVM_ENABLE_RUNTIMES=compiler-rt
+    -DRUNTIME_VARIANT_NAME=${VARIANT}
     -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON
     ${compiler_rt_test_cmake_args}
     STEP_TARGETS configure build install

--- a/arm-software/embedded/arm-runtimes/test-support/modify-compiler-rt-xml.py
+++ b/arm-software/embedded/arm-runtimes/test-support/modify-compiler-rt-xml.py
@@ -29,7 +29,7 @@ def main():
     # Variants such as armv8m.main need to be renamed.
     variant_name = args.variant.replace(".", "_")
 
-    xml_file = os.path.join(args.dir, "test", "results.junit.xml")
+    xml_file = os.path.join(args.dir, "compiler-rt", "test", "results.junit.xml")
 
     tree = ElementTree.parse(xml_file)
     root = tree.getroot()


### PR DESCRIPTION
When building the compiler-rt project using its standalone mode, its
CMake files will load the data from the pre-existing LLVM build via
`find_package(LLVM)` to collect information about the build
configuration. Doing this has the side effect of also including all the
libraries used by the pre-existing LLVM build as CMake targets of the
compiler-rt sub-project.

As the compiler-rt variants are being cross-compiled as part of ATfE to
target embedded environments, loading the library targets pre-compiled
to target the host environment during the LLVM build can cause conflicts
in CMake. Such incompatibilities have started to trigger an error during
ATfE builds on recent versions of CMake - e.g. version 4 and above -,
where the shared libraries (such as libLTO) will be reject by CMake when
the target does not support dynamic linking.

To fix this issue, this patch updates the method used by ATfE to build
compiler-rt. It now uses the `runtimes` project to perform the build
instead of building compiler-rt in standalone mode.

Fixes #337.
