### PR TITLE
[ATfE] Enable v7-A and v7-R variants for LLVM-libc tests

### DIFF
--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_hard_vfpv3_d16.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_hard_vfpv3_d16.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_hard_vfpv3_d16_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_hard_vfpv3_d16_exn_rtti.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_hard_vfpv3_d16_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_hard_vfpv3_d16_exn_rtti_unaligned.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_hard_vfpv3_d16_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_hard_vfpv3_d16_unaligned.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_nofp.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_nofp_exn_rtti.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_nofp_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_nofp_exn_rtti_unaligned.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_nofp_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_nofp_unaligned.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_vfpv3_d16.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_vfpv3_d16.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_vfpv3_d16_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_vfpv3_d16_exn_rtti.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_vfpv3_d16_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_vfpv3_d16_exn_rtti_unaligned.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_vfpv3_d16_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7a_soft_vfpv3_d16_unaligned.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3_d16.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3_d16.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3_d16_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3_d16_exn_rtti.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3_d16_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3_d16_exn_rtti_unaligned.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3_d16_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3_d16_unaligned.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3xd.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3xd.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3xd_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3xd_exn_rtti.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3xd_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3xd_exn_rtti_unaligned.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3xd_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_hard_vfpv3xd_unaligned.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_nofp.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_nofp_exn_rtti.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_nofp_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_nofp_exn_rtti_unaligned.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_nofp_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_nofp_unaligned.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_vfpv3xd.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_vfpv3xd.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_vfpv3xd_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_vfpv3xd_exn_rtti.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_vfpv3xd_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_vfpv3xd_exn_rtti_unaligned.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_vfpv3xd_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/armv7r_soft_vfpv3xd_unaligned.json
@@ -33,7 +33,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -635,7 +635,12 @@ endif()
 ###############################################################################
 
 if(C_LIBRARY STREQUAL llvmlibc)
-    set(test_cmd "qemu-system-arm -M ${QEMU_MACHINE} -semihosting -nographic -device loader$<COMMA>file=@BINARY@")
+    set(test_cmd 
+        "qemu-system-arm -M ${QEMU_MACHINE} -cpu ${QEMU_CPU} ${QEMU_PARAMS} \
+        -chardev stdio$<COMMA>mux=on$<COMMA>id=stdio0 \
+        -semihosting-config enable=on$<COMMA>chardev=stdio0$<COMMA>arg=program-name \
+        -monitor none -serial none -nographic -device loader$<COMMA>file=@BINARY@$<COMMA>cpu-num=0")
+    
     set(lib_compile_flags "${lib_compile_flags} -Wno-error=atomic-alignment")
 
     set(common_llvmlibc_cmake_args

--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions_7a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions_7a.h
@@ -95,7 +95,9 @@ EXFN_ATTR void handle_fiq() {
 // bytes long, and contains code. The whole table must be 32-byte aligned.
 // The table may also be relocated, so we make it position-independent by
 // having a table of handler addresses and loading the address to pc.
-__attribute__((naked, section(".vectors"), aligned(32))) void vector_table() {
+[[gnu::section(".vectors"), gnu::aligned(32), gnu::used, gnu::naked,
+  gnu::target("arm")]]
+void vector_table() {
   asm("LDR pc, [pc, #24]");
   asm("LDR pc, [pc, #24]");
   asm("LDR pc, [pc, #24]");
@@ -104,14 +106,14 @@ __attribute__((naked, section(".vectors"), aligned(32))) void vector_table() {
   asm("LDR pc, [pc, #24]");
   asm("LDR pc, [pc, #24]");
   asm("LDR pc, [pc, #24]");
-  asm(".word %0" : : "X"(handle_reset));
-  asm(".word %0" : : "X"(handle_undefined));
-  asm(".word %0" : : "X"(handle_svc_hyp_smc));
-  asm(".word %0" : : "X"(handle_prefetch_abort));
-  asm(".word %0" : : "X"(handle_data_abort));
-  asm(".word %0" : : "X"(handle_hyp_trap));
-  asm(".word %0" : : "X"(handle_irq));
-  asm(".word %0" : : "X"(handle_fiq));
+  asm(".word %c0" : : "X"(handle_reset));
+  asm(".word %c0" : : "X"(handle_undefined));
+  asm(".word %c0" : : "X"(handle_svc_hyp_smc));
+  asm(".word %c0" : : "X"(handle_prefetch_abort));
+  asm(".word %c0" : : "X"(handle_data_abort));
+  asm(".word %c0" : : "X"(handle_hyp_trap));
+  asm(".word %c0" : : "X"(handle_irq));
+  asm(".word %c0" : : "X"(handle_fiq));
 }
 
 } // namespace exceptions

--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions_a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions_a.h
@@ -35,8 +35,12 @@ void setup() {
   // The vector table is always at address 0. The inline assembly is needed
   // here to hide the memcpy to a null pointer from the compiler.
   void *final_vector_table = NULL;
-  asm("" : "+r"(final_vector_table));
-  memcpy(final_vector_table, (void *)&vector_table, 64);
+  // Don't use memcpy as llvmlibc memcpy will fault a copy to address 0.
+  // Size is more important than speed here so don't unroll the loop.
+  _Pragma("clang loop unroll(disable) vectorize(disable)") for (
+      int i = 0; i < 64 / sizeof(unsigned int); i++) {
+    ((unsigned int *)final_vector_table)[i] = ((unsigned int *)vector_table)[i];
+  }
 #endif
 }
 


### PR DESCRIPTION
Support added in https://github.com/llvm/llvm-project/pull/153576

Also update bootcode to support v7-A/v7-R outside of hermetic tests.