### PR TITLE
[ATfE] Fix downstream xfail patch about uses of `atomic`

### DIFF
--- a/arm-software/embedded/patches/llvm-project/0004-libc-tests-with-picolibc-XFAIL-uses-of-atomics.patch
+++ b/arm-software/embedded/patches/llvm-project/0004-libc-tests-with-picolibc-XFAIL-uses-of-atomics.patch
@@ -4,7 +4,7 @@ Date: Thu, 9 Nov 2023 15:25:14 +0100
 Subject: [libc++] tests with picolibc: XFAIL uses of atomics
 
 ---
- libcxx/test/libcxx/atomics/lit.local.cfg          |  3 +++
+ .../libcxx/atomics/atomics.flag/lit.local.cfg     |  3 +++
  .../test/libcxx/experimental/memory/lit.local.cfg |  3 +++
  .../intrusive_shared_ptr.pass.cpp                 |  2 ++
  libcxx/test/std/atomics/lit.local.cfg             |  3 +++
@@ -13,18 +13,18 @@ Subject: [libc++] tests with picolibc: XFAIL uses of atomics
  .../memory/memory.resource.global/lit.local.cfg   |  3 +++
  libcxx/utils/libcxx/test/features.py              | 15 +++++++++++++++
  8 files changed, 35 insertions(+)
- create mode 100644 libcxx/test/libcxx/atomics/lit.local.cfg
+ create mode 100644 libcxx/test/extensions/libcxx/atomics/atomics.flag/lit.local.cfg
  create mode 100644 libcxx/test/libcxx/experimental/memory/lit.local.cfg
  create mode 100644 libcxx/test/std/atomics/lit.local.cfg
  create mode 100644 libcxx/test/std/experimental/memory/memory.polymorphic.allocator.class/lit.local.cfg
  create mode 100644 libcxx/test/std/experimental/memory/memory.resource.aliases/lit.local.cfg
  create mode 100644 libcxx/test/std/experimental/memory/memory.resource.global/lit.local.cfg
 
-diff --git a/libcxx/test/libcxx/atomics/lit.local.cfg b/libcxx/test/libcxx/atomics/lit.local.cfg
+diff --git a/libcxx/test/extensions/libcxx/atomics/atomics.flag/lit.local.cfg b/libcxx/test/extensions/libcxx/atomics/atomics.flag/lit.local.cfg
 new file mode 100644
 index 000000000000..5ecc58f3e385
 --- /dev/null
-+++ b/libcxx/test/libcxx/atomics/lit.local.cfg
++++ b/libcxx/test/extensions/libcxx/atomics/atomics.flag/lit.local.cfg
 @@ -0,0 +1,3 @@
 +# Disable all of the atomics tests if the correct feature is not available.
 +if "has-no-atomics" in config.available_features:


### PR DESCRIPTION
One of the xfailed tests that use `atomic` has changed location, so we had to also relocate the corresponding `lit.local.cfg` to the same location.