### PR TITLE
[ATfE][NFC] Modernise llvmlibc-support to use C++ style code

### DIFF
--- a/arm-software/embedded/llvmlibc-support/crt0/bootcode.cpp
+++ b/arm-software/embedded/llvmlibc-support/crt0/bootcode.cpp
@@ -46,12 +46,12 @@ int main(int argc, const char **argv);
 extern "C" void __libc_init_array();
 extern "C" void _platform_init();
 
-extern uintptr_t __data_source[];
-extern uintptr_t __data_start[];
-extern uintptr_t __data_size[];
-extern uintptr_t __bss_start[];
-extern uintptr_t __bss_size[];
-[[gnu::weak]] extern uintptr_t __stack;
+extern char __data_source[];
+extern char __data_start[];
+extern char __data_size[];
+extern char __bss_start[];
+extern char __bss_size[];
+[[gnu::weak]] extern char __stack;
 
 namespace {
 #ifdef __ARM_FEATURE_PAUTH
@@ -65,8 +65,8 @@ void do_start() {
   misc::setup();
 
   // Perform the equivalent of scatterloading
-  memcpy(__data_start, __data_source, reinterpret_cast<uintptr_t>(__data_size));
-  memset(__bss_start, '\0', reinterpret_cast<uintptr_t>(__bss_size));
+  memcpy(__data_start, __data_source, reinterpret_cast<size_t>(__data_size));
+  memset(__bss_start, '\0', reinterpret_cast<size_t>(__bss_size));
 
   memory::enable_cache();
   __libc_init_array();

--- a/arm-software/embedded/llvmlibc-support/crt0/bootcode.cpp
+++ b/arm-software/embedded/llvmlibc-support/crt0/bootcode.cpp
@@ -46,49 +46,47 @@ int main(int argc, const char **argv);
 extern "C" void __libc_init_array();
 extern "C" void _platform_init();
 
-// Required for exit() on baremetal
-// TODO: This is temporary, remove once implemented upstream
-extern "C" [[gnu::weak]] void __cxa_finalize(void *) {}
+extern uintptr_t __data_source[];
+extern uintptr_t __data_start[];
+extern uintptr_t __data_size[];
+extern uintptr_t __bss_start[];
+extern uintptr_t __bss_size[];
+[[gnu::weak]] extern uintptr_t __stack;
 
-extern char __data_source[];
-extern char __data_start[];
-extern char __data_size[];
-extern char __bss_start[];
-extern char __bss_size[];
-extern char __stack __attribute__((weak));
-
+namespace {
 #ifdef __ARM_FEATURE_PAUTH
 // Disable pointer authentication, as it isn't enabled until misc::setup meaning
 // the PAC at the beginning would do nothing so the AUT at the end would fail.
-__attribute__((target("branch-protection=none")))
+[[gnu::target("branch-protection=none")]]
 #endif
-extern "C" void __startup() {
+void do_start() {
   exceptions::setup();
   memory::setup();
   misc::setup();
 
   // Perform the equivalent of scatterloading
-  memcpy(__data_start, __data_source, (uintptr_t)__data_size);
-  memset(__bss_start, '\0', (uintptr_t)__bss_size);
+  memcpy(__data_start, __data_source, reinterpret_cast<uintptr_t>(__data_size));
+  memset(__bss_start, '\0', reinterpret_cast<uintptr_t>(__bss_size));
 
   memory::enable_cache();
   __libc_init_array();
   _platform_init();
   exit(main(0, 0));
 }
+} // namespace
 
 extern "C" {
 // The entry point sets sp and branches to the main startup function.
 #ifdef __ARM_ARCH_ISA_ARM
 // If the target supports the A32 instruction set then the entry point has
 // to use it.
-__attribute__((target("arm")))
+[[gnu::target("arm")]]
 #elif defined(__ARM_ARCH_ISA_A64)
 // QEMU (AArch64) will jump to the first section when running from a .bin/.hex
 // file after boot. Therefore, place the entrypoint there.
-__attribute__((section(".text.init.enter")))
+[[gnu::section(".text.init.enter")]]
 #endif
-__attribute__((naked)) void _start() {
+[[gnu::naked]] void _start() {
 #if __ARM_ARCH_PROFILE != 'M' && __ARM_ARCH >= 8 && !defined(__ARM_ARCH_ISA_A64)
   // Check if we're in hypervisor mode
   asm("mrs r0, CPSR\n\t"
@@ -112,6 +110,6 @@ __attribute__((naked)) void _start() {
 
   // Configured through linker script defined symbols
   asm("mov sp, %0" : : "r"(&__stack));
-  asm("bl %0" : : "X"(__startup));
+  asm("bl %0" : : "X"(::do_start));
 }
 } // extern "C"

--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions_7a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions_7a.h
@@ -27,7 +27,7 @@ EXFN_ATTR void handle_reset() {
 
 EXFN_ATTR void handle_undefined() {
   unsigned pc_val = __arm_rsr("ELR_hyp");
-  unsigned instr = *(unsigned *)pc_val;
+  unsigned instr = *reinterpret_cast<unsigned *>(pc_val);
   print_str("CPU Exception: Undefined Instruction\n");
   print_str("  PC = ");
   print_hex(pc_val);

--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions_8a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions_8a.h
@@ -206,7 +206,8 @@ EXFN_ATTR void exception_handler() {
 // For our purposes, each entry just contains one branch instruction to the
 // exception reporting function, since we never want to resume after an
 // exception.
-__attribute__((naked, section(".vectors"), aligned(2048))) void vector_table() {
+[[gnu::naked, gnu::section(".vectors"), gnu::aligned(2048)]]
+void vector_table() {
 #define VECTOR_TABLE_ENTRY                                                     \
   asm(".balign 128");                                                          \
   asm("B %0" : : "X"(exception_handler));

--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions_a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions_a.h
@@ -26,11 +26,11 @@ using namespace sysreg;
 
 #ifndef __ARM_ARCH_ISA_A64
 // Floating-point instructions aren't enabled yet
-__attribute__((target("no-fpregs")))
+[[gnu::target("no-fpregs")]]
 #endif
 void setup() {
 #if __ARM_ARCH_PROFILE == 'A'
-  VBAR = (unsigned long)&vector_table;
+  VBAR = reinterpret_cast<unsigned long>(&vector_table);
 #elif __ARM_ARCH_PROFILE == 'R'
   // The vector table is always at address 0. The inline assembly is needed
   // here to hide the memcpy to a null pointer from the compiler.
@@ -39,7 +39,8 @@ void setup() {
   // Size is more important than speed here so don't unroll the loop.
   _Pragma("clang loop unroll(disable) vectorize(disable)") for (
       int i = 0; i < 64 / sizeof(unsigned int); i++) {
-    ((unsigned int *)final_vector_table)[i] = ((unsigned int *)vector_table)[i];
+    (reinterpret_cast<unsigned int *>(final_vector_table))[i] =
+        (reinterpret_cast<unsigned int *>(vector_table))[i];
   }
 #endif
 }

--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions_common.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions_common.h
@@ -14,7 +14,7 @@
 // We don't want memory tagging in exception handling functions, or the
 // functions that they call, as if there's been an exception due to memory
 // tagging we may well end up causing a recursive exception.
-#define EXFN_ATTR __attribute__((no_sanitize("memtag")))
+#define EXFN_ATTR [[clang::no_sanitize("memtag")]]
 
 namespace bootcode {
 namespace exceptions {

--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions_m.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions_m.h
@@ -46,7 +46,8 @@ EXFN_ATTR void __print_faulting_instruction(unsigned short *ptr) {
 }
 
 EXFN_ATTR void __hardfault_handler() {
-  unsigned *pushed_regs = 2 + (unsigned *)__builtin_frame_address(0);
+  unsigned *pushed_regs =
+      2 + reinterpret_cast<unsigned *>(__builtin_frame_address(0));
   unsigned pc_val = pushed_regs[6];
   print_str("CPU Exception: HardFault\n");
   print_str("  PC = 0x");
@@ -55,11 +56,12 @@ EXFN_ATTR void __hardfault_handler() {
   print_str("  HFSR = 0x");
   print_hex((unsigned int)HFSR);
   print_str("\n");
-  __print_faulting_instruction((unsigned short *)pc_val);
+  __print_faulting_instruction(reinterpret_cast<unsigned short *>(pc_val));
 }
 
 EXFN_ATTR void __memmanage_handler() {
-  unsigned *pushed_regs = 2 + (unsigned *)__builtin_frame_address(0);
+  unsigned *pushed_regs =
+      2 + reinterpret_cast<unsigned *>(__builtin_frame_address(0));
   unsigned pc_val = pushed_regs[6];
   print_str("CPU Exception: MemMange\n");
   print_str("  PC = 0x");
@@ -71,11 +73,12 @@ EXFN_ATTR void __memmanage_handler() {
   print_str("  MMFAR = 0x");
   print_hex((unsigned int)MMFAR);
   print_str("\n");
-  __print_faulting_instruction((unsigned short *)pc_val);
+  __print_faulting_instruction(reinterpret_cast<unsigned short *>(pc_val));
 }
 
 EXFN_ATTR void __busfault_handler() {
-  unsigned *pushed_regs = 2 + (unsigned *)__builtin_frame_address(0);
+  unsigned *pushed_regs =
+      2 + reinterpret_cast<unsigned *>(__builtin_frame_address(0));
   unsigned pc_val = pushed_regs[6];
   print_str("CPU Exception: BusFault\n");
   print_str("  PC = 0x");
@@ -87,11 +90,12 @@ EXFN_ATTR void __busfault_handler() {
   print_str("  BFAR = 0x");
   print_hex((unsigned int)BFAR);
   print_str("\n");
-  __print_faulting_instruction((unsigned short *)pc_val);
+  __print_faulting_instruction(reinterpret_cast<unsigned short *>(pc_val));
 }
 
 EXFN_ATTR void __usagefault_handler() {
-  unsigned *pushed_regs = 2 + (unsigned *)__builtin_frame_address(0);
+  unsigned *pushed_regs =
+      2 + reinterpret_cast<unsigned *>(__builtin_frame_address(0));
   unsigned pc_val = pushed_regs[6];
   print_str("CPU Exception: UsageFault\n");
   print_str("  PC = 0x");
@@ -99,11 +103,12 @@ EXFN_ATTR void __usagefault_handler() {
   print_str("\n");
   print_str("  CFSR.UsageFault = 0x");
   print_hex((unsigned short)CFSR.UFSR), print_str("\n");
-  __print_faulting_instruction((unsigned short *)pc_val);
+  __print_faulting_instruction(reinterpret_cast<unsigned short *>(pc_val));
 }
 
 EXFN_ATTR void __securefault_handler() {
-  unsigned *pushed_regs = 2 + (unsigned *)__builtin_frame_address(0);
+  unsigned *pushed_regs =
+      2 + reinterpret_cast<unsigned *>(__builtin_frame_address(0));
   unsigned pc_val = pushed_regs[6];
   print_str("CPU Exception: SecureFault\n");
   print_str("  PC = 0x");
@@ -115,7 +120,7 @@ EXFN_ATTR void __securefault_handler() {
   print_str("  SFAR = 0x");
   print_hex((unsigned int)SFAR);
   print_str("\n");
-  __print_faulting_instruction((unsigned short *)pc_val);
+  __print_faulting_instruction(reinterpret_cast<unsigned short *>(pc_val));
 }
 
 extern "C" unsigned int __systick_count = 0;
@@ -127,26 +132,26 @@ EXFN_ATTR void __exception_handler() { abort(); }
 // has to be 128-byte aligned, however an implementation can require more bits
 // to be zero and cortex-m23 can require up to 10, so 1024-byte align the vector
 // table.
-extern char __stack __attribute__((weak));
+[[gnu::weak]] extern uintptr_t __stack;
 using vtable_t = void (*)(void);
-const vtable_t vector_table[]
-    __attribute__((section(".vectors"), aligned(1024))) = {
-        (vtable_t)&__stack,    // SP
-        _start,                // Reset
-        __exception_handler,   // NMI
-        __hardfault_handler,   // HardFault
-        __memmanage_handler,   // MemManage fault
-        __busfault_handler,    // BusFault
-        __usagefault_handler,  // UsageFault
-        __securefault_handler, // SecureFault
-        __exception_handler,   // Reserved
-        __exception_handler,   // Reserved
-        __exception_handler,   // Reserved
-        __exception_handler,   // SVCall
-        __exception_handler,   // DebugMonitor
-        __exception_handler,   // Reserved
-        __exception_handler,   // PendSV
-        __systick_handler,     // SysTick
+[[gnu::section(".vectors"), gnu::aligned(1024)]]
+const vtable_t vector_table[] = {
+    reinterpret_cast<vtable_t>(&__stack), // SP
+    _start,                               // Reset
+    __exception_handler,                  // NMI
+    __hardfault_handler,                  // HardFault
+    __memmanage_handler,                  // MemManage fault
+    __busfault_handler,                   // BusFault
+    __usagefault_handler,                 // UsageFault
+    __securefault_handler,                // SecureFault
+    __exception_handler,                  // Reserved
+    __exception_handler,                  // Reserved
+    __exception_handler,                  // Reserved
+    __exception_handler,                  // SVCall
+    __exception_handler,                  // DebugMonitor
+    __exception_handler,                  // Reserved
+    __exception_handler,                  // PendSV
+    __systick_handler,                    // SysTick
 };
 
 void setup() {
@@ -161,15 +166,16 @@ void setup() {
     if (VTOR == 0x0) {
       // Do nothing, vector_table is already placed in the correct place
     } else {
-      memcpy((void *)(unsigned int)VTOR, &vector_table, sizeof(vector_table));
+      memcpy(reinterpret_cast<void *>(VTOR.read()), &vector_table,
+             sizeof(vector_table));
     }
   } else {
 
     // VTOR is writable, so set it to the address of the vector table. This
     // should be sufficiently-aligned for all existing CPUs, but it's possible
     // a future one will require more alignment so check just in case.
-    VTOR = (unsigned long)&vector_table;
-    if (VTOR != (unsigned long)&vector_table) {
+    VTOR = reinterpret_cast<unsigned long>(&vector_table);
+    if (VTOR != reinterpret_cast<unsigned long>(&vector_table)) {
       print_str("Bootcode failed to set VTOR\n");
       abort();
     }

--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions_m.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions_m.h
@@ -132,7 +132,7 @@ EXFN_ATTR void __exception_handler() { abort(); }
 // has to be 128-byte aligned, however an implementation can require more bits
 // to be zero and cortex-m23 can require up to 10, so 1024-byte align the vector
 // table.
-[[gnu::weak]] extern uintptr_t __stack;
+[[gnu::weak]] extern char __stack;
 using vtable_t = void (*)(void);
 [[gnu::section(".vectors"), gnu::aligned(1024)]]
 const vtable_t vector_table[] = {

--- a/arm-software/embedded/llvmlibc-support/crt0/memory_7a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/memory_7a.h
@@ -25,7 +25,7 @@ using namespace sysreg;
 void setup_mmu(volatile unsigned long *pagetable, unsigned long stackheap_start,
                unsigned long stackheap_end) {
   // Find the memory pages that the image and stackheap occupy
-  unsigned long start_page = ((unsigned long)setup_mmu) >> 30;
+  unsigned long start_page = reinterpret_cast<unsigned long>(&setup_mmu) >> 30;
   unsigned long stackheap_page = stackheap_start >> 30;
 
   // Enable manager access to domain 0
@@ -37,10 +37,10 @@ void setup_mmu(volatile unsigned long *pagetable, unsigned long stackheap_start,
   // Set the base address
   if (!pagetable) {
     // Place after the end of the image
-    pagetable = (unsigned long *)stackheap_end;
+    pagetable = reinterpret_cast<unsigned long *>(stackheap_end);
   }
   // Set the low bit to mark translation table as inner cacheable
-  TTBR0 = 1 | (unsigned long)pagetable;
+  TTBR0 = 1 | reinterpret_cast<unsigned long>(pagetable);
 
   // Ensure changes to system register are visible before the MMU is enabled
   __isb(0xf);

--- a/arm-software/embedded/llvmlibc-support/crt0/memory_8a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/memory_8a.h
@@ -25,7 +25,7 @@ using namespace sysreg;
 void setup_mmu(volatile unsigned long *pagetable, unsigned long stackheap_start,
                unsigned long stackheap_end) {
   // Find the memory pages that the image and stackheap occupy
-  unsigned long start_page = ((unsigned long)setup_mmu) >> 30;
+  unsigned long start_page = reinterpret_cast<unsigned long>(&setup_mmu) >> 30;
   unsigned long stackheap_page = stackheap_start >> 30;
 
   // Invalidate the TLBs
@@ -38,10 +38,10 @@ void setup_mmu(volatile unsigned long *pagetable, unsigned long stackheap_start,
   // Set the base address
   if (!pagetable) {
     // Place at end of image page
-    pagetable = (unsigned long *)(((start_page + 1) << 30) -
-                                  (512 * sizeof(unsigned long)));
+    pagetable = reinterpret_cast<unsigned long *>(
+        ((start_page + 1) << 30) - (512 * sizeof(unsigned long)));
   }
-  TTBR0 = (unsigned long)pagetable;
+  TTBR0 = reinterpret_cast<unsigned long>(pagetable);
 
   // No need to program TTBR1_EL2, as we will set TCR_EL3.EPD1=1 to prevent
   // table walks using this table.

--- a/arm-software/embedded/llvmlibc-support/crt0/memory_a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/memory_a.h
@@ -85,9 +85,8 @@ void setup() {
   // Put the page table in the .init section so it doesn't later get
   // zero-initialized.
   static_assert(sizeof(unsigned long) == PAGE_TABLE_ENTRY_SIZE);
-  [[gnu::section(".init"),
-    gnu::aligned(PAGE_TABLE_ALIGNMENT)]] static volatile unsigned long
-      pagetable[PAGE_TABLE_ENTRY_COUNT];
+  [[gnu::section(".init"), gnu::aligned(PAGE_TABLE_ALIGNMENT)]]
+  static volatile unsigned long pagetable[PAGE_TABLE_ENTRY_COUNT];
   setup_mmu(pagetable, get_stackheap_start(), get_stackheap_end());
 #endif
 

--- a/arm-software/embedded/llvmlibc-support/crt0/memory_a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/memory_a.h
@@ -85,8 +85,9 @@ void setup() {
   // Put the page table in the .init section so it doesn't later get
   // zero-initialized.
   static_assert(sizeof(unsigned long) == PAGE_TABLE_ENTRY_SIZE);
-  static volatile unsigned long pagetable[PAGE_TABLE_ENTRY_COUNT]
-      __attribute__((section(".init"), aligned(PAGE_TABLE_ALIGNMENT)));
+  [[gnu::section(".init"),
+    gnu::aligned(PAGE_TABLE_ALIGNMENT)]] static volatile unsigned long
+      pagetable[PAGE_TABLE_ENTRY_COUNT];
   setup_mmu(pagetable, get_stackheap_start(), get_stackheap_end());
 #endif
 

--- a/arm-software/embedded/llvmlibc-support/crt0/memory_common.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/memory_common.h
@@ -11,7 +11,7 @@
 #ifndef BOOTCODE_MEMORY_COMMON_H
 #define BOOTCODE_MEMORY_COMMON_H
 
-[[gnu::weak]] extern uintptr_t __stack;
+[[gnu::weak]] extern char __stack;
 [[gnu::weak]] extern char __heap_start;
 
 namespace bootcode {

--- a/arm-software/embedded/llvmlibc-support/crt0/memory_common.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/memory_common.h
@@ -11,8 +11,8 @@
 #ifndef BOOTCODE_MEMORY_COMMON_H
 #define BOOTCODE_MEMORY_COMMON_H
 
-extern char __stack __attribute__((weak));
-extern char __heap_start __attribute__((weak));
+[[gnu::weak]] extern uintptr_t __stack;
+[[gnu::weak]] extern char __heap_start;
 
 namespace bootcode {
 namespace memory {
@@ -20,24 +20,26 @@ namespace memory {
 unsigned long get_stackheap_start() {
   unsigned long val;
 
-  if ((val = (unsigned long)&__heap_start)) {
+  if ((val = reinterpret_cast<unsigned long>(&__heap_start))) {
     return val;
   }
 
   // Place stackheap in the page after this one (assuming 1Gb pages)
-  unsigned long page = ((unsigned long)get_stackheap_start) >> 30;
+  unsigned long page =
+      (reinterpret_cast<unsigned long>(&get_stackheap_start)) >> 30;
   return (page + 1) << 30;
 }
 
 unsigned long get_stackheap_end() {
   unsigned long val;
 
-  if ((val = (unsigned long)&__stack)) {
+  if ((val = reinterpret_cast<unsigned long>(&__stack))) {
     return val;
   }
 
   // Place stackheap in the page after this one (assuming 1Gb pages)
-  unsigned long page = ((unsigned long)get_stackheap_end) >> 30;
+  unsigned long page =
+      (reinterpret_cast<unsigned long>(&get_stackheap_end)) >> 30;
   return (page + 2) << 30;
 }
 

--- a/arm-software/embedded/llvmlibc-support/crt0/system_registers_a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/system_registers_a.h
@@ -66,7 +66,7 @@ public:
   // so we have to specialize the read/write functions for each register name.
   static unsigned long read();
   static void write(unsigned long val);
-  __attribute__((always_inline)) SysReg &operator=(unsigned long val) {
+  [[clang::always_inline]] SysReg &operator=(unsigned long val) {
     write(val);
     return *this;
   }
@@ -76,12 +76,12 @@ public:
 
 #define REGNAME(X, Y)                                                          \
   template <>                                                                  \
-  __attribute__((always_inline)) inline unsigned long                          \
+  [[clang::always_inline]] inline unsigned long                          \
   SysReg<SysRegName::X>::read() {                                              \
     return __arm_rsr64(#X "_EL0");                                             \
   }                                                                            \
   template <>                                                                  \
-  __attribute__((always_inline)) inline void SysReg<SysRegName::X>::write(     \
+  [[clang::always_inline]] inline void SysReg<SysRegName::X>::write(     \
       unsigned long val) {                                                     \
     __arm_wsr64(#X "_EL0", val);                                               \
   }
@@ -90,12 +90,12 @@ EL0_REGNAMES
 
 #define REGNAME(X, Y)                                                          \
   template <>                                                                  \
-  __attribute__((always_inline)) inline unsigned long                          \
+  [[clang::always_inline]] inline unsigned long                          \
   SysReg<SysRegName::X>::read() {                                              \
     return __arm_rsr64(#X "_EL1");                                             \
   }                                                                            \
   template <>                                                                  \
-  __attribute__((always_inline)) inline void SysReg<SysRegName::X>::write(     \
+  [[clang::always_inline]] inline void SysReg<SysRegName::X>::write(     \
       unsigned long val) {                                                     \
     __arm_wsr64(#X "_EL1", val);                                               \
   }
@@ -104,7 +104,7 @@ EL1_REGNAMES
 
 #define REGNAME(X, Y)                                                          \
   template <>                                                                  \
-  __attribute__((always_inline)) inline unsigned long                          \
+  [[clang::always_inline]] inline unsigned long                          \
   SysReg<SysRegName::X>::read() {                                              \
     if (__arm_rsr("CurrentEL") == 3 << 2)                                      \
       return __arm_rsr64(#X "_EL3");                                           \
@@ -112,7 +112,7 @@ EL1_REGNAMES
       return __arm_rsr64(#X "_EL2");                                           \
   }                                                                            \
   template <>                                                                  \
-  __attribute__((always_inline)) inline void SysReg<SysRegName::X>::write(     \
+  [[clang::always_inline]] inline void SysReg<SysRegName::X>::write(     \
       unsigned long val) {                                                     \
     if (__arm_rsr("CurrentEL") == 3 << 2)                                      \
       __arm_wsr64(#X "_EL3", val);                                             \
@@ -126,12 +126,12 @@ EL23_REGNAMES
 
 #define REGNAME(X, Y)                                                          \
   template <>                                                                  \
-  __attribute__((always_inline)) inline unsigned long                          \
+  [[clang::always_inline]] inline unsigned long                          \
   SysReg<SysRegName::X>::read() {                                              \
     return __arm_rsr(Y);                                                       \
   }                                                                            \
   template <>                                                                  \
-  __attribute__((always_inline)) inline void SysReg<SysRegName::X>::write(     \
+  [[clang::always_inline]] inline void SysReg<SysRegName::X>::write(     \
       unsigned long val) {                                                     \
     __arm_wsr(Y, val);                                                         \
   }
@@ -189,7 +189,7 @@ public:
   Field<30, 32> ICB;
   Field<33, 46> Ttype;
 
-  __attribute__((always_inline)) unsigned long Ctype(unsigned level) {
+  [[clang::always_inline]] unsigned long Ctype(unsigned level) {
     unsigned long val = *this;
     return (val >> (3 * level)) & 0x7;
   }

--- a/arm-software/embedded/llvmlibc-support/crt0/system_registers_common.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/system_registers_common.h
@@ -19,18 +19,18 @@ namespace sysreg {
 // methods.
 template <class C> class SysRegBase {
 public:
-  __attribute__((always_inline)) operator unsigned long() { return C::read(); }
+  [[clang::always_inline]] operator unsigned long() { return C::read(); }
 
   template <int start, int end> class Field {
   public:
-    __attribute__((always_inline)) operator unsigned long() {
+    [[clang::always_inline]] operator unsigned long() {
       unsigned long reg = C::read();
       reg >>= start;
       reg &= (1UL << (end - start + 1)) - 1;
       return reg;
     }
 
-    __attribute__((always_inline)) Field &operator=(unsigned long val) {
+    [[clang::always_inline]] Field &operator=(unsigned long val) {
       unsigned long reg = C::read();
       unsigned long mask = ((1UL << (end - start + 1)) - 1) << start;
       reg &= ~mask;
@@ -42,7 +42,7 @@ public:
 
   template <int idx> class Bit : public Field<idx, idx> {
   public:
-    __attribute__((always_inline)) Bit &operator=(unsigned long val) {
+    [[clang::always_inline]] Bit &operator=(unsigned long val) {
       Field<idx, idx>::operator=(val);
       return *this;
     }

--- a/arm-software/embedded/llvmlibc-support/crt0/system_registers_m.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/system_registers_m.h
@@ -63,15 +63,15 @@ private:
   static constexpr unsigned long Addr = SysRegTraits<Name>::Addr;
 
 public:
-  __attribute__((always_inline)) static unsigned long read() {
-    return *(volatile unsigned long *)Addr;
+  [[clang::always_inline]] static unsigned long read() {
+    return *reinterpret_cast<volatile unsigned long *>(Addr);
   }
 
-  __attribute__((always_inline)) static void write(unsigned long val) {
-    *(volatile unsigned long *)Addr = val;
+  [[clang::always_inline]] static void write(unsigned long val) {
+    *reinterpret_cast<volatile unsigned long *>(Addr) = val;
   }
 
-  __attribute__((always_inline)) SysReg &operator=(unsigned long val) {
+  [[clang::always_inline]] SysReg &operator=(unsigned long val) {
     write(val);
     return *this;
   }
@@ -104,10 +104,10 @@ private:
   static constexpr unsigned long Max = SysRegSetTraits<Name>::Max;
 
 public:
-  __attribute__((always_inline)) volatile unsigned long &
+  [[clang::always_inline]] volatile unsigned long &
   operator[](unsigned int idx) {
     assert(idx <= Max);
-    return ((volatile unsigned long *)Addr)[idx];
+    return (reinterpret_cast<volatile unsigned long *>(Addr))[idx];
   }
 };
 

--- a/arm-software/embedded/llvmlibc-support/semihost/semihost.cpp
+++ b/arm-software/embedded/llvmlibc-support/semihost/semihost.cpp
@@ -14,10 +14,10 @@
 
 namespace {
 
-void stdio_open(struct __llvm_libc_stdio_cookie *cookie, int mode) {
+void stdio_open(struct __llvm_libc_stdio_cookie *cookie, size_t mode) {
   size_t args[3];
   args[0] = reinterpret_cast<size_t>(":tt");
-  args[1] = static_cast<size_t>(mode);
+  args[1] = mode;
   args[2] = static_cast<size_t>(3); /* name length */
   cookie->handle = semihosting_call(SYS_OPEN, args);
 }

--- a/arm-software/embedded/llvmlibc-support/semihost/semihost.h
+++ b/arm-software/embedded/llvmlibc-support/semihost/semihost.h
@@ -14,6 +14,7 @@
 #define LLVMET_LLVMLIBC_SUPPORT_SEMIHOST_H
 
 #include <llvm-libc-types/ssize_t.h>
+#include <stdint.h>
 
 #if __ARM_64BIT_STATE
 #  define ARG_REG_0 "x0"
@@ -41,7 +42,7 @@
 #  endif
 #endif
 
-__attribute__((always_inline))
+[[clang::always_inline]]
 static long semihosting_call(long val, const void *ptr) {
   register long v __asm__(ARG_REG_0) = val;
   register const void *p __asm__(ARG_REG_1) = ptr;
@@ -52,56 +53,56 @@ static long semihosting_call(long val, const void *ptr) {
   return v;
 }
 
-#define SYS_CLOCK 0x10
-#define SYS_CLOSE 0x02
-#define SYS_ELAPSED 0x30
-#define SYS_ERRNO 0x13
-#define SYS_EXIT 0x18
-#define SYS_EXIT_EXTENDED 0x20
-#define SYS_FLEN 0x0c
-#define SYS_GET_CMDLINE 0x15
-#define SYS_HEAPINFO 0x16
-#define SYS_ISERROR 0x08
-#define SYS_ISTTY 0x09
-#define SYS_OPEN 0x01
-#define SYS_READ 0x06
-#define SYS_READC 0x07
-#define SYS_REMOVE 0x0e
-#define SYS_RENAME 0x0f
-#define SYS_SEEK 0x0a
-#define SYS_SYSTEM 0x12
-#define SYS_TICKFREQ 0x31
-#define SYS_TIME 0x11
-#define SYS_TMPNAM 0x0d
-#define SYS_WRITE0 0x04
-#define SYS_WRITE 0x05
-#define SYS_WRITEC 0x03
+inline constexpr uint32_t SYS_CLOCK = 0x10;
+inline constexpr uint32_t SYS_CLOSE = 0x02;
+inline constexpr uint32_t SYS_ELAPSED = 0x30;
+inline constexpr uint32_t SYS_ERRNO = 0x13;
+inline constexpr uint32_t SYS_EXIT = 0x18;
+inline constexpr uint32_t SYS_EXIT_EXTENDED = 0x20;
+inline constexpr uint32_t SYS_FLEN = 0x0c;
+inline constexpr uint32_t SYS_GET_CMDLINE = 0x15;
+inline constexpr uint32_t SYS_HEAPINFO = 0x16;
+inline constexpr uint32_t SYS_ISERROR = 0x08;
+inline constexpr uint32_t SYS_ISTTY = 0x09;
+inline constexpr uint32_t SYS_OPEN = 0x01;
+inline constexpr uint32_t SYS_READ = 0x06;
+inline constexpr uint32_t SYS_READC = 0x07;
+inline constexpr uint32_t SYS_REMOVE = 0x0e;
+inline constexpr uint32_t SYS_RENAME = 0x0f;
+inline constexpr uint32_t SYS_SEEK = 0x0a;
+inline constexpr uint32_t SYS_SYSTEM = 0x12;
+inline constexpr uint32_t SYS_TICKFREQ = 0x31;
+inline constexpr uint32_t SYS_TIME = 0x11;
+inline constexpr uint32_t SYS_TMPNAM = 0x0d;
+inline constexpr uint32_t SYS_WRITE0 = 0x04;
+inline constexpr uint32_t SYS_WRITE = 0x05;
+inline constexpr uint32_t SYS_WRITEC = 0x03;
 
-#define ADP_Stopped_BranchThroughZero 0x20000
-#define ADP_Stopped_UndefinedInstr 0x20001
-#define ADP_Stopped_SoftwareInterrupt 0x20002
-#define ADP_Stopped_PrefetchAbort 0x20003
-#define ADP_Stopped_DataAbort 0x20004
-#define ADP_Stopped_AddressException 0x20005
-#define ADP_Stopped_IRQ 0x20006
-#define ADP_Stopped_FIQ 0x20007
-#define ADP_Stopped_BreakPoint 0x20020
-#define ADP_Stopped_WatchPoint 0x20021
-#define ADP_Stopped_StepComplete 0x20022
-#define ADP_Stopped_RunTimeErrorUnknown 0x20023
-#define ADP_Stopped_InternalError 0x20024
-#define ADP_Stopped_UserInterruption 0x20025
-#define ADP_Stopped_ApplicationExit 0x20026
-#define ADP_Stopped_StackOverflow 0x20027
-#define ADP_Stopped_DivisionByZero 0x20028
-#define ADP_Stopped_OSSpecific 0x20029
+inline constexpr uint32_t ADP_Stopped_BranchThroughZero = 0x20000;
+inline constexpr uint32_t ADP_Stopped_UndefinedInstr = 0x20001;
+inline constexpr uint32_t ADP_Stopped_SoftwareInterrupt = 0x20002;
+inline constexpr uint32_t ADP_Stopped_PrefetchAbort = 0x20003;
+inline constexpr uint32_t ADP_Stopped_DataAbort = 0x20004;
+inline constexpr uint32_t ADP_Stopped_AddressException = 0x20005;
+inline constexpr uint32_t ADP_Stopped_IRQ = 0x20006;
+inline constexpr uint32_t ADP_Stopped_FIQ = 0x20007;
+inline constexpr uint32_t ADP_Stopped_BreakPoint = 0x20020;
+inline constexpr uint32_t ADP_Stopped_WatchPoint = 0x20021;
+inline constexpr uint32_t ADP_Stopped_StepComplete = 0x20022;
+inline constexpr uint32_t ADP_Stopped_RunTimeErrorUnknown = 0x20023;
+inline constexpr uint32_t ADP_Stopped_InternalError = 0x20024;
+inline constexpr uint32_t ADP_Stopped_UserInterruption = 0x20025;
+inline constexpr uint32_t ADP_Stopped_ApplicationExit = 0x20026;
+inline constexpr uint32_t ADP_Stopped_StackOverflow = 0x20027;
+inline constexpr uint32_t ADP_Stopped_DivisionByZero = 0x20028;
+inline constexpr uint32_t ADP_Stopped_OSSpecific = 0x20029;
 
 /* SYS_OPEN modes must be one of R,W,A, plus an optional B and optional PLUS */
-#define OPENMODE_R 0
-#define OPENMODE_W 4
-#define OPENMODE_A 8
-#define OPENMODE_B 1
-#define OPENMODE_PLUS 2
+inline constexpr uint32_t OPENMODE_R = 0;
+inline constexpr uint32_t OPENMODE_W = 4;
+inline constexpr uint32_t OPENMODE_A = 8;
+inline constexpr uint32_t OPENMODE_B = 1;
+inline constexpr uint32_t OPENMODE_PLUS = 2;
 
 struct __llvm_libc_stdio_cookie { int handle; };
 

--- a/arm-software/embedded/llvmlibc-support/semihost/semihost.h
+++ b/arm-software/embedded/llvmlibc-support/semihost/semihost.h
@@ -53,6 +53,7 @@ static long semihosting_call(long val, const void *ptr) {
   return v;
 }
 
+namespace {
 inline constexpr uint32_t SYS_CLOCK = 0x10;
 inline constexpr uint32_t SYS_CLOSE = 0x02;
 inline constexpr uint32_t SYS_ELAPSED = 0x30;
@@ -103,6 +104,7 @@ inline constexpr uint32_t OPENMODE_W = 4;
 inline constexpr uint32_t OPENMODE_A = 8;
 inline constexpr uint32_t OPENMODE_B = 1;
 inline constexpr uint32_t OPENMODE_PLUS = 2;
+} // namespace
 
 struct __llvm_libc_stdio_cookie { int handle; };
 


### PR DESCRIPTION
C casts have been changed to `reinterpret_cast` or `static_cast`. Defines have been changed to `inline constexpr`. GNU attributes have been changed to `[[c++11]]` style attributes.

No functional change. Everything still works.