### PR TITLE
[ATfE] Ensure folder exists when writing xfail files

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/xfails.py
+++ b/arm-software/embedded/arm-runtimes/test-support/xfails.py
@@ -507,7 +507,7 @@ def main():
     else:
         print("LIT_XFAIL=" + ";".join(tests_to_xfail))
     if args.xfails_not_file:
-        os.makedirs(os.path.dirname(args.xfails_file), exist_ok=True)
+        os.makedirs(os.path.dirname(args.xfails_not_file), exist_ok=True)
         with open(args.xfails_not_file, "w", encoding="utf-8") as f:
             for testname in tests_to_upass:
                 f.write(testname + "\n")


### PR DESCRIPTION
If the destination folder does not exist yet, it can be safely created. Additionally, this removes a couple of lines that appear to be in the wrong place, attempting to write to an unopened file instead of printing the test names.