### PR TITLE
[ATfE] Fix downstream xfail patch about uses of `atomic`

### DIFF
--- a/arm-software/embedded/patches/llvm-project/0001-libc-tests-with-picolibc-xfail-one-remaining-test.patch
+++ b/arm-software/embedded/patches/llvm-project/0001-libc-tests-with-picolibc-xfail-one-remaining-test.patch
@@ -1,4 +1,4 @@
-From 623881f1ea465f9c1837981db143f7225108580a Mon Sep 17 00:00:00 2001
+From 11de9e979083e65c416b62d7a5446263edbe4f46 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Mon, 16 Oct 2023 11:35:48 +0200
 Subject: [libc++] tests with picolibc: xfail one remaining test
@@ -22,5 +22,5 @@ index d8eff69cb53f..e16048df722e 100644
  
  void f() {}
 -- 
-2.39.5 (Apple Git-154)
+2.43.0
 

--- a/arm-software/embedded/patches/llvm-project/0002-libc-tests-with-picolibc-disable-large-tests.patch
+++ b/arm-software/embedded/patches/llvm-project/0002-libc-tests-with-picolibc-disable-large-tests.patch
@@ -1,4 +1,4 @@
-From 8a0f8650d58f27ca32948554188b98c8978d1eb6 Mon Sep 17 00:00:00 2001
+From 37aa88076ffb0638506b85a5e42b374974621eef Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Wed, 15 Nov 2023 12:18:35 +0100
 Subject: [libc++] tests with picolibc: disable large tests
@@ -9,7 +9,7 @@ Subject: [libc++] tests with picolibc: disable large tests
  2 files changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/libcxx/cmake/caches/Armv7M-picolibc.cmake b/libcxx/cmake/caches/Armv7M-picolibc.cmake
-index b5f9089308d2..0a83e75ceceb 100644
+index 0f8189b45728..9e1ae0832aee 100644
 --- a/libcxx/cmake/caches/Armv7M-picolibc.cmake
 +++ b/libcxx/cmake/caches/Armv7M-picolibc.cmake
 @@ -18,6 +18,9 @@ set(LIBCXXABI_ENABLE_SHARED OFF CACHE BOOL "")
@@ -22,7 +22,7 @@ index b5f9089308d2..0a83e75ceceb 100644
  set(LIBCXXABI_USE_COMPILER_RT ON CACHE BOOL "")
  set(LIBCXX_ENABLE_EXCEPTIONS ON CACHE BOOL "")
  set(LIBCXX_ENABLE_FILESYSTEM OFF CACHE STRING "")
-@@ -30,12 +33,16 @@ set(LIBCXX_ENABLE_THREADS OFF CACHE BOOL "")
+@@ -30,13 +33,17 @@ set(LIBCXX_ENABLE_THREADS OFF CACHE BOOL "")
  set(LIBCXX_ENABLE_WIDE_CHARACTERS OFF CACHE BOOL "")
  set(LIBCXX_INCLUDE_BENCHMARKS OFF CACHE BOOL "")
  # Long tests are prohibitively slow when run via emulation.
@@ -40,8 +40,9 @@ index b5f9089308d2..0a83e75ceceb 100644
 +set(LIBUNWIND_TEST_PARAMS "long_tests=False;large_tests=False" CACHE STRING "")
  set(LIBUNWIND_USE_COMPILER_RT ON CACHE BOOL "")
  find_program(QEMU_SYSTEM_ARM qemu-system-arm REQUIRED)
+ 
 diff --git a/libcxxabi/test/test_demangle.pass.cpp b/libcxxabi/test/test_demangle.pass.cpp
-index ad131bb3a8a7..ac612c79f71c 100644
+index 858347bedce1..b632f79f92ed 100644
 --- a/libcxxabi/test/test_demangle.pass.cpp
 +++ b/libcxxabi/test/test_demangle.pass.cpp
 @@ -7,7 +7,7 @@
@@ -53,7 +54,6 @@ index ad131bb3a8a7..ac612c79f71c 100644
  
  // This test exercises support for char array initializer lists added in
  // dd8b266ef.
- // UNSUPPORTED: using-built-library-before-llvm-20
 -- 
-2.39.5 (Apple Git-154)
+2.43.0
 

--- a/arm-software/embedded/patches/llvm-project/0003-Disable-failing-compiler-rt-test.patch
+++ b/arm-software/embedded/patches/llvm-project/0003-Disable-failing-compiler-rt-test.patch
@@ -1,4 +1,4 @@
-From 0f8dc80a7642430c8d02c36283766aeb5a59a331 Mon Sep 17 00:00:00 2001
+From ee5ef45fe87bfbd514806f59682858c7f6bd84fb Mon Sep 17 00:00:00 2001
 From: Piotr Przybyla <piotr.przybyla@arm.com>
 Date: Wed, 15 Nov 2023 16:04:24 +0000
 Subject: Disable failing compiler-rt test
@@ -8,7 +8,7 @@ Subject: Disable failing compiler-rt test
  1 file changed, 2 insertions(+)
 
 diff --git a/compiler-rt/test/builtins/Unit/arm/aeabi_uldivmod_test.c b/compiler-rt/test/builtins/Unit/arm/aeabi_uldivmod_test.c
-index 2ff65a8b9ec3..98611a75e85f 100644
+index 02cfa2f38713..2c04061a2ef6 100644
 --- a/compiler-rt/test/builtins/Unit/arm/aeabi_uldivmod_test.c
 +++ b/compiler-rt/test/builtins/Unit/arm/aeabi_uldivmod_test.c
 @@ -1,3 +1,5 @@
@@ -18,5 +18,5 @@ index 2ff65a8b9ec3..98611a75e85f 100644
  // RUN: %clang_builtins %s %librt -o %t && %run %t
  
 -- 
-2.39.5 (Apple Git-154)
+2.43.0
 

--- a/arm-software/embedded/patches/llvm-project/0004-libc-tests-with-picolibc-XFAIL-uses-of-atomics.patch
+++ b/arm-software/embedded/patches/llvm-project/0004-libc-tests-with-picolibc-XFAIL-uses-of-atomics.patch
@@ -1,10 +1,10 @@
-From f5b5a95bd02f6d5bc6e80c238c2e8f7e08985d80 Mon Sep 17 00:00:00 2001
+From 6e7b98a020e3027f7993ba558c2770986fdd407e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Thu, 9 Nov 2023 15:25:14 +0100
 Subject: [libc++] tests with picolibc: XFAIL uses of atomics
 
 ---
- libcxx/test/libcxx/atomics/lit.local.cfg          |  3 +++
+ .../libcxx/atomics/atomics.flag/lit.local.cfg     |  3 +++
  .../test/libcxx/experimental/memory/lit.local.cfg |  3 +++
  .../intrusive_shared_ptr.pass.cpp                 |  2 ++
  libcxx/test/std/atomics/lit.local.cfg             |  3 +++
@@ -13,18 +13,18 @@ Subject: [libc++] tests with picolibc: XFAIL uses of atomics
  .../memory/memory.resource.global/lit.local.cfg   |  3 +++
  libcxx/utils/libcxx/test/features.py              | 15 +++++++++++++++
  8 files changed, 35 insertions(+)
- create mode 100644 libcxx/test/libcxx/atomics/lit.local.cfg
+ create mode 100644 libcxx/test/extensions/libcxx/atomics/atomics.flag/lit.local.cfg
  create mode 100644 libcxx/test/libcxx/experimental/memory/lit.local.cfg
  create mode 100644 libcxx/test/std/atomics/lit.local.cfg
  create mode 100644 libcxx/test/std/experimental/memory/memory.polymorphic.allocator.class/lit.local.cfg
  create mode 100644 libcxx/test/std/experimental/memory/memory.resource.aliases/lit.local.cfg
  create mode 100644 libcxx/test/std/experimental/memory/memory.resource.global/lit.local.cfg
 
-diff --git a/libcxx/test/libcxx/atomics/lit.local.cfg b/libcxx/test/libcxx/atomics/lit.local.cfg
+diff --git a/libcxx/test/extensions/libcxx/atomics/atomics.flag/lit.local.cfg b/libcxx/test/extensions/libcxx/atomics/atomics.flag/lit.local.cfg
 new file mode 100644
 index 000000000000..5ecc58f3e385
 --- /dev/null
-+++ b/libcxx/test/libcxx/atomics/lit.local.cfg
++++ b/libcxx/test/extensions/libcxx/atomics/atomics.flag/lit.local.cfg
 @@ -0,0 +1,3 @@
 +# Disable all of the atomics tests if the correct feature is not available.
 +if "has-no-atomics" in config.available_features:
@@ -88,10 +88,10 @@ index 000000000000..5ecc58f3e385
 +if "has-no-atomics" in config.available_features:
 +    config.unsupported = True
 diff --git a/libcxx/utils/libcxx/test/features.py b/libcxx/utils/libcxx/test/features.py
-index 735eb5ac949d..6ca4e8acb3f4 100644
+index 0cb81546665d..3e6204db4d79 100644
 --- a/libcxx/utils/libcxx/test/features.py
 +++ b/libcxx/utils/libcxx/test/features.py
-@@ -215,6 +215,21 @@ DEFAULT_FEATURES = [
+@@ -206,6 +206,21 @@ DEFAULT_FEATURES = [
            """,
          ),
      ),
@@ -114,5 +114,5 @@ index 735eb5ac949d..6ca4e8acb3f4 100644
      Feature(
          name="32-bit-pointer",
 -- 
-2.39.5 (Apple Git-154)
+2.43.0
 

--- a/arm-software/embedded/patches/llvm-project/0005-libc-tests-with-picolibc-mark-two-more-large-tests.patch
+++ b/arm-software/embedded/patches/llvm-project/0005-libc-tests-with-picolibc-mark-two-more-large-tests.patch
@@ -1,4 +1,4 @@
-From 0961af52ac015c26829b4dae7fd6879a0b633f44 Mon Sep 17 00:00:00 2001
+From 35e7031a9e8dbf4edc10c0735aa71c3ed15da533 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Dominik=20W=C3=B3jt?= <dominik.wojt@arm.com>
 Date: Wed, 22 Nov 2023 16:12:39 +0100
 Subject: [libc++] tests with picolibc: mark two more large tests
@@ -37,5 +37,5 @@ index 64a6a135adda..057301e6f868 100644
  //     bool
  //     regex_search(BidirectionalIterator first, BidirectionalIterator last,
 -- 
-2.39.5 (Apple Git-154)
+2.43.0
 

--- a/arm-software/embedded/patches/llvm-project/0006-Define-_LIBCPP_HAS_C8RTOMB_MBRTOC8.patch
+++ b/arm-software/embedded/patches/llvm-project/0006-Define-_LIBCPP_HAS_C8RTOMB_MBRTOC8.patch
@@ -1,4 +1,4 @@
-From 9011c0e821d5b1563dc2dc6370f29c529e55f41f Mon Sep 17 00:00:00 2001
+From d63976dd43f5ae010e9860ccf14feb9c280fcdd0 Mon Sep 17 00:00:00 2001
 From: Victor Campos <victor.campos@arm.com>
 Date: Thu, 31 Oct 2024 09:58:34 +0000
 Subject: Define _LIBCPP_HAS_C8RTOMB_MBRTOC8
@@ -23,10 +23,10 @@ govern picolibc version are in `picolibc.h`.
  1 file changed, 2 insertions(+), 15 deletions(-)
 
 diff --git a/libcxx/include/__config b/libcxx/include/__config
-index 1cf80a46686a..615433869a4e 100644
+index 77a71b6cf1ca..0ce4caa11814 100644
 --- a/libcxx/include/__config
 +++ b/libcxx/include/__config
-@@ -1021,21 +1021,8 @@ typedef __char32_t char32_t;
+@@ -1015,21 +1015,8 @@ typedef __char32_t char32_t;
  // functions is gradually being added to existing C libraries. The conditions
  // below check for known C library versions and conditions under which these
  // functions are declared by the C library.

--- a/arm-software/embedded/patches/llvm-project/0007-libcxx-Remove-xfails-due-to-picolibc-s-support-for-c.patch
+++ b/arm-software/embedded/patches/llvm-project/0007-libcxx-Remove-xfails-due-to-picolibc-s-support-for-c.patch
@@ -1,4 +1,4 @@
-From 2c6b08baa20bb4a7e4a936ecf286a1c9e1f0f8c9 Mon Sep 17 00:00:00 2001
+From 113de46366fdc7304fff7a6e338697e872e0add0 Mon Sep 17 00:00:00 2001
 From: Victor Campos <victor.campos@arm.com>
 Date: Thu, 31 Oct 2024 14:03:58 +0000
 Subject: [libcxx] Remove xfails due to picolibc's support for char16_t and

--- a/arm-software/embedded/patches/llvm-project/0008-Compiler-rt-FVP-and-QEMU-do-not-support-crash-signal.patch
+++ b/arm-software/embedded/patches/llvm-project/0008-Compiler-rt-FVP-and-QEMU-do-not-support-crash-signal.patch
@@ -1,4 +1,4 @@
-From 8a5771253787cda5c8caa31b7e8a870840903084 Mon Sep 17 00:00:00 2001
+From 744d427172eaa9bced18d101c7f1cb23c87b2260 Mon Sep 17 00:00:00 2001
 From: Simi Pallipurath <simi.pallipurath@arm.com>
 Date: Tue, 22 Jul 2025 15:08:45 +0100
 Subject: [Compiler-rt] FVP and QEMU do not support crash signal handling.
@@ -22,5 +22,5 @@ index 2140944b0eec..f3b8bb234f38 100644
  // RUN: %expect_crash %run %t 4
  
 -- 
-2.34.1
+2.43.0
 

--- a/arm-software/embedded/patches/llvm-project/0009-Clang-XFAIL-tests-with-frwpi-as-ATFE-don-t-have-an-a.patch
+++ b/arm-software/embedded/patches/llvm-project/0009-Clang-XFAIL-tests-with-frwpi-as-ATFE-don-t-have-an-a.patch
@@ -1,4 +1,4 @@
-From be2b0fe15e9717ddb4a75b0cd4e30b22ab614124 Mon Sep 17 00:00:00 2001
+From a891d66394a8008c8ae10b60fcf4ceded4879006 Mon Sep 17 00:00:00 2001
 From: Simi Pallipurath <simi.pallipurath@arm.com>
 Date: Tue, 22 Jul 2025 15:10:20 +0100
 Subject: [Clang] XFAIL tests with -frwpi as ATFE don't have an appropriate
@@ -34,5 +34,5 @@ index 9082d7948511..e79701417b52 100644
  // Pre-defined macros for position-independence modes
  
 -- 
-2.34.1
+2.43.0
 


### PR DESCRIPTION
One of the xfailed tests that use `atomic` has changed location, so we had to also relocate the corresponding `lit.local.cfg` to the same location.