### PR TITLE
Disable review approval portion of downstream change check

### DIFF
--- a/.github/workflows/check_downstream_changes.yml
+++ b/.github/workflows/check_downstream_changes.yml
@@ -23,19 +23,15 @@ on:
       - reopened
       - edited
       - synchronize
-  # Trigger whenever a pull request is reviewed to check which
-  # teams have approved.
-  pull_request_review:
-    types:
-      - submitted
-      - edited
-      - dismissed
+    branches:
+      - arm-software
+      - release/arm-software/**
 
 jobs:
   check-downstream-changes:
     runs-on: ubuntu-24.04-arm
 
-    if: github.repository == 'arm/arm-toolchain' && (github.event.pull_request.base.ref == 'arm-software' || startsWith(github.event.pull_request.base.ref, 'release/arm-software/'))
+    if: github.repository == 'arm/arm-toolchain'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
The default access token used in GitHub Actions workflows does not have the required permissions to see the list of team members, which exists outside of the arm-toolchain repo at the arm org level. As a result, attempting to check which teams have reviewed a pull request will currently cause an error.

For now, remove the check until it can be reworked. Since there will no longer be a hard gated check on whether a pull request has been sufficiently reviewed, the automated comment has been updated to remind to wait for both teams before merging.