### PR TITLE
[ATfE] Enable AArch64 LLVM-libc tests on QEMU

### DIFF
--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_exn_rtti_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_exn_rtti_unaligned.json
@@ -32,7 +32,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_soft_nofp.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_soft_nofp.json
@@ -32,7 +32,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_soft_nofp_exn_rtti.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_soft_nofp_exn_rtti.json
@@ -32,7 +32,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-multilib/json/variants/aarch64a_unaligned.json
+++ b/arm-software/embedded/arm-multilib/json/variants/aarch64a_unaligned.json
@@ -32,7 +32,7 @@
         },
         "llvmlibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }

--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -655,12 +655,19 @@ endif()
 ###############################################################################
 
 if(C_LIBRARY STREQUAL llvmlibc)
-    set(test_cmd 
-        "qemu-system-arm -M ${QEMU_MACHINE} -cpu ${QEMU_CPU} ${QEMU_PARAMS} \
-        -chardev stdio$<COMMA>mux=on$<COMMA>id=stdio0 \
-        -semihosting-config enable=on$<COMMA>chardev=stdio0$<COMMA>arg=program-name \
-        -monitor none -serial none -nographic -device loader$<COMMA>file=@BINARY@$<COMMA>cpu-num=0")
-    
+    if(TARGET_ARCH MATCHES "^aarch64")
+        set(test_cmd
+            "qemu-system-aarch64 -M ${QEMU_MACHINE} -cpu ${QEMU_CPU} \
+            -chardev stdio$<COMMA>mux=on$<COMMA>id=stdio0 \
+            -semihosting-config enable=on$<COMMA>chardev=stdio0$<COMMA>arg=program-name \
+            -monitor none -serial none -nographic -kernel @BINARY@")
+    else()
+        set(test_cmd
+            "qemu-system-arm -M ${QEMU_MACHINE} -cpu ${QEMU_CPU} ${QEMU_PARAMS} \
+            -chardev stdio$<COMMA>mux=on$<COMMA>id=stdio0 \
+            -semihosting-config enable=on$<COMMA>chardev=stdio0$<COMMA>arg=program-name \
+            -monitor none -serial none -nographic -device loader$<COMMA>file=@BINARY@$<COMMA>cpu-num=0")
+    endif()
     set(lib_compile_flags "${lib_compile_flags} -Wno-error=atomic-alignment")
 
     set(common_llvmlibc_cmake_args


### PR DESCRIPTION
Enabled in https://github.com/llvm/llvm-project/pull/154789

Minor changes to the CMake file, to select `qemu-system-aarch64` if applicable. These tests don't pass, but they compile, so we enable them.