### PR TITLE
Extend SECURITY.md with Arm Toolchain details

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,16 @@
-# Reporting LLVM Security Issues
-
-To report security issues in LLVM, please follow the steps outlined on the
-[LLVM Security Group](https://llvm.org/docs/Security.html#how-to-report-a-security-issue)
-page.
+# Reporting Arm Toolchain Security Issues
+ 
+To report security issues in LLVM components of Arm Toolchain,
+please follow LLVM Project
+[security policy](https://github.com/llvm/llvm-project/blob/main/SECURITY.md).
+ 
+To report security issues in any other components of Arm Toolchain,
+please use the _Report a vulnerability_ feature under the Security tab.
+ 
+> Please refer to
+> [What is considered a security issue?](https://llvm.org/docs/Security.html#what-is-considered-a-security-issue)
+> in LLVM Project for an overview of which toolchain components are considered
+> security-sensitive.
+>
+> The `picolibc` and `newlib` standard C libraries are not part of the `llvm-project`,
+> however Arm Toolchain treats these in the same way as the `llvm-project` runtime libraries.

--- a/arm-software/ci/.automerge_ignore
+++ b/arm-software/ci/.automerge_ignore
@@ -3,3 +3,4 @@ arm-software
 CONTRIBUTING.md
 README.md
 LICENSE.TXT
+SECURITY.md

--- a/arm-software/ci/.automerge_ignore
+++ b/arm-software/ci/.automerge_ignore
@@ -3,4 +3,3 @@ arm-software
 CONTRIBUTING.md
 README.md
 LICENSE.TXT
-SECURITY.md


### PR DESCRIPTION
This extends the SECURITY.md inherited from the LLVM Project by adding details on how to report security issues for components not provided by LLVM Project.

SECURITY.md file was added to the automerge ignore list in a separate PR.