### PR TITLE
[ATfE] Build `armv8.1m.main` strictly aligned picolibc for minsize

### DIFF
--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti.json
@@ -18,7 +18,7 @@
             "STACK_SIZE": "4K"
         },
         "picolibc": {
-            "PICOLIBC_BUILD_TYPE": "release",
+            "PICOLIBC_BUILD_TYPE": "minsize",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti.json
@@ -18,7 +18,7 @@
             "STACK_SIZE": "4K"
         },
         "picolibc": {
-            "PICOLIBC_BUILD_TYPE": "release",
+            "PICOLIBC_BUILD_TYPE": "minsize",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti.json
@@ -18,7 +18,7 @@
             "STACK_SIZE": "4K"
         },
         "picolibc": {
-            "PICOLIBC_BUILD_TYPE": "release",
+            "PICOLIBC_BUILD_TYPE": "minsize",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti.json
@@ -18,7 +18,7 @@
             "STACK_SIZE": "4K"
         },
         "picolibc": {
-            "PICOLIBC_BUILD_TYPE": "release",
+            "PICOLIBC_BUILD_TYPE": "minsize",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve.json
@@ -18,7 +18,7 @@
             "STACK_SIZE": "4K"
         },
         "picolibc": {
-            "PICOLIBC_BUILD_TYPE": "release",
+            "PICOLIBC_BUILD_TYPE": "minsize",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_exn_rtti.json
@@ -18,7 +18,7 @@
             "STACK_SIZE": "4K"
         },
         "picolibc": {
-            "PICOLIBC_BUILD_TYPE": "release",
+            "PICOLIBC_BUILD_TYPE": "minsize",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti.json
@@ -18,7 +18,7 @@
             "STACK_SIZE": "4K"
         },
         "picolibc": {
-            "PICOLIBC_BUILD_TYPE": "release",
+            "PICOLIBC_BUILD_TYPE": "minsize",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti.json
@@ -18,7 +18,7 @@
             "STACK_SIZE": "4K"
         },
         "picolibc": {
-            "PICOLIBC_BUILD_TYPE": "release",
+            "PICOLIBC_BUILD_TYPE": "minsize",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti.json
@@ -18,7 +18,7 @@
             "STACK_SIZE": "4K"
         },
         "picolibc": {
-            "PICOLIBC_BUILD_TYPE": "release",
+            "PICOLIBC_BUILD_TYPE": "minsize",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti.json
@@ -18,7 +18,7 @@
             "STACK_SIZE": "4K"
         },
         "picolibc": {
-            "PICOLIBC_BUILD_TYPE": "release",
+            "PICOLIBC_BUILD_TYPE": "minsize",
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",


### PR DESCRIPTION
This patch makes the Armv8.1-M Main strictly aligned variants built for code size. This is a significant concern for M-profile due to memory constraints.

We decided to change their build type from release to minsize, as opposed to creating new variants, because the strictly aligned variants are there mostly for compatibility. Users in preference of performance will use unaligned variants, for which we'll still provide options that will have been built with release build type.