### PR TITLE
[ATfE] Use a consistent name for xml results

### DIFF
--- a/.github/workflows/atfe_nightly_build_and_test.yml
+++ b/.github/workflows/atfe_nightly_build_and_test.yml
@@ -99,7 +99,7 @@ jobs:
         if: always()
         with:
           name: test-results-${{ matrix.build_script }}-${{ matrix.target_os }}
-          path: build/**/*.junit.xml
+          path: build/**/lit_results.junit.xml
 
       - name: Upload built packages
         uses: actions/upload-artifact@v4

--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -283,7 +283,7 @@ if(ENABLE_COMPILER_RT_TESTS)
     set(compiler_rt_xfails_file_path "${CMAKE_CURRENT_BINARY_DIR}/${VARIANT}_compiler-rt.xfails")
     set(compiler_rt_xfails_not_file_path "${CMAKE_CURRENT_BINARY_DIR}/${VARIANT}_compiler-rt.upasses")
     set(compiler_rt_test_flags "${lib_compile_flags} ${test_link_flags}")
-    set(compiler_rt_lit_args "${LLVM_LIT_ARGS} --path=${LLVM_BINARY_DIR}/bin --xunit-xml-output=results.junit.xml --real-lit-path=${LLVM_BINARY_DIR}/bin/llvm-lit --xfails-file=${compiler_rt_xfails_file_path} --xfails-not-file=${compiler_rt_xfails_not_file_path}"
+    set(compiler_rt_lit_args "${LLVM_LIT_ARGS} --path=${LLVM_BINARY_DIR}/bin --real-lit-path=${LLVM_BINARY_DIR}/bin/llvm-lit --xfails-file=${compiler_rt_xfails_file_path} --xfails-not-file=${compiler_rt_xfails_not_file_path}"
     )
     add_custom_target(
         compiler-rt-xfail-files
@@ -515,7 +515,7 @@ if(C_LIBRARY STREQUAL picolibc)
         set(picolibc_lit_dir ${CMAKE_CURRENT_BINARY_DIR}/picolibc_lit)
         set(picolibc_xfails_file_path "${picolibc_lit_dir}/${VARIANT}_picolibc.xfails")
         set(picolibc_xfails_not_file_path "${picolibc_lit_dir}/${VARIANT}_picolibc.upasses")
-        set(picolibc_lit_args -sv --xunit-xml-output=${picolibc_lit_dir}/results.junit.xml --real-lit-path=${LLVM_BINARY_DIR}/bin/llvm-lit --xfails-file=${picolibc_xfails_file_path} --xfails-not-file=${picolibc_xfails_not_file_path})
+        set(picolibc_lit_args -sv --real-lit-path=${LLVM_BINARY_DIR}/bin/llvm-lit --xfails-file=${picolibc_xfails_file_path} --xfails-not-file=${picolibc_xfails_not_file_path})
 
         ExternalProject_Add_Step(
             picolibc
@@ -858,7 +858,7 @@ if(ENABLE_CXX_LIBS)
             # Pass it the xfail/xfail-not lists.
             set(libcxx_xfails_file_path "${CMAKE_CURRENT_BINARY_DIR}/${VARIANT}_libcxx.xfails")
             set(libcxx_xfails_not_file_path "${CMAKE_CURRENT_BINARY_DIR}/${VARIANT}_libcxx.upasses")
-            set(libcxx_lit_args "${LLVM_LIT_ARGS} -sv --xunit-xml-output=results.junit.xml --real-lit-path=${LLVM_BINARY_DIR}/bin/llvm-lit --xfails-file=${libcxx_xfails_file_path} --xfails-not-file=${libcxx_xfails_not_file_path}"
+            set(libcxx_lit_args "${LLVM_LIT_ARGS} -sv --real-lit-path=${LLVM_BINARY_DIR}/bin/llvm-lit --xfails-file=${libcxx_xfails_file_path} --xfails-not-file=${libcxx_xfails_not_file_path}"
             )
             add_custom_target(
                 libcxx-xfail-files

--- a/arm-software/embedded/arm-runtimes/test-support/modify-compiler-rt-xml.py
+++ b/arm-software/embedded/arm-runtimes/test-support/modify-compiler-rt-xml.py
@@ -8,6 +8,7 @@
 
 import argparse
 import os
+import re
 from xml.etree import ElementTree
 
 
@@ -25,7 +26,26 @@ def main():
     )
     args = parser.parse_args()
 
-    xml_file = os.path.join(args.dir, "compiler-rt", "test", "results.junit.xml")
+    xml_file = None
+    # The xml file path can be set by lit's --xunit-xml-output option.
+    # Since ATfE does not set this directly, it will likely be found
+    # in the LIT_OPTS environment variable, which lit will read
+    # options from.
+    if "LIT_OPTS" in os.environ:
+        lit_opts = os.environ["LIT_OPTS"]
+        m = re.search("--xunit-xml-output=([^ ]+)", lit_opts)
+        if m is not None:
+            results_path = m.group(1)
+            # Path may be absolute or relative.
+            if os.path.isabs(results_path):
+                xml_file = results_path
+            else:
+                # If not absolute, the path will be relative to compiler-rt/test
+                # in the build directory, not this script.
+                xml_file = os.path.join(args.dir, "compiler-rt", "test", results_path)
+    if xml_file is None:
+        print(f"No xml results generated to modify.")
+        return
 
     tree = ElementTree.parse(xml_file)
     root = tree.getroot()

--- a/arm-software/embedded/scripts/test.sh
+++ b/arm-software/embedded/scripts/test.sh
@@ -15,21 +15,20 @@ set -ex
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
 
-cd "${REPO_ROOT}"/build
-
 # If a test fails, lit will ordinarily return a non-zero result,
 # which prevents further testing. Setting the --ignore-fail option
 # will cause testing to continue, so that CI systems can get a
 # full set of results.
-# The check-all target runs the upstream clang and LLVM tests,
-# which do not generate an junit xml results file by default.
-# Additionally setting the --xunit-xml-output option store the
-# results.
-export LIT_OPTS="--ignore-fail --xunit-xml-output=results.xml"
-ninja check-all
+# The lit test suites do not generate xml results by default.
+# This can be enabled with the --xunit-xml-output option. The file
+# written will be relative to the individual suite's build directly,
+# so the same name can be used for all files for consistency.
+export LIT_OPTS="--ignore-fail --xunit-xml-output=lit_results.junit.xml"
 
-# The llvm-toolchain targets already set --xunit-xml-output so
-# only the --ignore-fail option is needed.
-# The picolibc tests do not use lit so do not support this option.
-export LIT_OPTS="--ignore-fail"
-ninja check-llvm-toolchain check-cxxabi check-unwind check-package-llvm-toolchain
+# Run all relevant test targets using Ninja.
+cd "${REPO_ROOT}"/build
+ninja check-all
+ninja check-llvm-toolchain
+ninja check-cxxabi
+ninja check-unwind
+ninja check-package-llvm-toolchain

--- a/arm-software/embedded/scripts/test_atfe_sanitizer.sh
+++ b/arm-software/embedded/scripts/test_atfe_sanitizer.sh
@@ -18,24 +18,19 @@ set -vx
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
 
-cd "${REPO_ROOT}"/build
-
 # If a test fails, lit will ordinarily return a non-zero result,
 # which prevents further testing. Setting the --ignore-fail option
 # will cause testing to continue, so that CI systems can get a
 # full set of results.
-# The check-all target runs the upstream clang and LLVM tests,
-# which do not generate an junit xml results file by default.
-# Additionally setting the --xunit-xml-output option store the
-# results.
-export LIT_OPTS="--ignore-fail --xunit-xml-output=results.xml"
-ninja check-all
+# The lit test suites do not generate xml results by default.
+# This can be enabled with the --xunit-xml-output option. The file
+# written will be relative to the individual suite's build directly,
+# so the same name can be used for all files for consistency.
+export LIT_OPTS="--ignore-fail --xunit-xml-output=lit_results.junit.xml"
 
-# The llvm-toolchain targets already set --xunit-xml-output so
-# only the --ignore-fail option is needed.
-# The picolibc tests do not use lit so do not support this option.
 # Command for each test is splitted across individual lines, to aid in debugging.
-export LIT_OPTS="--ignore-fail"
+cd "${REPO_ROOT}"/build
+ninja check-all
 ninja check-compiler-rt-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size
 ninja check-picolibc-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size
 ninja check-cxx-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size

--- a/arm-software/embedded/scripts/test_libcxx.sh
+++ b/arm-software/embedded/scripts/test_libcxx.sh
@@ -19,10 +19,15 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
 
 # If a test fails, lit will ordinarily return a non-zero result,
-# which prevents further testing. Setting the --ignore-fail flag
+# which prevents further testing. Setting the --ignore-fail option
 # will cause testing to continue, so that CI systems can get a
 # full set of results.
-export LIT_OPTS="--ignore-fail"
+# The lit test suites do not generate xml results by default.
+# This can be enabled with the --xunit-xml-output option. The file
+# written will be relative to the individual suite's build directly,
+# so the same name can be used for all files for consistency.
+export LIT_OPTS="--ignore-fail --xunit-xml-output=lit_results.junit.xml"
 
+# Run all relevant test targets using Ninja.
 cd "${REPO_ROOT}"/build
 ninja check-cxx

--- a/arm-software/embedded/scripts/test_post-merge.sh
+++ b/arm-software/embedded/scripts/test_post-merge.sh
@@ -15,38 +15,27 @@ set -ex
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
 
-# Get processor count, to execute job in parallel threads
-PROCESSOR_COUNT=$(getconf _NPROCESSORS_ONLN)
-
-cd "${REPO_ROOT}"/build
-
 # If a test fails, lit will ordinarily return a non-zero result,
 # which prevents further testing. Setting the --ignore-fail option
 # will cause testing to continue, so that CI systems can get a
 # full set of results.
-# The check-all target runs the upstream clang and LLVM tests,
-# which do not generate a junit xml results file by default.
-# Additionally setting the --xunit-xml-output option store the
-# results.
-export LIT_OPTS="--ignore-fail --xunit-xml-output=results.xml"
+# The lit test suites do not generate xml results by default.
+# This can be enabled with the --xunit-xml-output option. The file
+# written will be relative to the individual suite's build directly,
+# so the same name can be used for all files for consistency.
+export LIT_OPTS="--ignore-fail --xunit-xml-output=lit_results.junit.xml"
+
+# Run all relevant test targets using Ninja.
+cd "${REPO_ROOT}"/build
 ninja check-all
-
-# The llvm-toolchain targets already set --xunit-xml-output so
-# only the --ignore-fail option is needed.
-# The picolibc tests do not use lit so do not support this option.
-export LIT_OPTS="--ignore-fail"
-
-# Run all relevant test targets using Ninja in parallel
-ninja -j$PROCESSOR_COUNT \
-    check-all \
-    check-compiler-rt-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-compiler-rt-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size \
-    check-cxx-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-cxx-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size \
-    check-cxxabi-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-cxxabi-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size \
-    check-picolibc-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-picolibc-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size \
-    check-unwind-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-unwind-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size
+ninja check-compiler-rt-armv7a_hard_vfpv3_d16_exn_rtti_unaligned
+ninja check-compiler-rt-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size
+ninja check-cxx-armv7a_hard_vfpv3_d16_exn_rtti_unaligned
+ninja check-cxx-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size
+ninja check-cxxabi-armv7a_hard_vfpv3_d16_exn_rtti_unaligned
+ninja check-cxxabi-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size
+ninja check-picolibc-armv7a_hard_vfpv3_d16_exn_rtti_unaligned
+ninja check-picolibc-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size
+ninja check-unwind-armv7a_hard_vfpv3_d16_exn_rtti_unaligned
+ninja check-unwind-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size
 

--- a/arm-software/embedded/scripts/test_pre-merge.sh
+++ b/arm-software/embedded/scripts/test_pre-merge.sh
@@ -15,37 +15,26 @@ set -ex
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
 
-# Get processor count, to execute job in parallel threads
-PROCESSOR_COUNT=$(getconf _NPROCESSORS_ONLN)
-
-cd "${REPO_ROOT}"/build
-
 # If a test fails, lit will ordinarily return a non-zero result,
 # which prevents further testing. Setting the --ignore-fail option
 # will cause testing to continue, so that CI systems can get a
 # full set of results.
-# The check-all target runs the upstream clang and LLVM tests,
-# which do not generate a junit xml results file by default.
-# Additionally setting the --xunit-xml-output option store the
-# results.
-export LIT_OPTS="--ignore-fail --xunit-xml-output=results.xml"
+# The lit test suites do not generate xml results by default.
+# This can be enabled with the --xunit-xml-output option. The file
+# written will be relative to the individual suite's build directly,
+# so the same name can be used for all files for consistency.
+export LIT_OPTS="--ignore-fail --xunit-xml-output=lit_results.junit.xml"
+
+# Run all relevant test targets using Ninja.
+cd "${REPO_ROOT}"/build
 ninja check-all
-
-# The llvm-toolchain targets already set --xunit-xml-output so
-# only the --ignore-fail option is needed.
-# The picolibc tests do not use lit so do not support this option.
-export LIT_OPTS="--ignore-fail"
-
-# Run all relevant test targets using Ninja in parallel
-ninja -j$PROCESSOR_COUNT \
-    check-all \
-    check-compiler-rt-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-compiler-rt-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size \
-    check-cxx-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-cxx-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size \
-    check-cxxabi-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-cxxabi-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size \
-    check-picolibc-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-picolibc-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size \
-    check-unwind-armv7a_hard_vfpv3_d16_exn_rtti_unaligned \
-    check-unwind-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size
+ninja check-compiler-rt-armv7a_hard_vfpv3_d16_exn_rtti_unaligned
+ninja check-compiler-rt-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size
+ninja check-cxx-armv7a_hard_vfpv3_d16_exn_rtti_unaligned
+ninja check-cxx-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size
+ninja check-cxxabi-armv7a_hard_vfpv3_d16_exn_rtti_unaligned
+ninja check-cxxabi-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size
+ninja check-picolibc-armv7a_hard_vfpv3_d16_exn_rtti_unaligned
+ninja check-picolibc-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size
+ninja check-unwind-armv7a_hard_vfpv3_d16_exn_rtti_unaligned
+ninja check-unwind-armv7m_hard_fpv5_d16_exn_rtti_unaligned_size


### PR DESCRIPTION
Currently, some test suites are hard-coded to use a specific name/path to write xml results to. Others rely on this being set manually. Some of the CI scripts don't set it at all for certain test targets.

This patch aligns all the test suites to use the same name, controlled via the same mechanism. A user or CI system can set the `--xunit-xml-output` lit option via the `LIT_OPTS` environment variable to control the name of xml file, and therefore know the correct name to look for when storing the results.

A few minor corrections have also been made to the CI scripts for running tests:

* Since ninja defaults to building in parallel, so there is no reason to set the `-j` option.
* `check-all` was getting built twice in some scripts.
* Comments and lit options updated to reflect that picolibc testing does in fact use lit now.