### PR TITLE
[ATfE] Fix issue with LLVM-libc builds for certain variants

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -735,7 +735,7 @@ if(C_LIBRARY STREQUAL llvmlibc)
 
     if(ENABLE_LIBC_TESTS)
         if(NOT(TEST_EXECUTOR STREQUAL qemu))
-            message(FATAL_ERROR "Using LLVM-libc and FVPs together is unsupported")
+            message(FATAL_ERROR "LLVM-libc tests are only able to run on QEMU.")
         endif()
 
         add_custom_target(check-llvmlibc)


### PR DESCRIPTION
FATAL_ERROR is supposed to be raised when a variant that uses FVPs tries to build tests for LLVM-libc, as they are not supported.

However, this check runs regardless of whether tests are enabled or not, causing build failures. This PR addresses that.