### PR TITLE
[ATfE] rename VERSION.TXT in overlay packages

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -569,25 +569,18 @@ add_custom_target(
     -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/generate_version_txt.cmake
     BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/VERSION.txt
 )
-if(LLVM_TOOLCHAIN_C_LIBRARY MATCHES "^llvmlibc")
+if(NOT (LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc))
     install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/VERSION.txt"
-    DESTINATION .
-    RENAME VERSION_llvmlibc.txt
-    COMPONENT llvm-toolchain-third-party-licenses
-    )
-elseif(LLVM_TOOLCHAIN_C_LIBRARY MATCHES "^newlib")
-    install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/VERSION.txt"
-    DESTINATION .
-    RENAME VERSION_newlib.txt
-    COMPONENT llvm-toolchain-third-party-licenses
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/VERSION.txt"
+        DESTINATION .
+        RENAME VERSION_${LLVM_TOOLCHAIN_C_LIBRARY}.txt
+        COMPONENT llvm-toolchain-third-party-licenses
     )
 else()
     install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/VERSION.txt"
-    DESTINATION .
-    COMPONENT llvm-toolchain-third-party-licenses
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/VERSION.txt"
+        DESTINATION .
+        COMPONENT llvm-toolchain-third-party-licenses
     )
 endif()
 


### PR DESCRIPTION
[ATfE] rename VERSION.txt in overlay packages

The file currently has the same name in an overlay package as it does in the base toolchain that the overlay is installed on top of, so when unpacking the overlay package, the two files collide and the base toolchain's version is overwritten.