### PR TITLE
NFC: Fix note markdown formatting

### DIFF
--- a/arm-software/embedded/docs/newlib.md
+++ b/arm-software/embedded/docs/newlib.md
@@ -35,7 +35,8 @@ $ clang --config=newlib.cfg --target=arm-none-eabi -march=armv7m -T redboot.ld -
 
 ## Building `newlib` library package
 
-> [!IMPORTANT] Building `newlib` package is only supported on Linux and macOS.
+> [!IMPORTANT]
+> Building `newlib` package is only supported on Linux and macOS.
 
 Configure the toolchain with the CMake setting
 `-DLLVM_TOOLCHAIN_C_LIBRARY=newlib` to build a newlib-based version of


### PR DESCRIPTION
The marker has to be on a separate line to show correctly.