### PR TITLE
[ATfE] Fix bootcode not working for ARMv4T

### DIFF
--- a/arm-software/embedded/llvmlibc-support/crt0/bootcode.cpp
+++ b/arm-software/embedded/llvmlibc-support/crt0/bootcode.cpp
@@ -22,6 +22,7 @@
 #include "system_registers_m.h"
 #else
 // ARMv4T
+// TODO: fill in stub functions once we can start testing LLVM-libc
 namespace bootcode {
 namespace exceptions {
 void setup() noexcept {}

--- a/arm-software/embedded/llvmlibc-support/crt0/bootcode.cpp
+++ b/arm-software/embedded/llvmlibc-support/crt0/bootcode.cpp
@@ -7,6 +7,8 @@
 //
 
 #include <stdint.h>
+#include <stdlib.h> // for exit()
+#include <string.h> // for memcpy(), memset()
 
 #if __ARM_ARCH_PROFILE == 'A' || __ARM_ARCH_PROFILE == 'R'
 #include "exceptions_a.h"
@@ -18,6 +20,23 @@
 #include "memory_m.h"
 #include "misc_m.h"
 #include "system_registers_m.h"
+#else
+// ARMv4T
+namespace bootcode {
+namespace exceptions {
+void setup() noexcept {}
+} // namespace exceptions
+
+namespace memory {
+void enable_cache() noexcept {}
+void setup() noexcept {}
+} // namespace memory
+
+namespace misc {
+void setup() noexcept {}
+} // namespace misc
+
+} // namespace bootcode
 #endif
 
 using namespace bootcode;
@@ -35,6 +54,7 @@ extern char __data_start[];
 extern char __data_size[];
 extern char __bss_start[];
 extern char __bss_size[];
+extern char __stack __attribute__((weak));
 
 #ifdef __ARM_FEATURE_PAUTH
 // Disable pointer authentication, as it isn't enabled until misc::setup meaning


### PR DESCRIPTION
To fix some of the nightly failing build errors (introduced by the patch https://github.com/arm/arm-toolchain/pull/394) which was caused by the ARMv4T variant, stub functions need to be introduced temporarily. 

Previously, only ARM architectures 'A', 'R' and 'M' were considered, therefore the `#if ... #endif` clause would miss any other variants. When tests are able to run, we can fill in the stub functions to fix any future failed tests, but up until the tests, this acts to suppress the build errors.