### PR TITLE
[ATfE] Enable compiler-rt tests on Armv8-M Main variants

### DIFF
--- a/arm-software/embedded/arm-multilib/json/variants/armv8m.main_hard_fp_exn_rtti_unaligned_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8m.main_hard_fp_exn_rtti_unaligned_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8m.main_hard_fp_unaligned_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8m.main_hard_fp_unaligned_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8m.main_soft_nofp_exn_rtti_unaligned_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8m.main_soft_nofp_exn_rtti_unaligned_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {

--- a/arm-software/embedded/arm-multilib/json/variants/armv8m.main_soft_nofp_unaligned_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv8m.main_soft_nofp_unaligned_size.json
@@ -21,7 +21,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "newlib": {


### PR DESCRIPTION
The compiler-rt tests on Armv8-M Main are passing, so it's time we enable them.