### PR TITLE
[ATfE] Move errno from semihost to libc and add time utils

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -673,6 +673,7 @@ if(C_LIBRARY STREQUAL llvmlibc)
         ${common_llvmlibc_cmake_args}
         -DLIBC_TARGET_TRIPLE=${target_triple}
         -DLIBC_CONF_TIME_64BIT=ON
+        -DLIBC_CONF_ERRNO_MODE=LIBC_ERRNO_MODE_SHARED
         -DLIBC_CONF_PRINTF_DISABLE_FLOAT=OFF
         -DLIBC_CONF_PRINTF_FLOAT_TO_STR_USE_FLOAT320=ON
         -DLLVM_CMAKE_DIR=${LLVM_BINARY_DIR}/lib/cmake/llvm


### PR DESCRIPTION
Previously, we used an external errno in LLVM-libc, which had to be defined in the semihosting library. However, LLVM-libc does provide an option to use a single-threaded errno implementation on request, so for consistency with other C libraries, we move errno from `libsemihost.a` to `libc.a`.

Also add new functions to allow clock().