### PR TITLE
Format Python files

### DIFF
--- a/arm-software/ci/automerge.py
+++ b/arm-software/ci/automerge.py
@@ -48,14 +48,16 @@ class Git:
     def run_cmd(self, args: list[str], check: bool = True) -> str:
         git_cmd = ["git", "-C", str(self.repo_path)] + args
         logger.debug("Running git command: %s", git_cmd)
-        git_process = subprocess.run(git_cmd, check=check, capture_output=True, text=True)
+        git_process = subprocess.run(
+            git_cmd, check=check, capture_output=True, text=True
+        )
         logger.debug("Stdout:\n%s\nStderr:\n%s", git_process.stdout, git_process.stderr)
         return git_process.stdout
 
 
 def is_merge_in_progress(git_repo: Git) -> bool:
     # The `.git/MERGE_HEAD` file only exists when a merge operation is in progress.
-    merge_head_path = Path(git_repo.repo_path) / '.git' / 'MERGE_HEAD'
+    merge_head_path = Path(git_repo.repo_path) / ".git" / "MERGE_HEAD"
     return merge_head_path.exists()
 
 
@@ -67,7 +69,9 @@ def restore_changes_to_ignored_files(git_repo: Git, ignore_list: list[str]) -> N
     git_repo.run_cmd(["restore", "--ours", "--worktree"] + ignore_list)
     # Next, any files still unmerged are the ones deleted on the destination branch.
     # Make sure they stay deleted.
-    ls_files_output = git_repo.run_cmd(["diff", "--name-only", "--diff-filter=U", "--"] + ignore_list)
+    ls_files_output = git_repo.run_cmd(
+        ["diff", "--name-only", "--diff-filter=U", "--"] + ignore_list
+    )
     deleted_by_us = ls_files_output.splitlines()
     if deleted_by_us:
         git_repo.run_cmd(["rm"] + deleted_by_us)
@@ -82,16 +86,27 @@ def has_unresolved_conflicts(git_repo: Git) -> bool:
 
 
 def prefix_current_commit_message(git_repo: Git) -> None:
-    log_output = git_repo.run_cmd(["log", "HEAD", "--max-count=1", "--pretty=format:%B"])
+    log_output = git_repo.run_cmd(
+        ["log", "HEAD", "--max-count=1", "--pretty=format:%B"]
+    )
     commit_msg = f"Automerge: {log_output}"
     git_repo.run_cmd(["commit", "--amend", "--message=" + commit_msg])
 
 
-def merge_commit(git_repo: Git, to_branch: str, commit_hash: str, ignored_paths: list[str], dry_run: bool, verbose: bool) -> None:
+def merge_commit(
+    git_repo: Git,
+    to_branch: str,
+    commit_hash: str,
+    ignored_paths: list[str],
+    dry_run: bool,
+    verbose: bool,
+) -> None:
     logger.info("Merging commit %s into %s", commit_hash, to_branch)
     git_repo.run_cmd(["switch", to_branch])
     if verbose:
-        current_head = git_repo.run_cmd(["log", "--no-walk", "HEAD", "--pretty=reference"])
+        current_head = git_repo.run_cmd(
+            ["log", "--no-walk", "HEAD", "--pretty=reference"]
+        )
         logger.debug("Current HEAD of %s is %s", to_branch, current_head)
     # `git merge` will return a non-zero exit status if there's a conflict, but
     # the conflict might be resolved by applying our ignore list. We work around
@@ -108,7 +123,9 @@ def merge_commit(git_repo: Git, to_branch: str, commit_hash: str, ignored_paths:
     git_repo.run_cmd(["commit", "--reuse-message", commit_hash])
     prefix_current_commit_message(git_repo)
     if verbose:
-        merge_reference = git_repo.run_cmd(["log", "--no-walk", "HEAD", "--pretty=reference"])
+        merge_reference = git_repo.run_cmd(
+            ["log", "--no-walk", "HEAD", "--pretty=reference"]
+        )
         logger.debug("Merge commit finalized: %s", merge_reference)
     if dry_run:
         logger.info("Dry run. Skipping push into remote repository.")
@@ -119,17 +136,33 @@ def merge_commit(git_repo: Git, to_branch: str, commit_hash: str, ignored_paths:
 
 def create_pull_request(git_repo: Git, to_branch: str) -> None:
     logger.info("Creating Pull Request")
-    log_output = git_repo.run_cmd(["log", "HEAD", "--max-count=1", "--pretty=format:%s"])
+    log_output = git_repo.run_cmd(
+        ["log", "HEAD", "--max-count=1", "--pretty=format:%s"]
+    )
     pr_title = f"Automerge conflict: {log_output}"
     subprocess.run(
-        ["gh", "pr", "create", "--head", AUTOMERGE_BRANCH, "--base", to_branch, "--fill", "--title", pr_title,
-         "--label", MERGE_CONFLICT_LABEL],
+        [
+            "gh",
+            "pr",
+            "create",
+            "--head",
+            AUTOMERGE_BRANCH,
+            "--base",
+            to_branch,
+            "--fill",
+            "--title",
+            pr_title,
+            "--label",
+            MERGE_CONFLICT_LABEL,
+        ],
         cwd=git_repo.get_repo_path(),
         check=True,
     )
 
 
-def process_conflict(git_repo: Git, commit_hash: str, to_branch: str, dry_run: bool) -> None:
+def process_conflict(
+    git_repo: Git, commit_hash: str, to_branch: str, dry_run: bool
+) -> None:
     logger.info("Processing conflict for %s", commit_hash)
     git_repo.run_cmd(["switch", "--force-create", AUTOMERGE_BRANCH, commit_hash])
     if dry_run:
@@ -141,10 +174,14 @@ def process_conflict(git_repo: Git, commit_hash: str, to_branch: str, dry_run: b
 
 
 def get_merge_commit_list(git_repo: Git, from_branch: str, to_branch: str) -> list[str]:
-    logger.info("Calculating list of commits to be merged from %s to %s", from_branch, to_branch)
+    logger.info(
+        "Calculating list of commits to be merged from %s to %s", from_branch, to_branch
+    )
     merge_base_output = git_repo.run_cmd(["merge-base", from_branch, to_branch])
     merge_base_commit = merge_base_output.strip()
-    log_output = git_repo.run_cmd(["log", f"{merge_base_commit}..{from_branch}", "--pretty=format:%H"])
+    log_output = git_repo.run_cmd(
+        ["log", f"{merge_base_commit}..{from_branch}", "--pretty=format:%H"]
+    )
     commit_list = log_output.strip()
     if not commit_list:
         logger.info("No commits to be merged")
@@ -232,9 +269,18 @@ def main():
         with open(MERGE_IGNORE_PATHSPEC_FILE) as ignored_paths_file:
             ignored_paths = ignored_paths_file.read().splitlines()
 
-        merge_commits = get_merge_commit_list(git_repo, args.from_branch, args.to_branch)
+        merge_commits = get_merge_commit_list(
+            git_repo, args.from_branch, args.to_branch
+        )
         for commit_hash in merge_commits:
-            merge_commit(git_repo, args.to_branch, commit_hash, ignored_paths, args.dry_run, args.verbose)
+            merge_commit(
+                git_repo,
+                args.to_branch,
+                commit_hash,
+                ignored_paths,
+                args.dry_run,
+                args.verbose,
+            )
     except MergeConflictError as conflict:
         process_conflict(
             git_repo,

--- a/arm-software/embedded/arm-multilib/common-headers-generate.py
+++ b/arm-software/embedded/arm-multilib/common-headers-generate.py
@@ -99,7 +99,9 @@ def extract_common_headers_for_targets(args):
             # optimization is applied. In that case, multilib-optimised will just contain a copy of the
             # single variant from the non-optimised multilib directory.
             if os.path.exists(input_target_dir):
-                shutil.copytree(input_target_dir, output_target_dir, dirs_exist_ok=False)
+                shutil.copytree(
+                    input_target_dir, output_target_dir, dirs_exist_ok=False
+                )
             continue
 
         # Creating the common include headers for each target

--- a/arm-software/embedded/arm-multilib/multilib-generate.py
+++ b/arm-software/embedded/arm-multilib/multilib-generate.py
@@ -135,9 +135,7 @@ def get_target_features(args, fpu):
         "-###",  # print all the command lines rather than actually doing it
     ]
 
-    output = subprocess.check_output(
-        command, stderr=subprocess.STDOUT
-    ).decode()
+    output = subprocess.check_output(command, stderr=subprocess.STDOUT).decode()
 
     # Find the clang -cc1 command, and parse it into an argv list.
     for line in output.splitlines():
@@ -184,8 +182,7 @@ def generate_fpus(args):
     # Collect all the data: make the list of FPU names, and the set of
     # features that LLVM maps each one to.
     fpu_features = {
-        fpuname: get_target_features(args, fpuname)
-        for fpuname in get_fpu_list(args)
+        fpuname: get_target_features(args, fpuname) for fpuname in get_fpu_list(args)
     }
 
     # Now, for each FPU, find all the FPUs that are subsets of it
@@ -223,9 +220,7 @@ def get_extension_list(clang, triple):
         "--print-supported-extensions",
     ]
 
-    output = subprocess.check_output(
-        command, stderr=subprocess.STDOUT
-    ).decode()
+    output = subprocess.check_output(command, stderr=subprocess.STDOUT).decode()
 
     for line in output.split("\n"):
         parts = line.split(maxsplit=1)
@@ -242,12 +237,16 @@ def generate_extensions(args):
     # Combine the aarch64 and aarch32 lists without duplication.
     # Casting to sets and merging would be simpler, but creates
     # non-deterministic output.
-    all_features.extend(feat for feat in list(aarch32_features) if feat not in all_features)
+    all_features.extend(
+        feat for feat in list(aarch32_features) if feat not in all_features
+    )
 
     print("# Expand -march=...+[no]feature... into individual options we can match")
     print("# on. We use 'armvX' to represent a feature applied to any architecture, so")
     print("# that these don't need to be repeated for every version. Libraries which")
-    print("# require a particular architecture version or profile should also match on the")
+    print(
+        "# require a particular architecture version or profile should also match on the"
+    )
     print("# original option to check that.")
 
     for feature in all_features:
@@ -281,13 +280,14 @@ class Version:
             for compat_minor in range(self.minor + 5 + 1):
                 yield Version(self.major - 1, compat_minor, self.profile)
 
+
 def generate_versions(args):
     """Generate match blocks which allow selecting a library build for a
     lower-version architecture, for the v8.x-A and v9.x-A minor versions."""
     versions = (
-        [Version(8, minor, "a") for minor in range(10)] +
-        [Version(9, minor, "a") for minor in range(6)] +
-        [Version(8, minor, "r") for minor in range(1)]
+        [Version(8, minor, "a") for minor in range(10)]
+        + [Version(9, minor, "a") for minor in range(6)]
+        + [Version(8, minor, "r") for minor in range(1)]
     )
 
     for match_ver in versions:
@@ -298,15 +298,12 @@ def generate_versions(args):
     print()
 
 
-
 def main():
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument(
-        "--clang", required=True, help="Path to clang executable."
-    )
+    parser.add_argument("--clang", required=True, help="Path to clang executable.")
     parser.add_argument(
         "--llvm-source",
         required=True,
@@ -317,6 +314,7 @@ def main():
     generate_fpus(args)
     generate_extensions(args)
     generate_versions(args)
+
 
 if __name__ == "__main__":
     main()

--- a/arm-software/embedded/arm-runtimes/test-support/lit-exec-fvp.py
+++ b/arm-software/embedded/arm-runtimes/test-support/lit-exec-fvp.py
@@ -13,9 +13,7 @@ import sys
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Run a single test using Arm FVPs"
-    )
+    parser = argparse.ArgumentParser(description="Run a single test using Arm FVPs")
     parser.add_argument(
         "--fvp-install-dir",
         help="Directory in which FVP models are installed",

--- a/arm-software/embedded/arm-runtimes/test-support/lit-exec-qemu.py
+++ b/arm-software/embedded/arm-runtimes/test-support/lit-exec-qemu.py
@@ -13,12 +13,8 @@ import sys
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Run a single test using qemu"
-    )
-    parser.add_argument(
-        "--qemu-command", required=True, help="qemu-system-<arch> path"
-    )
+    parser = argparse.ArgumentParser(description="Run a single test using qemu")
+    parser.add_argument("--qemu-command", required=True, help="qemu-system-<arch> path")
     parser.add_argument(
         "--qemu-machine",
         required=True,

--- a/arm-software/embedded/arm-runtimes/test-support/modify-compiler-rt-xml.py
+++ b/arm-software/embedded/arm-runtimes/test-support/modify-compiler-rt-xml.py
@@ -50,5 +50,6 @@ def main():
     tree.write(xml_file)
     print(f"Results written to {xml_file}")
 
+
 if __name__ == "__main__":
     main()

--- a/arm-software/embedded/arm-runtimes/test-support/picolibc-test-wrapper.py
+++ b/arm-software/embedded/arm-runtimes/test-support/picolibc-test-wrapper.py
@@ -95,9 +95,7 @@ def main():
         description="Run a single test using either qemu or an FVP"
     )
     main_arg_group = parser.add_mutually_exclusive_group(required=True)
-    main_arg_group.add_argument(
-        "--qemu-command", help="qemu-system-<arch> path"
-    )
+    main_arg_group.add_argument("--qemu-command", help="qemu-system-<arch> path")
     main_arg_group.add_argument(
         "--fvp-install-dir", help="Directory in which FVP models are installed"
     )

--- a/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
+++ b/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
@@ -133,12 +133,14 @@ def run_fvp(
     command.extend(["--parameter", f"{model.cmdline_param}={shlex.join(arguments)}"])
     command.extend(["--plugin", path.join(fvp_install_dir, model.crypto_plugin)])
     if tarmac_file is not None:
-        command.extend([
-            "--plugin",
-            path.join(fvp_install_dir, model.tarmac_plugin),
-            "--parameter",
-            "TRACE.TarmacTrace.trace-file=" + tarmac_file,
-        ])
+        command.extend(
+            [
+                "--plugin",
+                path.join(fvp_install_dir, model.tarmac_plugin),
+                "--parameter",
+                "TRACE.TarmacTrace.trace-file=" + tarmac_file,
+            ]
+        )
 
     if verbose:
         print("running: {}".format(shlex.join(command)))

--- a/arm-software/embedded/cmake/copy_target_libraries.py
+++ b/arm-software/embedded/cmake/copy_target_libraries.py
@@ -36,9 +36,7 @@ def main():
     for distribution_file in glob.glob(args.distribution_file):
         break
     else:
-        raise RuntimeError(
-            f"Distribution glob '{args.distribution_file}' not found"
-        )
+        raise RuntimeError(f"Distribution glob '{args.distribution_file}' not found")
 
     lib_dir = os.path.join(args.build_dir, "llvm", "lib")
     os.makedirs(lib_dir, exist_ok=True)

--- a/arm-software/embedded/packagetest/lit.cfg.py
+++ b/arm-software/embedded/packagetest/lit.cfg.py
@@ -10,10 +10,10 @@ from lit.llvm.subst import FindTool, ToolSubst
 
 # Configuration file for the 'lit' test runner.
 
-config.name = 'package'
+config.name = "package"
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
-config.suffixes = ['.c', '.cpp', '.test']
-config.excludes = ['CMakeLists.txt', 'README.md']
+config.suffixes = [".c", ".cpp", ".test"]
+config.excludes = ["CMakeLists.txt", "README.md"]
 config.test_source_root = os.path.dirname(__file__)
 
 
@@ -38,10 +38,14 @@ tool_patterns = [
     ),
 ]
 llvm_config.config.substitutions.append(("%python", '"%s"' % (sys.executable)))
-llvm_config.add_tool_substitutions(tool_patterns, [os.path.join(config.llvm_obj_root, "bin")])
+llvm_config.add_tool_substitutions(
+    tool_patterns, [os.path.join(config.llvm_obj_root, "bin")]
+)
 llvm_config.add_err_msg_substitutions()
 llvm_config.use_clang()
 llvm_config.config.substitutions.append(("%samples_dir", '"%s"' % config.samples_dir))
-llvm_config.config.substitutions.append(("%unpack_directory", '"%s"' % config.unpack_directory))
+llvm_config.config.substitutions.append(
+    ("%unpack_directory", '"%s"' % config.unpack_directory)
+)
 
 config.environment["CLANG_NO_DEFAULT_CONFIG"] = "1"

--- a/arm-software/embedded/test/lit.cfg.py
+++ b/arm-software/embedded/test/lit.cfg.py
@@ -8,10 +8,10 @@ from lit.llvm import llvm_config
 
 # Configuration file for the 'lit' test runner.
 
-config.name = 'Arm Toolchain for Embedded'
+config.name = "Arm Toolchain for Embedded"
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
-config.suffixes = ['.c', '.cpp', '.test']
-config.excludes = ['CMakeLists.txt']
+config.suffixes = [".c", ".cpp", ".test"]
+config.excludes = ["CMakeLists.txt"]
 config.test_source_root = os.path.dirname(__file__)
 
 llvm_config.use_default_substitutions()

--- a/arm-software/linux/SBOM_Files/generate_ATfL-SBOM.py
+++ b/arm-software/linux/SBOM_Files/generate_ATfL-SBOM.py
@@ -288,7 +288,7 @@ document.packages = [
     package_flang,
     package_flang_rt,
     package_zlib,
-    package_zstd
+    package_zstd,
 ]
 
 # A DESCRIBES relationship asserts that the document indeed describes the package.

--- a/arm-software/shared/elf2bin/test/makeelf.py
+++ b/arm-software/shared/elf2bin/test/makeelf.py
@@ -23,7 +23,7 @@ import struct
 
 class ElfHdr:
     def __init__(self, bigend):
-        self.e_ident = list(b"\x7FELF") + [0] * 12
+        self.e_ident = list(b"\x7fELF") + [0] * 12
         self.e_ident[5] = 2 if bigend else 1
         self.e_type = 2  # ET_EXEC
         self.e_machine = 0
@@ -329,9 +329,7 @@ A line beginning 'entry' specifies the entry point of the file.
         "-o", "--output", type=opener("wb"), required=True, help="Output file."
     )
     parser.add_argument("-b", "--bi", action="store_true", help="Big-endian")
-    parser.add_argument(
-        "-s", "--sixtyfour", action="store_true", help="64-bit"
-    )
+    parser.add_argument("-s", "--sixtyfour", action="store_true", help="64-bit")
     args = parser.parse_args()
 
     with args.infile() as fh:

--- a/arm-software/shared/elf2bin/test/test.py
+++ b/arm-software/shared/elf2bin/test/test.py
@@ -96,9 +96,7 @@ class Base(unittest.TestCase):
         cmd = [elf2bin_path] + list(args)
         with open("commands.txt", "a") as fh:
             print(" ".join(map(shlex.quote, cmd)), file=fh)
-        p = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = p.communicate(b"")
         p.wait()
         if not expect_error:
@@ -390,9 +388,7 @@ class bincombined(Base):
                         ],
                     )
 
-                    self.elf2bin(
-                        "--bincombined", "-o", "output.bin", "input.elf"
-                    )
+                    self.elf2bin("--bincombined", "-o", "output.bin", "input.elf")
                     with open("output.bin", "rb") as fh:
                         bindata = fh.read()
                     self.assertEqual(
@@ -517,10 +513,7 @@ class bincombined(Base):
                 bindata = fh.read()
             self.assertEqual(
                 bindata,
-                b"\0" * 0x34
-                + segment1_contents
-                + b"\0" * 0x20
-                + segment2_contents,
+                b"\0" * 0x34 + segment1_contents + b"\0" * 0x20 + segment2_contents,
             )
 
             # Should be OK to restate the base address we were going
@@ -571,24 +564,20 @@ class bincombined(Base):
                         [
                             # A segment that is definitely not empty
                             SegmentDesc(1, 0x1000, segment1_contents),
-
                             # A segment that has no initialized contents but
                             # does have ZI contents, so it's normally empty,
                             # but stops counting as empty if you say
                             # --zi
-                            SegmentDesc(1, 0x1100, b'', pad=0x80),
-
+                            SegmentDesc(1, 0x1100, b"", pad=0x80),
                             # A completely empty segment
-                            SegmentDesc(1, 0x1200, b''),
+                            SegmentDesc(1, 0x1200, b""),
                         ],
                     )
 
                     # Without --zi: the first segment is the only non-empty
                     # one, so we expect the output file to contain nothing but
                     # the bytes in segment1_contents.
-                    self.elf2bin(
-                        "--bincombined", "-o", "output.bin", "input.elf"
-                    )
+                    self.elf2bin("--bincombined", "-o", "output.bin", "input.elf")
                     with open("output.bin", "rb") as fh:
                         bindata = fh.read()
                     self.assertEqual(
@@ -604,14 +593,13 @@ class bincombined(Base):
                     # stop there, and don't go on to the third segment, which
                     # is still completely empty.
                     self.elf2bin(
-                        "--bincombined", "-o", "output.bin", "input.elf",
-                        "--zi"
+                        "--bincombined", "-o", "output.bin", "input.elf", "--zi"
                     )
                     with open("output.bin", "rb") as fh:
                         bindata = fh.read()
                     self.assertEqual(
                         bindata,
-                        segment1_contents + b'\0' * (0xF0 + 0x80),
+                        segment1_contents + b"\0" * (0xF0 + 0x80),
                     )
 
 
@@ -678,18 +666,12 @@ class vhx(Base):
                         ],
                     )
 
-                    self.elf2bin(
-                        "--vhxcombined", "-o", "output.hex", "input.elf"
-                    )
+                    self.elf2bin("--vhxcombined", "-o", "output.hex", "input.elf")
                     with open("output.hex") as fh:
                         hexdata = fh.read()
                     self.assertEqual(
                         hexdata,
-                        to_vhx(
-                            segment1_contents
-                            + b"\0" * 0x20
-                            + segment2_contents
-                        ),
+                        to_vhx(segment1_contents + b"\0" * 0x20 + segment2_contents),
                     )
 
 
@@ -728,8 +710,7 @@ class banks(Base):
                             bytes(
                                 b
                                 for i, b in enumerate(input_data)
-                                if (b % mod)
-                                in range(bank * width, (bank + 1) * width)
+                                if (b % mod) in range(bank * width, (bank + 1) * width)
                             ),
                         )
 
@@ -1092,9 +1073,7 @@ class segselect(Base):
                 hexdata = fh.read()
                 self.assertEqual(
                     hexdata,
-                    to_vhx(
-                        segment_contents1 + b"\0" * 0x30 + segment_contents3
-                    ),
+                    to_vhx(segment_contents1 + b"\0" * 0x30 + segment_contents3),
                 )
 
     def testIHex(self):
@@ -1254,9 +1233,7 @@ S70500000000FA
                 ],
             )
 
-            self.elf2bin(
-                "--bincombined", "--zi", "-o", "output.bin", "input.elf"
-            )
+            self.elf2bin("--bincombined", "--zi", "-o", "output.bin", "input.elf")
             with open(f"output.bin", "rb") as fh:
                 bindata = fh.read()
             self.assertEqual(
@@ -1286,9 +1263,7 @@ S70500000000FA
                 ],
             )
 
-            self.elf2bin(
-                "--bincombined", "--zi", "-o", "output.bin", "input.elf"
-            )
+            self.elf2bin("--bincombined", "--zi", "-o", "output.bin", "input.elf")
             with open(f"output.bin", "rb") as fh:
                 bindata = fh.read()
             self.assertEqual(
@@ -1311,11 +1286,7 @@ class vaddr(Base):
                     "input.elf",
                     False,
                     sixtyfour,
-                    [
-                        SegmentDesc(
-                            segtype=1, paddr=0x1234, vaddr=0x5678, data=b"a"
-                        )
-                    ],
+                    [SegmentDesc(segtype=1, paddr=0x1234, vaddr=0x5678, data=b"a")],
                 )
 
                 # Expected Intel Hex output if the segment's physical
@@ -1335,17 +1306,13 @@ class vaddr(Base):
 """
 
                 # Explicitly select --physical
-                self.elf2bin(
-                    "--physical", "--ihex", "-o", "output.hex", "input.elf"
-                )
+                self.elf2bin("--physical", "--ihex", "-o", "output.hex", "input.elf")
                 with open("output.hex") as fh:
                     hexdata = fh.read()
                 self.assertEqual(hexdata, expected_physical)
 
                 # Explicitly select --virtual
-                self.elf2bin(
-                    "--virtual", "--ihex", "-o", "output.hex", "input.elf"
-                )
+                self.elf2bin("--virtual", "--ihex", "-o", "output.hex", "input.elf")
                 with open("output.hex") as fh:
                     hexdata = fh.read()
                 self.assertEqual(hexdata, expected_virtual)


### PR DESCRIPTION
- Use ruff to format Python files
- In future, "ruff format" will be included in the pre-merge workflow