### PR TITLE
Revert the upstream picolibc removal of dummyhost library.

### DIFF
--- a/arm-software/embedded/patches/picolibc/0004-Revert-Delete-dummyhost.patch
+++ b/arm-software/embedded/patches/picolibc/0004-Revert-Delete-dummyhost.patch
@@ -1,0 +1,231 @@
+From 12b4ed4c5744c995e901bb54e659109f9e03efb4 Mon Sep 17 00:00:00 2001
+From: Mark Murray <mark.murray@arm.com>
+Date: Mon, 4 Aug 2025 11:21:18 +0100
+Subject: [PATCH] Revert "Delete 'dummyhost'."
+
+Needed for the 21.x release to buy us time to properly fix
+https://jira.arm.com/browse/LLVMREQ-935
+
+This reverts commit 6972284de615b135522f0eb247a2cf04f7021ba4.
+---
+ dummyhost/exit.c      | 43 ++++++++++++++++++++++++
+ dummyhost/iob.c       | 76 +++++++++++++++++++++++++++++++++++++++++++
+ dummyhost/meson.build | 58 +++++++++++++++++++++++++++++++++
+ meson.build           |  3 ++
+ 4 files changed, 180 insertions(+)
+ create mode 100644 dummyhost/exit.c
+ create mode 100644 dummyhost/iob.c
+ create mode 100644 dummyhost/meson.build
+
+diff --git a/dummyhost/exit.c b/dummyhost/exit.c
+new file mode 100644
+index 000000000..eee23f5c8
+--- /dev/null
++++ b/dummyhost/exit.c
+@@ -0,0 +1,43 @@
++/*
++ * SPDX-License-Identifier: BSD-3-Clause
++ *
++ * Copyright © 2023 Keith Packard
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ *
++ * 2. Redistributions in binary form must reproduce the above
++ *    copyright notice, this list of conditions and the following
++ *    disclaimer in the documentation and/or other materials provided
++ *    with the distribution.
++ *
++ * 3. Neither the name of the copyright holder nor the names of its
++ *    contributors may be used to endorse or promote products derived
++ *    from this software without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
++ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
++ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
++ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
++ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
++ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
++ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
++ * OF THE POSSIBILITY OF SUCH DAMAGE.
++ */
++
++#include <unistd.h>
++
++__noreturn void
++_exit(int code)
++{
++    (void) code;
++    for (;;);
++}
+diff --git a/dummyhost/iob.c b/dummyhost/iob.c
+new file mode 100644
+index 000000000..81d60e479
+--- /dev/null
++++ b/dummyhost/iob.c
+@@ -0,0 +1,76 @@
++/*
++ * SPDX-License-Identifier: BSD-3-Clause
++ *
++ * Copyright © 2019 Keith Packard
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ *
++ * 2. Redistributions in binary form must reproduce the above
++ *    copyright notice, this list of conditions and the following
++ *    disclaimer in the documentation and/or other materials provided
++ *    with the distribution.
++ *
++ * 3. Neither the name of the copyright holder nor the names of its
++ *    contributors may be used to endorse or promote products derived
++ *    from this software without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
++ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
++ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
++ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
++ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
++ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
++ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
++ * OF THE POSSIBILITY OF SUCH DAMAGE.
++ */
++
++#include <stdio.h>
++
++/*
++ * Dummy stdio hooks. This allows programs to link without requiring
++ * any system-dependent functions. This is only used if the program
++ * doesn't provide its own version of stdin, stdout, stderr
++ */
++
++static int
++dummy_putc(char c, FILE *file)
++{
++	(void) c;
++	(void) file;
++	return (unsigned char) c;
++}
++
++static int
++dummy_getc(FILE *file)
++{
++	(void) file;
++	return EOF;
++}
++
++static int
++dummy_flush(FILE *file)
++{
++	(void) file;
++	return 0;
++}
++
++static FILE __stdio = FDEV_SETUP_STREAM(dummy_putc, dummy_getc, dummy_flush, _FDEV_SETUP_RW);
++
++#ifdef __strong_reference
++#define STDIO_ALIAS(x) __strong_reference(stdin, x);
++#else
++#define STDIO_ALIAS(x) FILE *const x = &__stdio;
++#endif
++
++FILE *const stdin = &__stdio;
++STDIO_ALIAS(stdout);
++STDIO_ALIAS(stderr);
+diff --git a/dummyhost/meson.build b/dummyhost/meson.build
+new file mode 100644
+index 000000000..1acaabd73
+--- /dev/null
++++ b/dummyhost/meson.build
+@@ -0,0 +1,58 @@
++#
++# SPDX-License-Identifier: BSD-3-Clause
++#
++# Copyright © 2019 Keith Packard
++#
++# Redistribution and use in source and binary forms, with or without
++# modification, are permitted provided that the following conditions
++# are met:
++#
++# 1. Redistributions of source code must retain the above copyright
++#    notice, this list of conditions and the following disclaimer.
++#
++# 2. Redistributions in binary form must reproduce the above
++#    copyright notice, this list of conditions and the following
++#    disclaimer in the documentation and/or other materials provided
++#    with the distribution.
++#
++# 3. Neither the name of the copyright holder nor the names of its
++#    contributors may be used to endorse or promote products derived
++#    from this software without specific prior written permission.
++#
++# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
++# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
++# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
++# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
++# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
++# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
++# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
++# OF THE POSSIBILITY OF SUCH DAMAGE.
++#
++
++srcs_dummyhost = [
++  'iob.c',
++  'exit.c',
++]
++
++foreach params : targets
++  target = params['name']
++  target_dir = params['dir']
++  target_c_args = params['c_args']
++  target_lib_prefix = params['lib_prefix']
++
++  instdir = join_paths(lib_dir, target_dir)
++
++  libdummyhost_name = 'dummyhost'
++
++  set_variable('lib_dummyhost' + target,
++	       static_library(join_paths(target_dir, target_lib_prefix + libdummyhost_name),
++			      srcs_dummyhost,
++			      install : true,
++			      install_dir : instdir,
++			      include_directories : inc,
++			      c_args : target_c_args + c_args))
++endforeach
+diff --git a/meson.build b/meson.build
+index 00f8ba8b1..710d4be25 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1558,6 +1558,9 @@ bios_bin = []
+ if enable_semihost
+   subdir('semihost')
+ endif
++if tinystdio
++  subdir('dummyhost')
++endif
+ 
+ conf_data.set('__SEMIHOST', has_semihost, description: 'Semihost APIs supported')
+ conf_data.set('__ARM_SEMIHOST', has_arm_semihost, description: 'ARM Semihost APIs supported')
+-- 
+2.34.1
+


### PR DESCRIPTION
This is not an approach that is going to be used in later releases, but it does give us time to work on a more complete solution.