### PR TITLE
[ATfE] Disable parallel multilib configuration steps

### DIFF
--- a/arm-software/embedded/scripts/build_llvmlibc_overlay.sh
+++ b/arm-software/embedded/scripts/build_llvmlibc_overlay.sh
@@ -22,7 +22,7 @@ BUILD_DIR=${REPO_ROOT}/build_llvmlibc_overlay
 mkdir -p "${BUILD_DIR}"
 cd "${BUILD_DIR}"
 
-cmake ../arm-software/embedded -GNinja -DFETCHCONTENT_QUIET=OFF -DLLVM_TOOLCHAIN_C_LIBRARY=llvmlibc -DLLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL=on
+cmake ../arm-software/embedded -GNinja -DFETCHCONTENT_QUIET=OFF -DLLVM_TOOLCHAIN_C_LIBRARY=llvmlibc -DLLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL=on -DENABLE_PARALLEL_LIB_CONFIG=OFF
 ninja package-llvm-toolchain
 
 # The package-llvm-toolchain target will produce a .tar.xz package, but we also

--- a/arm-software/embedded/scripts/build_llvmlibc_toolchain.sh
+++ b/arm-software/embedded/scripts/build_llvmlibc_toolchain.sh
@@ -22,5 +22,5 @@ BUILD_DIR=${REPO_ROOT}/build_llvmlibc_toolchain
 mkdir -p "${BUILD_DIR}"
 cd "${BUILD_DIR}"
 
-cmake ../arm-software/embedded -GNinja -DFETCHCONTENT_QUIET=OFF -DLLVM_TOOLCHAIN_C_LIBRARY=llvmlibc
+cmake ../arm-software/embedded -GNinja -DFETCHCONTENT_QUIET=OFF -DLLVM_TOOLCHAIN_C_LIBRARY=llvmlibc -DENABLE_PARALLEL_LIB_CONFIG=OFF
 ninja package-llvm-toolchain


### PR DESCRIPTION
Overlay builds are being killed at config time due to an unknown reason. Disabling parallel config is a workaround that gets us green builds for now. This will be reverted when the underlying cause is fixed.