### PR TITLE
NFC: Make use of GitHub markdown for block notes

### DIFF
--- a/arm-software/embedded/README.md
+++ b/arm-software/embedded/README.md
@@ -100,7 +100,8 @@ Install appropriate latest supported Microsoft Visual C++ Redistributable packag
 
 ### Using the toolchain
 
-> *Note:* If you are using the toolchain in a shared environment with untrusted input,
+> [!CAUTION]
+> If you are using the toolchain in a shared environment with untrusted input,
 > make sure it is sufficiently sandboxed.
 
 To use the toolchain, on the command line you need to provide the following options:
@@ -200,7 +201,8 @@ and [Experimental newlib support](docs/newlib.md)
 for advice on using Arm Toolchain for Embedded with existing projects
 relying on the Arm GNU Toolchain.
 
-> *Note:* `picolibc` provides excellent
+> [!TIP]
+> `picolibc` provides excellent
 > [support for Arm GNU Toolchain](https://github.com/picolibc/picolibc/blob/main/doc/using.md),
 > so projects that require using both Arm GNU Toolchain and Arm Toolchain for Embedded
 > can choose either `picolibc` or `newlib`/`newlib-nano`.

--- a/arm-software/embedded/docs/llvmlibc.md
+++ b/arm-software/embedded/docs/llvmlibc.md
@@ -5,13 +5,14 @@ Arm Toolchain for Embedded uses
 library. For experimental and evaluation purposes, you can instead
 choose to use the LLVM project's own C library.
 
-> **NOTE:** `llvmlibc` support in Arm Toolchain for Embedded is
+> [!WARNING]
+> `llvmlibc` support in Arm Toolchain for Embedded is
 > an experimental technology preview, with significant limitations.
 
 ## Building the toolchain with LLVM libc
 
-> **NOTE:** Building the LLVM libc package is only supported on Linux
-> and macOS.
+> [!IMPORTANT]
+> Building the LLVM libc package is only supported on Linux and macOS.
 
 Configure the toolchain with the CMake setting
 `-DLLVM_TOOLCHAIN_C_LIBRARY=llvmlibc` to build a version of the

--- a/arm-software/embedded/docs/newlib.md
+++ b/arm-software/embedded/docs/newlib.md
@@ -5,7 +5,8 @@ as the standard C library. For compatibility with existing projects using
 [`newlib`](https://sourceware.org/newlib/), a separate package of `newlib`-based
 library variants is provided.
 
-> **NOTE:**  `newlib` support in Arm Toolchain for Embedded is experimental
+> [!WARNING]
+> `newlib` support in Arm Toolchain for Embedded is experimental
 > and may change in following releases.
 
 ## Using pre-built `newlib` library package
@@ -34,7 +35,7 @@ $ clang --config=newlib.cfg --target=arm-none-eabi -march=armv7m -T redboot.ld -
 
 ## Building `newlib` library package
 
-> **NOTE:**  Building `newlib` package is only supported on Linux and macOS.
+> [!IMPORTANT] Building `newlib` package is only supported on Linux and macOS.
 
 Configure the toolchain with the CMake setting
 `-DLLVM_TOOLCHAIN_C_LIBRARY=newlib` to build a newlib-based version of


### PR DESCRIPTION
Make use of GitHub markdown markers in block notes sections to highlight importance level and show icons.