### PR TITLE
[ATfE] Fix variants names in the CI scripts

### DIFF
--- a/arm-software/embedded/scripts/test_atfe_sanitizer.sh
+++ b/arm-software/embedded/scripts/test_atfe_sanitizer.sh
@@ -39,8 +39,8 @@ ninja -j$PROCESSOR_COUNT check-all
 # The picolibc tests do not use lit so do not support this option.
 # Command for each test is splitted across individual lines, to aid in debugging.
 export LIT_OPTS="--ignore-fail"
-ninja -j$PROCESSOR_COUNT check-compiler-rt-armv7m_hard_fpv5_d16_exn_rtti_unaligned
-ninja -j$PROCESSOR_COUNT check-picolibc-armv7m_hard_fpv5_d16_exn_rtti_unaligned
-ninja -j$PROCESSOR_COUNT check-cxx-armv7m_hard_fpv5_d16_exn_rtti_unaligned
-ninja -j$PROCESSOR_COUNT check-cxxabi-armv7m_hard_fpv5_d16_exn_rtti_unaligned
-ninja -j$PROCESSOR_COUNT check-unwind-armv7m_hard_fpv5_d16_exn_rtti_unaligned
+ninja -j$PROCESSOR_COUNT check-compiler-rt-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size
+ninja -j$PROCESSOR_COUNT check-picolibc-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size
+ninja -j$PROCESSOR_COUNT check-cxx-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size
+ninja -j$PROCESSOR_COUNT check-cxxabi-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size
+ninja -j$PROCESSOR_COUNT check-unwind-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size

--- a/arm-software/embedded/scripts/test_post-merge.sh
+++ b/arm-software/embedded/scripts/test_post-merge.sh
@@ -40,13 +40,13 @@ export LIT_OPTS="--ignore-fail"
 ninja -j$PROCESSOR_COUNT \
     check-all \
     check-compiler-rt-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-compiler-rt-armv7m_hard_fpv5_d16_exn_rtti_unaligned \
+    check-compiler-rt-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size \
     check-cxx-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-cxx-armv7m_hard_fpv5_d16_exn_rtti_unaligned \
+    check-cxx-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size \
     check-cxxabi-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-cxxabi-armv7m_hard_fpv5_d16_exn_rtti_unaligned \
+    check-cxxabi-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size \
     check-picolibc-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-picolibc-armv7m_hard_fpv5_d16_exn_rtti_unaligned \
+    check-picolibc-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size \
     check-unwind-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-unwind-armv7m_hard_fpv5_d16_exn_rtti_unaligned
+    check-unwind-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size
 

--- a/arm-software/embedded/scripts/test_pre-merge.sh
+++ b/arm-software/embedded/scripts/test_pre-merge.sh
@@ -40,12 +40,12 @@ export LIT_OPTS="--ignore-fail"
 ninja -j$PROCESSOR_COUNT \
     check-all \
     check-compiler-rt-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-compiler-rt-armv7m_hard_fpv5_d16_exn_rtti_unaligned \
+    check-compiler-rt-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size \
     check-cxx-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-cxx-armv7m_hard_fpv5_d16_exn_rtti_unaligned \
+    check-cxx-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size \
     check-cxxabi-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-cxxabi-armv7m_hard_fpv5_d16_exn_rtti_unaligned \
+    check-cxxabi-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size \
     check-picolibc-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-picolibc-armv7m_hard_fpv5_d16_exn_rtti_unaligned \
+    check-picolibc-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size \
     check-unwind-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-unwind-armv7m_hard_fpv5_d16_exn_rtti_unaligned
+    check-unwind-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size


### PR DESCRIPTION
Some variants have been renamed in de3d30435188d87ae72a258f525fa09a56a0f4e5