### PR TITLE
[ATfE] Enable compiler-rt tests on Armv8.1-M Main variants

### DIFF
--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_exn_rtti_unaligned.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_exn_rtti_unaligned_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_exn_rtti_unaligned_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti_unaligned_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_exn_rtti_unaligned_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_unaligned_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_pacret_bti_unaligned_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_unaligned.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_unaligned_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fp_nomve_unaligned_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_exn_rtti_unaligned.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_exn_rtti_unaligned_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_exn_rtti_unaligned_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti_unaligned_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_exn_rtti_unaligned_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_unaligned_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_pacret_bti_unaligned_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_unaligned.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_unaligned_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_fpdp_nomve_unaligned_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_exn_rtti_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_exn_rtti_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_exn_rtti_unaligned.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_exn_rtti_unaligned_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_exn_rtti_unaligned_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti_unaligned_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_exn_rtti_unaligned_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_unaligned_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_pacret_bti_unaligned_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_unaligned.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_unaligned_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_hard_nofp_mve_unaligned_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_exn_rtti_unaligned_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_exn_rtti_unaligned_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti_unaligned_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_exn_rtti_unaligned_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_unaligned_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_pacret_bti_unaligned_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_unaligned_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8.1m.main_soft_nofp_nomve_unaligned_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {


### PR DESCRIPTION
The compiler-rt tests on Armv8.1-M Main are passing, so it's time we enable them.