### PR TITLE
[ATfE] Fix linker script path in llvmlibc sample

### DIFF
--- a/arm-software/embedded/llvmlibc-samples/src/cpp-baremetal-semihosting-llvmlibc/make.bat
+++ b/arm-software/embedded/llvmlibc-samples/src/cpp-baremetal-semihosting-llvmlibc/make.bat
@@ -40,6 +40,6 @@ if exist hello.hex del /q hello.hex
 @exit /B 1
 
 :build_fn
-%BIN_PATH%\clang++.exe --config=llvmlibc.cfg --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -nostartfiles -lcrt0-semihost -lsemihost -g -T ..\..\ldscripts\llvmlibc-microbit.ld -lm -o hello.elf hello.cpp
+%BIN_PATH%\clang++.exe --config=llvmlibc.cfg --target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m -mfpu=none -nostartfiles -lcrt0-semihost -lsemihost -g -T microbit-llvmlibc.ld -lm -o hello.elf hello.cpp
 %BIN_PATH%\llvm-objcopy.exe -O ihex hello.elf hello.hex
 @exit /B


### PR DESCRIPTION
The previous patch to the C++ llvmlibc sample's make script incorrectly changed the linker script path to a file that doesn't exist on the branch. This patch changes it back.