### PR TITLE
[ATfE] Throw an error if a requested variant name is not found (#457)

### DIFF
--- a/arm-software/embedded/arm-multilib/CMakeLists.txt
+++ b/arm-software/embedded/arm-multilib/CMakeLists.txt
@@ -173,6 +173,7 @@ foreach(lib_idx RANGE ${lib_count_dec})
     endif()
 
     if(variant IN_LIST ENABLE_VARIANTS OR ENABLE_VARIANTS STREQUAL "all")
+        list(APPEND enabled_variants ${variant})
         string(JSON variant_multilib_flags GET ${lib_def} "flags")
         # Placeholder libraries won't have a json, so store the error in
         # a variable so a fatal error isn't generated.
@@ -363,6 +364,16 @@ foreach(lib_idx RANGE ${lib_count_dec})
     endif()
 
 endforeach()
+
+# Check that all variants that were configured to be enabled
+# were actually enabled.
+if(NOT ENABLE_VARIANTS STREQUAL "all")
+    foreach(expected_variant ${ENABLE_VARIANTS})
+        if(NOT expected_variant IN_LIST enabled_variants)
+            message(FATAL_ERROR "Variant name ${expected_variant} not found in ${MULTILIB_JSON}")
+        endif()
+    endforeach()
+endif()
 
 # Multilib file is generated in two parts.
 # 1. Template is filled with multilib flags from json


### PR DESCRIPTION
By default the toolchain enables all available library variants to be built, but a list of specific variants can instead be enabled through the `-DLLVM_TOOLCHAIN_LIBRARY_VARIANTS` option. Currently, if an invalid name is specified, the configuration will not notice and that variant will silently not be built. This patch instead causes the script to throw an error, so that it is clear that an expected variant is missing if the name is incorrect.

(cherry picked from commit 2bce241944438676ec85a68cfe2cd7b3f0e5baa3)