### PR TITLE
[ATfE] Fail with an error message when -frwpi is used.

### DIFF
--- a/arm-software/embedded/arm-multilib/multilib.yaml.in
+++ b/arm-software/embedded/arm-multilib/multilib.yaml.in
@@ -42,6 +42,15 @@ Groups:
 Variants:
 @multilib_yaml_content@
 
+# Append an error case to the Variants list, matching anything that
+# enables the RWPI option. We don't build any library variants using
+# the RWPI style of access to writable static data, so if a user
+# compiles with -frwpi, we don't have any compatible library.
+- Error: Arm Toolchain for Embedded does not provide RWPI library variants
+  Flags:
+  - -frwpi
+  Group: stdlibs
+
 Mappings:
 
 # Map higher architecture versions to subsets of them, so that a

--- a/arm-software/embedded/test/multilib/rwpi.test
+++ b/arm-software/embedded/test/multilib/rwpi.test
@@ -1,0 +1,8 @@
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a 2>%t | FileCheck --check-prefix=NORWPI --allow-empty %s
+# NORWPI: arm-none-eabi/armv7a_soft_vfpv3_d16_exn_rtti_unaligned{{$}}
+
+# RUN: not %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -frwpi 2>%t | FileCheck --check-prefix=RWPI --allow-empty %s
+# RUN: FileCheck --check-prefix=RWPI_ERR %s < %t
+# RWPI-NOT: arm-none-eabi
+# RWPI_ERR: clang: error: multilib configuration error: Arm Toolchain for Embedded does not provide RWPI library variants
+


### PR DESCRIPTION
ATfE doesn't currently provide any library variants built for RWPI. And if you link RWPI with non-RWPI code, nothing good will happen – they have incompatible ABIs. So we ought to give an error message rather than silently choose an incompatible library.

Using https://github.com/llvm/llvm-project/pull/149132 which allowed multilib selection to be aware of the relocation model at all, this commit does the simplest possible thing: adds a catch-all error message that will trigger on _any_ use of `-frwpi`, and report that there's no suitable library variant.

(Another possibility would have been to add `-fno-rwpi` to the validity criteria for each existing library, but that seemed less likely to give a good error message. It would allow RWPI variants to be present for some cases but not all, but at the moment, we don't need that.)

Since the error message works the same everywhere, I've just added one test.