### PR TITLE
Check review approvals in downstream changes

### DIFF
--- a/.github/workflows/check_downstream_changes.yml
+++ b/.github/workflows/check_downstream_changes.yml
@@ -35,9 +35,7 @@ jobs:
   check-downstream-changes:
     runs-on: ubuntu-24.04-arm
 
-    if: github.repository == 'arm/arm-toolchain' &&
-      (github.event.pull_request.base.ref == 'arm-software' ||
-      startsWith(github.event.pull_request.base.ref, 'release/arm-software/')
+    if: github.repository == 'arm/arm-toolchain' && (github.event.pull_request.base.ref == 'arm-software' || startsWith(github.event.pull_request.base.ref, 'release/arm-software/'))
 
     steps:
       - name: Checkout

--- a/arm-software/ci/check_downstream_changes.py
+++ b/arm-software/ci/check_downstream_changes.py
@@ -323,7 +323,7 @@ def add_issue_label(issue_num: str, repo: str, input_json: dict) -> None:
 
 # Add a comment explaining the additional requirements for downstream changes
 def add_help_comment(pr_num: str, repo: str, input_json: dict) -> None:
-    # Check if the comment has already been made first, so as to repost
+    # Check if the comment has already been made first, so as not to repost
     # every time the script runs.
     for comment_json in input_json["comments"]:
         if comment_json["body"] == HELP_COMMENT_TEXT:


### PR DESCRIPTION
Currently, pull requests only require a single approved review in order to merge. For downstream changes, we would prefer both product teams to review the changes first, but GitHub does not have the functionality to set different merge requirements depending on the paths of the changed files.

However, since we have a script that already runs on downstream changes to check it meets certain requirements, this could also check the review state and which teams have approved. This patch adds this additional check, getting the review information from the existing query and using the API to get the members of each team. If a review from a team is missing, the check will fail which will prevent merging. Once both have approved, the check will pass allowing merging.

The script automatically runs on modifications to the pull request, so it is additionally set to trigger when a pull request is reviewed. The `pull_request_review` trigger does not have a `branches` filter, so the job is set to run conditionally instead.