### PR TITLE
[ATfE] Build AArch64 library variants with `-ffixed-x18`

### DIFF
--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a",
-            "COMPILE_FLAGS": "-march=armv8-a -mno-unaligned-access -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-a -mno-unaligned-access -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_be.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_be.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_be",
-            "COMPILE_FLAGS": "-march=armv8-a -mbig-endian -mno-unaligned-access -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-a -mbig-endian -mno-unaligned-access -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_be_exn_rtti",
-            "COMPILE_FLAGS": "-march=armv8-a -mbig-endian -mno-unaligned-access -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-a -mbig-endian -mno-unaligned-access -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_soft_nofp.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_be_soft_nofp",
-            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mbig-endian -mabi=aapcs-soft -mno-unaligned-access -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mbig-endian -mabi=aapcs-soft -mno-unaligned-access -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_be_soft_nofp_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_be_soft_nofp_exn_rtti",
-            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mbig-endian -mabi=aapcs-soft -mno-unaligned-access -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mbig-endian -mabi=aapcs-soft -mno-unaligned-access -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_exn_rtti",
-            "COMPILE_FLAGS": "-march=armv8-a -mno-unaligned-access -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-a -mno-unaligned-access -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_exn_rtti_unaligned.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_exn_rtti_unaligned",
-            "COMPILE_FLAGS": "-march=armv8-a -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-a -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "qemu",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_soft_nofp.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_soft_nofp",
-            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_soft_nofp_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_soft_nofp_exn_rtti",
-            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "qemu",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_unaligned.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_unaligned",
-            "COMPILE_FLAGS": "-march=armv8-a -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-a -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r",
-            "COMPILE_FLAGS": "-march=armv8-r -mno-unaligned-access -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-r -mno-unaligned-access -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_be.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_be.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_be",
-            "COMPILE_FLAGS": "-march=armv8-r -mbig-endian -mno-unaligned-access -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-r -mbig-endian -mno-unaligned-access -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_be_exn_rtti",
-            "COMPILE_FLAGS": "-march=armv8-r -mbig-endian -mno-unaligned-access -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-r -mbig-endian -mno-unaligned-access -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_soft_nofp.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_be_soft_nofp",
-            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mbig-endian -mabi=aapcs-soft -mno-unaligned-access -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mbig-endian -mabi=aapcs-soft -mno-unaligned-access -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_be_soft_nofp_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_be_soft_nofp_exn_rtti",
-            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mbig-endian -mabi=aapcs-soft -mno-unaligned-access -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mbig-endian -mabi=aapcs-soft -mno-unaligned-access -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_exn_rtti",
-            "COMPILE_FLAGS": "-march=armv8-r -mno-unaligned-access -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-r -mno-unaligned-access -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_exn_rtti_unaligned.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_exn_rtti_unaligned",
-            "COMPILE_FLAGS": "-march=armv8-r -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-r -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_soft_nofp",
-            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_exn_rtti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_soft_nofp_exn_rtti",
-            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_exn_rtti_unaligned.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_soft_nofp_exn_rtti_unaligned",
-            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mabi=aapcs-soft -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mabi=aapcs-soft -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "ON",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_soft_nofp_unaligned.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_soft_nofp_unaligned",
-            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mabi=aapcs-soft -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-r+nofp+nosimd -mabi=aapcs-soft -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64r_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64r_unaligned.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64r",
             "VARIANT": "aarch64r_unaligned",
-            "COMPILE_FLAGS": "-march=armv8-r -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-r -fPIC -ffixed-x18",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "fvp",


### PR DESCRIPTION
In the procedure call standard, `X18` is reserved for the platform. As a bare-metal toolchain we don't know what the platform will be so avoid using `X18` in case it is used by other code.

The clang's `-fsanitize=shadow-call-stack` is one such feature that relies on `X18` not being modified by the library.