### PR TITLE
[ATfE] Build `armv8m.main` picolibc with minsize

### DIFF
--- a/arm-software/embedded/arm-multilib/json/variants/armv8m.main_hard_fp_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8m.main_hard_fp_exn_rtti_unaligned.json
@@ -18,7 +18,7 @@
             "STACK_SIZE": "4K"
         },
         "picolibc": {
-            "PICOLIBC_BUILD_TYPE": "release",
+            "PICOLIBC_BUILD_TYPE": "minsize",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8m.main_hard_fp_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8m.main_hard_fp_unaligned.json
@@ -18,7 +18,7 @@
             "STACK_SIZE": "4K"
         },
         "picolibc": {
-            "PICOLIBC_BUILD_TYPE": "release",
+            "PICOLIBC_BUILD_TYPE": "minsize",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8m.main_soft_nofp_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8m.main_soft_nofp_exn_rtti_unaligned.json
@@ -18,7 +18,7 @@
             "STACK_SIZE": "4K"
         },
         "picolibc": {
-            "PICOLIBC_BUILD_TYPE": "release",
+            "PICOLIBC_BUILD_TYPE": "minsize",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8m.main_soft_nofp_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8m.main_soft_nofp_unaligned.json
@@ -18,7 +18,7 @@
             "STACK_SIZE": "4K"
         },
         "picolibc": {
-            "PICOLIBC_BUILD_TYPE": "release",
+            "PICOLIBC_BUILD_TYPE": "minsize",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",


### PR DESCRIPTION
The variants for Armv8-M Main must be built heeding code size as they target the M-profile.

We change them to minsize instead of creating new variants because we anticipate that users interested in flat out performance will target Armv8.1-M Main, for which we'll still provide variants built with Release build type.