### PR TITLE
[ATfE] Add AArch64 samples for LLVM-libc

### DIFF
--- a/arm-software/embedded/llvmlibc-samples/ldscripts/llvmlibc-raspi3b.ld
+++ b/arm-software/embedded/llvmlibc-samples/ldscripts/llvmlibc-raspi3b.ld
@@ -1,0 +1,25 @@
+/* Copyright (c) 2025, Arm Limited and affiliates. 
+ *
+ * Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */
+
+/*
+Raspberry Pi does not have flash, but to accommodate for the llvmlibc.ld, we
+put the boot_flash, flash and ram momory in Raspberry's RAM. The boot_flash
+memory has to be put at fixed address. The flash and ram memory are placed
+arbitrarily.
+
+This is enough for simple testing, for real projects appropriate custom
+linker script file should be provided.
+*/
+
+__boot_flash = 0x80000; /* Default firmware address for Rapberry Pi 3 */
+__boot_flash_size = 0x2000; /* 8K of space for added page table */
+__flash = 0x10000000;
+__flash_size = 0x10000000;
+__ram = 0x20000000;
+__ram_size = 0x20000000;
+__stack_size = 4096;
+
+INCLUDE llvmlibc.ld

--- a/arm-software/embedded/llvmlibc-samples/src/baremetal-semihosting-aarch64-llvmlibc/Makefile
+++ b/arm-software/embedded/llvmlibc-samples/src/baremetal-semihosting-aarch64-llvmlibc/Makefile
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+include ../../Makefile.conf
+
+build: hello.elf
+
+hello.elf: *.c
+	$(BIN_PATH)/clang --config=llvmlibc.cfg $(AARCH64_TARGET) $(CRT_SEMIHOST) -lm -g -T ../../ldscripts/llvmlibc-raspi3b.ld -o hello.elf $^
+
+%.img: %.elf
+	$(BIN_PATH)/llvm-objcopy -O binary $< $@
+
+run: hello.img
+	qemu-system-aarch64 -M raspi3b -semihosting -nographic -kernel $<
+
+debug: hello.img
+	qemu-system-aarch64 -M raspi3b -semihosting -nographic -kernel $< -s -S
+
+clean:
+	rm -f *.img *.elf
+
+.PHONY: clean run debug

--- a/arm-software/embedded/llvmlibc-samples/src/baremetal-semihosting-aarch64-llvmlibc/hello.c
+++ b/arm-software/embedded/llvmlibc-samples/src/baremetal-semihosting-aarch64-llvmlibc/hello.c
@@ -1,0 +1,29 @@
+/* Copyright (c) 2025, Arm Limited and affiliates. 
+ *
+ * Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+// Example that uses heap, string and math library.
+
+int main(void) {
+  const char *hello_s = "hello ";
+  const char *world_s = "world";
+  const size_t hello_s_len = strlen(hello_s);
+  const size_t world_s_len = strlen(world_s);
+  const size_t out_s_len = hello_s_len + world_s_len + 1;
+  char *out_s = (char*) malloc(out_s_len);
+  assert(out_s_len >= hello_s_len + 1);
+  strncpy(out_s, hello_s, hello_s_len + 1);
+  assert(out_s_len >= strlen(out_s) + world_s_len + 1);
+  strncat(out_s, world_s, world_s_len + 1);
+  printf("%s\npi = %f\n", out_s, 4.0f * atanf(1.0f));
+  free(out_s);
+  return 0;
+}

--- a/arm-software/embedded/llvmlibc-samples/src/baremetal-semihosting-aarch64-llvmlibc/make.bat
+++ b/arm-software/embedded/llvmlibc-samples/src/baremetal-semihosting-aarch64-llvmlibc/make.bat
@@ -1,0 +1,45 @@
+@REM Copyright (c) 2025, Arm Limited and affiliates.
+@REM
+@REM Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+@REM See https://llvm.org/LICENSE.txt for license information.
+@REM SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+@if [%1]==[] goto :target_empty
+@set target=%1
+@goto :make
+:target_empty
+@set target=build
+
+:make
+@if [%target%]==[build] goto :build
+@if [%target%]==[run] goto :run
+@if [%target%]==[clean] goto :clean
+@echo Error: unknown target "%target%"
+@exit /B 1
+
+:build
+@if [%BIN_PATH%]==[] goto :bin_path_empty
+@call :build_fn
+@exit /B
+
+:run
+@if exist hello.img goto :do_run
+@if [%BIN_PATH%]==[] goto :bin_path_empty
+@call :build_fn
+:do_run
+qemu-system-aarch64.exe -M raspi3b -semihosting -nographic -kernel hello.img
+@exit /B
+
+:clean
+if exist hello.elf del /q hello.elf
+if exist hello.img del /q hello.img
+@exit /B
+
+:bin_path_empty
+@echo Error: BIN_PATH environment variable is not set
+@exit /B 1
+
+:build_fn
+%BIN_PATH%\clang.exe --config=llvmlibc.cfg --target=aarch64-none-elf -nostartfiles -lcrt0-semihost -lsemihost -g -T ..\..\ldscripts\llvmlibc-raspi3b.ld -o hello.elf hello.c
+%BIN_PATH%\llvm-objcopy.exe -O binary hello.elf hello.img
+@exit /B

--- a/arm-software/embedded/llvmlibc-support/crt0/bootcode.cpp
+++ b/arm-software/embedded/llvmlibc-support/crt0/bootcode.cpp
@@ -77,13 +77,18 @@ extern "C" void __startup() {
   exit(main(0, 0));
 }
 
+extern "C" {
 // The entry point sets sp and branches to the main startup function.
 #ifdef __ARM_ARCH_ISA_ARM
-// If the target supports the A32 instruction set then the entry point has to
-// use it.
+// If the target supports the A32 instruction set then the entry point has
+// to use it.
 __attribute__((target("arm")))
+#elif defined(__ARM_ARCH_ISA_A64)
+// QEMU (AArch64) will jump to the first section when running from a .bin/.hex
+// file after boot. Therefore, place the entrypoint there.
+__attribute__((section(".text.init.enter")))
 #endif
-__attribute__((naked)) extern "C" void _start() {
+__attribute__((naked)) void _start() {
 #if __ARM_ARCH_PROFILE != 'M' && __ARM_ARCH >= 8 && !defined(__ARM_ARCH_ISA_A64)
   // Check if we're in hypervisor mode
   asm("mrs r0, CPSR\n\t"
@@ -109,3 +114,4 @@ __attribute__((naked)) extern "C" void _start() {
   asm("mov sp, %0" : : "r"(&__stack));
   asm("bl %0" : : "X"(__startup));
 }
+} // extern "C"

--- a/arm-software/embedded/llvmlibc-support/llvmlibc.ld.in
+++ b/arm-software/embedded/llvmlibc-support/llvmlibc.ld.in
@@ -65,9 +65,11 @@ SECTIONS
 {
         PROVIDE(__stack = ORIGIN(ram) + LENGTH(ram));
 
-        .boot_flash : {
-                KEEP (*(.vectors))
-        } >boot_flash AT>boot_flash :text_boot_flash
+		.boot_flash : {
+				KEEP (*(.text.init.enter))
+				KEEP (*(.vectors))
+				KEEP (*(.init))
+		} >boot_flash AT>boot_flash :text_boot_flash
 
         .text : {
 


### PR DESCRIPTION
This is based on the AArch64 sample from picolibc. This requires a minor hack. We need to place the _start at the beginning of the boot_flash section, and run QEMU from 0x0. This allows QEMU to turn off multithreading, and reach the _start symbol.

We use the section `.text.init.enter` for this. We do need extra space in `boot_flash`, because we also put the page table in this section.