### PR TITLE
Update codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,4 +14,4 @@
 /arm-software/linux/ @arm/arm-toolchain-linux
 
 # ATfE workflows. Only requires the ATfE team input
-.github/workflows/atfe_* @arm/arm-toolchain-embedded
+/.github/workflows/atfe_* @arm/arm-toolchain-embedded


### PR DESCRIPTION
- With the new added rule, the ATfL team is not added by default as a reviewer for ATfE workflows
- Added comments for clarification