### PR TITLE
[ATfE] pacret_bti variants shouldn't be built with pacbti

### DIFF
--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "armv8.1m.main",
             "VARIANT": "armv8.1m.main_hard_fp_nomve_pacret_bti",
-            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+nomve+pacbti -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti -mno-unaligned-access",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+nomve -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti -mno-unaligned-access",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "armv8.1m.main",
             "VARIANT": "armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti",
-            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+nomve+pacbti -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti -mno-unaligned-access",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+nomve -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti -mno-unaligned-access",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti_unaligned.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "armv8.1m.main",
             "VARIANT": "armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti_unaligned",
-            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+nomve+pacbti -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+nomve -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_unaligned.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "armv8.1m.main",
             "VARIANT": "armv8.1m.main_hard_fp_nomve_pacret_bti_unaligned",
-            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+nomve+pacbti -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+nomve -mfpu=fp-armv8-fullfp16-sp-d16 -mbranch-protection=pac-ret+bti",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "armv8.1m.main",
             "VARIANT": "armv8.1m.main_hard_fpdp_nomve_pacret_bti",
-            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+nomve+pacbti -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti -mno-unaligned-access",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+nomve -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti -mno-unaligned-access",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "armv8.1m.main",
             "VARIANT": "armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti",
-            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+nomve+pacbti -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti -mno-unaligned-access",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+nomve -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti -mno-unaligned-access",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti_unaligned.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "armv8.1m.main",
             "VARIANT": "armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti_unaligned",
-            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+nomve+pacbti -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+nomve -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_unaligned.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "armv8.1m.main",
             "VARIANT": "armv8.1m.main_hard_fpdp_nomve_pacret_bti_unaligned",
-            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+nomve+pacbti -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+nomve -mfpu=fp-armv8-fullfp16-d16 -mbranch-protection=pac-ret+bti",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "armv8.1m.main",
             "VARIANT": "armv8.1m.main_hard_nofp_mve_pacret_bti",
-            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+mve+pacbti -mfpu=none -mbranch-protection=pac-ret+bti -mno-unaligned-access",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+mve -mfpu=none -mbranch-protection=pac-ret+bti -mno-unaligned-access",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "armv8.1m.main",
             "VARIANT": "armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti",
-            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+mve+pacbti -mfpu=none -mbranch-protection=pac-ret+bti -mno-unaligned-access",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+mve -mfpu=none -mbranch-protection=pac-ret+bti -mno-unaligned-access",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti_unaligned.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "armv8.1m.main",
             "VARIANT": "armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti_unaligned",
-            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+mve+pacbti -mfpu=none -mbranch-protection=pac-ret+bti",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+mve -mfpu=none -mbranch-protection=pac-ret+bti",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_unaligned.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "armv8.1m.main",
             "VARIANT": "armv8.1m.main_hard_nofp_mve_pacret_bti_unaligned",
-            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+mve+pacbti -mfpu=none -mbranch-protection=pac-ret+bti",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv8.1m.main+mve -mfpu=none -mbranch-protection=pac-ret+bti",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "armv8.1m.main",
             "VARIANT": "armv8.1m.main_soft_nofp_nomve_pacret_bti",
-            "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv8.1m.main+nomve+pacbti -mfpu=none -mbranch-protection=pac-ret+bti -mno-unaligned-access",
+            "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv8.1m.main+nomve -mfpu=none -mbranch-protection=pac-ret+bti -mno-unaligned-access",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "armv8.1m.main",
             "VARIANT": "armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti",
-            "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv8.1m.main+nomve+pacbti -mfpu=none -mbranch-protection=pac-ret+bti -mno-unaligned-access",
+            "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv8.1m.main+nomve -mfpu=none -mbranch-protection=pac-ret+bti -mno-unaligned-access",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti_unaligned.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "armv8.1m.main",
             "VARIANT": "armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti_unaligned",
-            "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv8.1m.main+nomve+pacbti -mfpu=none -mbranch-protection=pac-ret+bti",
+            "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv8.1m.main+nomve -mfpu=none -mbranch-protection=pac-ret+bti",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_unaligned.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "armv8.1m.main",
             "VARIANT": "armv8.1m.main_soft_nofp_nomve_pacret_bti_unaligned",
-            "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv8.1m.main+nomve+pacbti -mfpu=none -mbranch-protection=pac-ret+bti",
+            "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv8.1m.main+nomve -mfpu=none -mbranch-protection=pac-ret+bti",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",


### PR DESCRIPTION
In multilib.json the flags for these library variants don't have pacbti, so if we compile with e.g. -mcpu=cortex-m55 -mbranch-protection=standard we select the pacret_bti variant and end up executing an undefined bxaut instruction. Fix this by not building with pacbti, which means -mbranch-protection=standard causes instructions to be used that are forward-compatible with pacbti but are nop without it.