### PR TITLE
[ATfE] Enable LLVM-libc tests in nightly

### DIFF
--- a/.github/workflows/atfe_nightly_build_and_test.yml
+++ b/.github/workflows/atfe_nightly_build_and_test.yml
@@ -51,7 +51,7 @@ jobs:
 
           # LLVM-libc Overlay Package Build
           - build_script: build_llvmlibc_overlay.sh
-            test_script: test.sh
+            test_script: test_llvmlibc.sh
             install_script: install_dependencies.sh
             target_os: Ubuntu-22.04-arm64
             runner: ah-ubuntu_22_04-c7g_8x-100

--- a/.github/workflows/atfe_nightly_build_and_test.yml
+++ b/.github/workflows/atfe_nightly_build_and_test.yml
@@ -51,7 +51,7 @@ jobs:
 
           # LLVM-libc Overlay Package Build
           - build_script: build_llvmlibc_overlay.sh
-            test_script: ''
+            test_script: test.sh
             install_script: install_dependencies.sh
             target_os: Ubuntu-22.04-arm64
             runner: ah-ubuntu_22_04-c7g_8x-100

--- a/arm-software/embedded/scripts/test_llvmlibc.sh
+++ b/arm-software/embedded/scripts/test_llvmlibc.sh
@@ -6,7 +6,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # A bash script to run the LLVM-libc tests from the Arm Toolchain for Embedded.
-
 # This script should be deleted when the generic test.sh script works
 
 set -ex
@@ -27,8 +26,6 @@ cd "${REPO_ROOT}"/build
 export LIT_OPTS="--ignore-fail --xunit-xml-output=results.xml"
 ninja check-all
 
-# The llvm-toolchain targets already set --xunit-xml-output so
-# only the --ignore-fail option is needed.
-# The picolibc tests do not use lit so do not support this option.
-export LIT_OPTS="--ignore-fail"
-ninja check-llvm-toolchain
+# The GTest framework in LLVM-libc does not yet have integration with lit.
+# However, we run all tests anyways (don't stop on failure with the flag -k 0)
+ninja check-llvmlibc -k 0

--- a/arm-software/embedded/scripts/test_llvmlibc.sh
+++ b/arm-software/embedded/scripts/test_llvmlibc.sh
@@ -15,17 +15,7 @@ REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
 
 cd "${REPO_ROOT}"/build
 
-# If a test fails, lit will ordinarily return a non-zero result,
-# which prevents further testing. Setting the --ignore-fail option
-# will cause testing to continue, so that CI systems can get a
-# full set of results.
-# The check-all target runs the upstream clang and LLVM tests,
-# which do not generate an junit xml results file by default.
-# Additionally setting the --xunit-xml-output option store the
-# results.
-export LIT_OPTS="--ignore-fail --xunit-xml-output=results.xml"
-ninja check-all
-
 # The GTest framework in LLVM-libc does not yet have integration with lit.
 # However, we run all tests anyways (don't stop on failure with the flag -k 0)
-ninja check-llvmlibc -k 0
+# If the test script fails, the package will not be uploaded
+ninja check-llvmlibc -k 0 || true

--- a/arm-software/embedded/scripts/test_llvmlibc.sh
+++ b/arm-software/embedded/scripts/test_llvmlibc.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# A bash script to run the LLVM-libc tests from the Arm Toolchain for Embedded.
+
+# This script should be deleted when the generic test.sh script works
+
+set -ex
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
+
+cd "${REPO_ROOT}"/build
+
+# If a test fails, lit will ordinarily return a non-zero result,
+# which prevents further testing. Setting the --ignore-fail option
+# will cause testing to continue, so that CI systems can get a
+# full set of results.
+# The check-all target runs the upstream clang and LLVM tests,
+# which do not generate an junit xml results file by default.
+# Additionally setting the --xunit-xml-output option store the
+# results.
+export LIT_OPTS="--ignore-fail --xunit-xml-output=results.xml"
+ninja check-all
+
+# The llvm-toolchain targets already set --xunit-xml-output so
+# only the --ignore-fail option is needed.
+# The picolibc tests do not use lit so do not support this option.
+export LIT_OPTS="--ignore-fail"
+ninja check-llvm-toolchain


### PR DESCRIPTION
LLVM-libc tests can now be run for a lot of variants. This is experimental, however, there should be no reason why these tests won't run.