### PR TITLE
[arm-toolchain][workflow] Reinstate mrege from upstream 21.x.

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -3,10 +3,6 @@
 # branch of the arm/arm-toolchain repository.
 name: Automerge
 on:
-  workflow_run:
-    workflows: [Sync from Upstream LLVM]
-    types:
-      - completed
   workflow_dispatch:
 jobs:
   Run-Automerge:
@@ -17,8 +13,8 @@ jobs:
     strategy:
       matrix:
         branches:
-          - from_branch: main
-            to_branch: arm-software
+          - from_branch: release/21.x
+            to_branch: release/arm-software/21.x
     steps:
       - name: Configure Access Token
         uses: actions/create-github-app-token@v1


### PR DESCRIPTION
For release engineering, reinstate merging from upstream release/21.x, but only triggered manually, no automerging for now.