### PR TITLE
[ATfE] Enable picolibc, compiler-rt and libcxx texts for armv4t and armv5te exn_rtti

### DIFF
--- a/arm-software/embedded/arm-multilib/json/variants/armv4t_exn_rtti_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv4t_exn_rtti_size.json
@@ -21,9 +21,9 @@
         },
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
+            "ENABLE_LIBCXX_TESTS": "ON"
         },
         "newlib": {
             "ENABLE_CXX_LIBS": "ON",

--- a/arm-software/embedded/arm-multilib/json/variants/armv5te_exn_rtti_size.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv5te_exn_rtti_size.json
@@ -21,9 +21,9 @@
         },
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
+            "ENABLE_LIBCXX_TESTS": "ON"
         },
         "newlib": {
             "ENABLE_CXX_LIBS": "ON",


### PR DESCRIPTION
The tests are passing now, so we can enable them.