### PR TITLE
Optimize ATfE pre/post-merge workflows with path filters

### DIFF
--- a/.github/workflows/atfe_post_merge.yml
+++ b/.github/workflows/atfe_post_merge.yml
@@ -19,8 +19,28 @@ on:
   pull_request:
     types: [closed]
     branches:
-      - arm-toolchain
-      - release/arm-software/**
+      - 'arm-toolchain'
+      - 'release/arm-software/**'
+    paths:
+      # Run workflow if the PR modifies any of the following directories
+      - 'arm-software/embedded/**'
+      - 'clang/**'
+      - 'cmake/**'
+      - 'compiler-rt/**'
+      - 'libc/**'
+      - 'libcxx/**'
+      - 'libcxxabi/**'
+      - 'libunwind/**'
+      - 'lld/**'
+      - 'llvm/**'
+      - 'runtimes/**'
+      - 'utils/**'
+      # Exclude directories that are not relevant for ATfE
+      - '!arm-software/linux/**'
+      # Exclude changes in files with these extensions
+      - '!**/*.cfg'
+      - '!**/*.md'
+      - '!**/*.rst'
 
   # Trigger after the Automerge workflow completes
   workflow_run:

--- a/.github/workflows/atfe_pre_merge.yml
+++ b/.github/workflows/atfe_pre_merge.yml
@@ -18,8 +18,28 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
-      - arm-software
-      - release/arm-software/**
+      - 'arm-software'
+      - 'release/arm-software/**'
+    paths:
+      # Run workflow if the PR modifies any of the following directories
+      - 'arm-software/embedded/**'
+      - 'clang/**'
+      - 'cmake/**'
+      - 'compiler-rt/**'
+      - 'libc/**'
+      - 'libcxx/**'
+      - 'libcxxabi/**'
+      - 'libunwind/**'
+      - 'lld/**'
+      - 'llvm/**'
+      - 'runtimes/**'
+      - 'utils/**'
+      # Exclude directories that are not relevant for ATfE
+      - '!arm-software/linux/**'
+      # Exclude changes in files with these extensions
+      - '!**/*.cfg'
+      - '!**/*.md'
+      - '!**/*.rst'
 
 jobs:
   build-and-test:


### PR DESCRIPTION
- Added path filters so ATfE workflows only run when relevant directories are modified
- https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#example-excluding-paths