### PR TITLE
Update downstream check script on 21.x branch

### DIFF
--- a/.github/workflows/check_downstream_changes.yml
+++ b/.github/workflows/check_downstream_changes.yml
@@ -23,19 +23,15 @@ on:
       - reopened
       - edited
       - synchronize
-  # Trigger whenever a pull request is reviewed to check which
-  # teams have approved.
-  pull_request_review:
-    types:
-      - submitted
-      - edited
-      - dismissed
+    branches:
+      - arm-software
+      - release/arm-software/**
 
 jobs:
   check-downstream-changes:
     runs-on: ubuntu-24.04-arm
 
-    if: github.repository == 'arm/arm-toolchain' && (github.event.pull_request.base.ref == 'arm-software' || startsWith(github.event.pull_request.base.ref, 'release/arm-software/'))
+    if: github.repository == 'arm/arm-toolchain'
 
     steps:
       - name: Checkout

--- a/.github/workflows/check_downstream_changes.yml
+++ b/.github/workflows/check_downstream_changes.yml
@@ -23,29 +23,25 @@ on:
       - reopened
       - edited
       - synchronize
-    branches:
-      - arm-software
-      - release/arm-software/**
+  # Trigger whenever a pull request is reviewed to check which
+  # teams have approved.
+  pull_request_review:
+    types:
+      - submitted
+      - edited
+      - dismissed
 
 jobs:
   check-downstream-changes:
     runs-on: ubuntu-24.04-arm
 
-    if: github.repository == 'arm/arm-toolchain'
+    if: github.repository == 'arm/arm-toolchain' && (github.event.pull_request.base.ref == 'arm-software' || startsWith(github.event.pull_request.base.ref, 'release/arm-software/'))
 
     steps:
-      # Generate a token for gh tool
-      - name: Configure Access Token
-        uses: actions/create-github-app-token@v1
-        id: generate-token
-        with:
-          app-id: ${{ secrets.SYNC_APP_ID }}
-          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
-
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Run Check Script
         run: python3 arm-software/ci/check_downstream_changes.py --repo ${{ github.repository }} --pr ${{ github.event.pull_request.number }}
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The downstream change checking script has received a number of improvements on trunk which should be cherry-picked to the release branch, ahead of changes that fail to make branching being made. This includes:

Check review approvals in downstream changes 0361b4ecd03c963a0de13527983e465a162fa463 https://github.com/arm/arm-toolchain/pull/408
Disable review approval portion of downstream change check 5522f06d57fe73d74ccf72c223c8b3abbd88fb0d https://github.com/arm/arm-toolchain/pull/449
Allow additional whitespace in downstream issue tagging 52fc4c285b02fb0abc15a30a4851c4b91c00cf11 https://github.com/arm/arm-toolchain/pull/459

Together, these make the following changes:
* The GutHub token being used is changed to one automatically generated for the Action, instead of the LLVM Sync token which has different permissions.
* When a pull request is detected as making a downstream change, a comment is left by the bot to explain the downstream patch policy, and the existence of the check.
* The pull request making the downstream change, and the tracking issue are both automatically labelled with the downstream change tag.
* The regular expression for searching for the tagging line in the pull request has been relaxed to allow for additional whietspace.
* A dry run option is added to script so it can be run to check without the aboce automatic comment/labelling.

This patch series also added an additional check on who has reviewed the downsteam change, but this check is reverted within the same series.