### PR TITLE
Update llvmlibc.ld to match picolibc.ld

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -748,7 +748,7 @@ if(C_LIBRARY STREQUAL llvmlibc)
         -DLLVM_ENABLE_RUNTIMES=libc
         -DLLVM_LIBC_ALL_HEADERS=ON
         -DLLVM_LIBC_FULL_BUILD=ON
-        -DLIBC_TEST_LINK_OPTIONS_DEFAULT=-nostartfiles,-lcrt0-semihost,-lsemihost,-T,llvmlibc.ld
+        -DLIBC_TEST_LINK_OPTIONS_DEFAULT=-nostartfiles,-lsemihost,-T,llvmlibc.ld
         -DLIBC_TEST_CMD=${test_cmd}
         -DLIBC_TEST_HERMETIC_ONLY=true
         STEP_TARGETS configure build install

--- a/arm-software/embedded/docs/llvmlibc.md
+++ b/arm-software/embedded/docs/llvmlibc.md
@@ -51,6 +51,11 @@ following command line options, in addition to `--target`, `-march` or
   or write your own linker script defining `__stack`, and
   `__llvm_libc_heap_limit` if you are using the heap
 
+> [!IMPORTANT]
+> The default `llvmlibc.ld` is provided for testing and is derived from the
+> `picolibc.ld` licensed under the BSD 3 Clause license. This may cause
+> licensing obligations if used in real projects.
+
 For example:
 
 ```

--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions_7a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions_7a.h
@@ -95,7 +95,7 @@ EXFN_ATTR void handle_fiq() {
 // bytes long, and contains code. The whole table must be 32-byte aligned.
 // The table may also be relocated, so we make it position-independent by
 // having a table of handler addresses and loading the address to pc.
-[[gnu::section(".vectors"), gnu::aligned(32), gnu::used, gnu::naked,
+[[gnu::section(".text.init.enter"), gnu::aligned(32), gnu::used, gnu::naked,
   gnu::target("arm")]]
 void vector_table() {
   asm("LDR pc, [pc, #24]");

--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions_8a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions_8a.h
@@ -206,7 +206,7 @@ EXFN_ATTR void exception_handler() {
 // For our purposes, each entry just contains one branch instruction to the
 // exception reporting function, since we never want to resume after an
 // exception.
-[[gnu::naked, gnu::section(".vectors"), gnu::aligned(2048)]]
+[[gnu::naked, gnu::section(".text.init.enter"), gnu::aligned(2048)]]
 void vector_table() {
 #define VECTOR_TABLE_ENTRY                                                     \
   asm(".balign 128");                                                          \

--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions_m.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions_m.h
@@ -134,7 +134,7 @@ EXFN_ATTR void __exception_handler() { abort(); }
 // table.
 [[gnu::weak]] extern char __stack;
 using vtable_t = void (*)(void);
-[[gnu::section(".vectors"), gnu::aligned(1024)]]
+[[gnu::section(".text.init.enter"), gnu::aligned(1024)]]
 const vtable_t vector_table[] = {
     reinterpret_cast<vtable_t>(&__stack), // SP
     _start,                               // Reset

--- a/arm-software/embedded/llvmlibc-support/llvmlibc.ld.in
+++ b/arm-software/embedded/llvmlibc-support/llvmlibc.ld.in
@@ -34,11 +34,11 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Linker script adapted from picolibc linker script
+/* This linker script is adapted from picolibc linker script:
  * llvm-libc uses different linker defined symbols for heap placement.
+ * All changes are annotated with ATfE:begin and ATfE:end
  */
 
-/* TODO: could we just use the picolibc.ld.in file with the one modification? */
 MEMORY
 {
     boot_flash (rx!w) :
@@ -54,186 +54,372 @@ MEMORY
 
 PHDRS
 {
-    text_boot_flash PT_LOAD;
-    text PT_LOAD;
-    ram_init PT_LOAD;
-    ram PT_LOAD;
-    tls PT_TLS;
+	text_boot_flash PT_LOAD;
+	text PT_LOAD;
+	ram_init PT_LOAD;
+	ram PT_LOAD;
+	tls PT_TLS;
 }
 
 SECTIONS
 {
-    PROVIDE(__stack = ORIGIN(ram) + LENGTH(ram));
+	PROVIDE(__stack = ORIGIN(ram) + LENGTH(ram));
 
-    .boot_flash : {
-        KEEP (*(.text.init.enter))
-        KEEP (*(.vectors))
-        KEEP (*(.init))
-    } >boot_flash AT>boot_flash :text_boot_flash
+	.boot_flash : {
+		KEEP (*(.text.init.enter))
+		/* ATfE:begin */
+		KEEP (*(.vectors))
+		/* ATfE:end */
+		KEEP (*(.data.init.enter))
+		KEEP (*(SORT_BY_NAME(.init) SORT_BY_NAME(.init.*)))
+	} >boot_flash AT>boot_flash :text_boot_flash
 
-    .text : {
-        /* code */
-        *(.text.unlikely .text.unlikely.*)
-        *(.text.startup .text.startup.*)
-        *(.text .text.* .opd .opd.*)
-        PROVIDE (__start___lcxx_override = .);
-        *(__lcxx_override)
-        PROVIDE (__stop___lcxx_override = .);
-        *(.gnu.linkonce.t.*)
-        KEEP (*(.fini .fini.*))
-        __text_end = .;
+	.text : {
 
-        PROVIDE (__etext = __text_end);
-        PROVIDE (_etext = __text_end);
-        PROVIDE (etext = __text_end);
+		/* code */
+		*(.literal.unlikely .text.unlikely .literal.unlikely.* .text.unlikely.*)
+		*(.literal.startup .text.startup .literal.startup.* .text.startup.*)
+		*(SORT(.text.sorted.*))
+		*(.literal .text .literal.* .text.* .opd .opd.* .branch_lt .branch_lt.* )
+		PROVIDE (__start___lcxx_override = .);
+		*(__lcxx_override)
+		PROVIDE (__stop___lcxx_override = .);
+		*(.gnu.linkonce.t.*)
+		KEEP (*(.fini .fini.*))
+		__text_end = .;
 
-        /* Need to pre-align so that the symbols come after padding */
-        . = ALIGN(8);
+		PROVIDE (__etext = __text_end);
+		PROVIDE (_etext = __text_end);
+		PROVIDE (etext = __text_end);
 
-        /* lists of constructors and destructors */
-        PROVIDE_HIDDEN ( __preinit_array_start = . );
-        KEEP (*(.preinit_array))
-        PROVIDE_HIDDEN ( __preinit_array_end = . );
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
 
-        PROVIDE_HIDDEN ( __init_array_start = . );
-        KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
-        KEEP (*(.init_array .ctors))
-        PROVIDE_HIDDEN ( __init_array_end = . );
+		/* lists of constructors and destructors */
+		PROVIDE_HIDDEN ( __preinit_array_start = . );
+		PROVIDE_HIDDEN ( __bothinit_array_start = . );
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN ( __preinit_array_end = . );
 
-        PROVIDE_HIDDEN ( __fini_array_start = . );
-        KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
-        KEEP (*(.fini_array .dtors))
-        PROVIDE_HIDDEN ( __fini_array_end = . );
+		PROVIDE_HIDDEN ( __init_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array .ctors))
+		PROVIDE_HIDDEN ( __init_array_end = . );
+		PROVIDE_HIDDEN ( __bothinit_array_end = . );
 
-    } >flash AT>flash :text
+		PROVIDE_HIDDEN ( __fini_array_start = . );
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array .dtors))
+		KEEP (*(.fini_array*))
+		PROVIDE_HIDDEN ( __fini_array_end = . );
 
-    .rodata : {
-        /* read-only data */
-        *(.rdata)
-        *(.rodata .rodata.*)
-        *(.gnu.linkonce.r.*)
+	} >flash AT>flash :text
 
-        *(.srodata.cst16)
-        *(.srodata.cst8)
-        *(.srodata.cst4)
-        *(.srodata.cst2)
-        *(.srodata .srodata.*)
-    } >flash AT>flash :text
+	.rodata : {
 
-    .data.rel.ro : {
-        /* data that needs relocating */
-        *(.data.rel.ro .data.rel.ro.*)
-    } >flash AT>flash :text
+		/* read-only data */
+		*(.rdata)
+		*(.rodata .rodata.* )
+		*(.gnu.linkonce.r.*)
 
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
 
-    /*
-    * Needs to be in its own segment with the PLT entries first
-    * so that the linker will compute the offsets to those
-    * entries correctly.
-    */
-    .got : {
-        *(.got.plt)
-        *(.got)
-    } >flash AT>flash :text
+	} >flash AT>flash :text
+	PROVIDE(_pid_base = ADDR(.rodata));
 
-    .except_ordered : {
-        *(.gcc_except_table *.gcc_except_table.*)
-        *(.ARM.extab* .gnu.linkonce.armextab.*)
-    } >flash AT>flash :text
+	.data.rel.ro : {
 
-    .except_unordered : {
-        . = ALIGN(8);
+		/* data that needs relocating */
+		*(.data.rel.ro .data.rel.ro.*)
 
-        PROVIDE(__exidx_start = .);
-        *(.ARM.exidx*)
-        PROVIDE(__exidx_end = .);
-    } >flash AT>flash :text
+	} >flash AT>flash :text
 
-
-    .data : /* For ld.bfd:  ALIGN_WITH_INPUT */ {
-        *(.data .data.*)
-        *(.gnu.linkonce.d.*)
-
-        /* Need to pre-align so that the symbols come after padding */
-        . = ALIGN(8);
-
-        PROVIDE( __global_pointer$ = . + 0x800 );
-        PROVIDE( _gp = . + 0x8000);
-        *(.sdata .sdata.* .sdata2.*)
-        *(.gnu.linkonce.s.*)
-    } >ram AT>flash :ram_init
-    PROVIDE(__data_start = ADDR(.data));
-    PROVIDE(__data_source = LOADADDR(.data));
-
-    /* Thread local initialized data. This gets
-    * space allocated as it is expected to be placed
-    * in ram to be used as a template for TLS data blocks
-    * allocated at runtime. We're slightly abusing that
-    * by placing the data in flash where it will be copied
-    * into the allocate ram addresses by the existing
-    * data initialization code in crt0.
-    * BFD includes .tbss alignment when computing .tdata
-    * alignment, but for ld.lld we have to explicitly pad
-    * as it only guarantees usage as a TLS template works
-    * rather than supporting this use case.
-    */
-    .tdata :  ALIGN(__tls_align)  /* For ld.bfd:  ALIGN_WITH_INPUT */ {
-        *(.tdata .tdata.* .gnu.linkonce.td.*)
-        PROVIDE(__data_end = .);
-        PROVIDE(__tdata_end = .);
-    } >ram AT>flash :tls :ram_init
-
-    PROVIDE( __tls_base = ADDR(.tdata));
-    PROVIDE( __tdata_start = ADDR(.tdata));
-    PROVIDE( __tdata_source = LOADADDR(.tdata) );
-    PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
-    PROVIDE( __data_source_end = __tdata_source_end );
-    PROVIDE( __tdata_size = SIZEOF(.tdata) );
-
-    PROVIDE( __edata = __data_end );
-    PROVIDE( _edata = __data_end );
-    PROVIDE( edata = __data_end );
-    PROVIDE( __data_size = __data_end - __data_start );
-    PROVIDE( __data_source_size = __data_source_end - __data_source );
-
-    .tbss (NOLOAD) : {
-        *(.tbss .tbss.* .gnu.linkonce.tb.*)
-        *(.tcommon)
-        PROVIDE( __tls_end = . );
-        PROVIDE( __tbss_end = . );
-    } >ram AT>ram :tls :ram
-    PROVIDE( __bss_start = ADDR(.tbss));
-    PROVIDE( __tbss_start = ADDR(.tbss));
-    PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
-    PROVIDE( __tbss_size = SIZEOF(.tbss) );
-    PROVIDE( __tls_size = __tls_end - __tls_base );
-    PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
-    PROVIDE( __tls_size_align = (__tls_size + __tls_align - 1) & ~(__tls_align - 1));
-    PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
-    PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
-
-    .bss (NOLOAD) : {
-        *(.sbss*)
-        *(.gnu.linkonce.sb.*)
-        *(.bss .bss.*)
-        *(.gnu.linkonce.b.*)
-        *(COMMON)
-
-        /* Align the heap */
-        . = ALIGN(8);
-        __bss_end = .;
-    } >ram AT>ram :ram
-    PROVIDE( __non_tls_bss_start = ADDR(.bss) );
-    PROVIDE( __end = __bss_end );
-    _end = __bss_end;
-    PROVIDE( end = __bss_end );
-    PROVIDE( __bss_size = __bss_end - __bss_start );
-
-    /* Make the rest of memory available for heap storage
-	 * LLVM libc denotes heap with [__end, __llvm_libc_heap_limit)
+	/*
+	 * Procedure linkage table. This ends up
+	 * with an array of structs containing pointers
+	 * to the function descriptors and iplt references
+	 * that need to contain them after startup.
 	 */
-    PROVIDE (__llvm_libc_heap_limit = __stack - (DEFINED(__stack_size) ? __stack_size : 4K));
+	/* For ld.bfd: 
+	.plt : {
+		*(.rela.iplt)
+		*(.rela.*)
+	} >flash AT>flash :text
+
+	PROVIDE( __plt_start = ADDR(.plt) );
+	PROVIDE( __plt_size = SIZEOF(.plt) );
+	*/
+
+	/*
+	 * Needs to be in its own segment with the PLT entries first
+	 * so that the linker will compute the offsets to those
+	 * entries correctly.
+	 */
+	.got : {
+		*(.got.plt)
+		*(.got)
+	} >flash AT>flash :text
+
+	.toc : {
+		*(.toc .toc.*)
+		/*
+		 * These get written at startup, so this isn't correct,
+		 * but they must be reachable from tocbase so we can't
+		 * stick them in :ram
+		 */
+		*(.iplt .iplt.*)
+	} >flash AT>flash :text
+
+	/* additional sections when compiling with C++ exception support */
+	
+	.except_ordered : {
+		*(.gcc_except_table *.gcc_except_table.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} >flash AT>flash :text
+	.eh_frame_hdr : {
+		PROVIDE_HIDDEN ( __eh_frame_hdr_start = . );
+		*(.eh_frame_hdr) *(.eh_frame_entry .eh_frame_entry.*)
+		PROVIDE_HIDDEN ( __eh_frame_hdr_end = . );
+	} >flash AT>flash :text
+	.eh_frame : {
+		PROVIDE_HIDDEN ( __eh_frame_start = . );
+		KEEP (*(.eh_frame .eh_frame.*))
+		PROVIDE_HIDDEN ( __eh_frame_end = . );
+	} >flash AT>flash :text
+
+	.except_unordered : {
+		. = ALIGN(8);
+
+		PROVIDE(__exidx_start = .);
+		*(.ARM.exidx*)
+		PROVIDE(__exidx_end = .);
+	} >flash AT>flash :text
+	
+
+	/*
+	 * Data values which are preserved across reset
+	 */
+	.preserve (NOLOAD) : {
+		PROVIDE(__preserve_start__ = .);
+		KEEP(*(SORT_BY_NAME(.preserve.*)))
+		KEEP(*(.preserve))
+		PROVIDE(__preserve_end__ = .);
+	} >ram AT>ram :ram
+
+	.data : /* For ld.bfd:  ALIGN_WITH_INPUT */ {
+		*(.data .data.* )
+		*(.gnu.linkonce.d.*)
+
+		/* Need to pre-align so that the symbols come after padding */
+		. = ALIGN(8);
+
+		PROVIDE( __global_pointer$ = . + 0x800 );
+		PROVIDE( _gp = . + 0x8000);
+		*(.sdata .sdata.* .sdata2.* )
+		*(.gnu.linkonce.s.*)
+		/*
+		 * Make sure there is space for PowerPC thread-local
+		 * stack-check value which lives before the thread
+		 * local storage block. We can't include this in
+		 * .tdata because the linker would then allocate TLS
+		 * offsets for it; in reality, it lives at a known
+		 * fixed offset outside of the usual TLS range
+		 */
+		PROVIDE( __stack_chk_start = .);
+		KEEP (*(.stack_chk .stack_chk.*))
+		PROVIDE( __stack_chk_end = .);
+	} >ram AT>flash :ram_init
+	PROVIDE(__data_start = ADDR(.data));
+	PROVIDE(__data_source = LOADADDR(.data));
+	PROVIDE(__x86_gdt_ro = DEFINED(__x86_gdt) ? __x86_gdt - __data_start + __data_source : 0);
+
+	/* Thread local initialized data. This gets
+	 * space allocated as it is expected to be placed
+	 * in ram to be used as a template for TLS data blocks
+	 * allocated at runtime. We're slightly abusing that
+	 * by placing the data in flash where it will be copied
+	 * into the allocate ram addresses by the existing
+	 * data initialization code in crt0.
+	 * BFD includes .tbss alignment when computing .tdata
+	 * alignment, but for ld.lld we have to explicitly pad
+	 * as it only guarantees usage as a TLS template works
+	 * rather than supporting this use case.
+	 */
+	.tdata :  ALIGN(__tls_align)  /* For ld.bfd:  ALIGN_WITH_INPUT */ {
+		*(.tdata .tdata.* .gnu.linkonce.td.*)
+		PROVIDE(__data_end = .);
+		PROVIDE(__tdata_end = .);
+	} >ram AT>flash :tls :ram_init
+	PROVIDE( __stack_chk_size = __stack_chk_end - __stack_chk_start );
+	PROVIDE( __tdata_start = ADDR(.tdata) - __stack_chk_size );
+	PROVIDE( __tdata_source = LOADADDR(.tdata) - __stack_chk_size );
+	PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
+	PROVIDE( __data_source_end = __tdata_source_end );
+	PROVIDE( __tdata_size = SIZEOF(.tdata) + __stack_chk_size );
+
+	PROVIDE( __edata = __data_end );
+	PROVIDE( _edata = __data_end );
+	PROVIDE( edata = __data_end );
+	PROVIDE( __data_size = __data_end - __data_start );
+	PROVIDE( __data_source_size = __data_source_end - __data_source );
+
+	.tbss (NOLOAD) : {
+		*(.tbss .tbss.* .gnu.linkonce.tb.*)
+		*(.tcommon)
+		PROVIDE( __tls_end = . );
+		PROVIDE( __tbss_end = . );
+	} >ram AT>ram :tls :ram
+	PROVIDE( __tls_first = SIZEOF(.tdata) ? ADDR(.tdata) : ADDR(.tbss) );
+	PROVIDE( __tls_base = __tls_first - __stack_chk_size );
+	PROVIDE( __bss_start = ADDR(.tbss));
+	PROVIDE( __tbss_start = ADDR(.tbss));
+	PROVIDE( __tbss_offset = ADDR(.tbss) - __tls_first );
+	PROVIDE( __tbss_size = SIZEOF(.tbss) );
+	PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
+	PROVIDE( __tls_size = (__tls_tail_extra_size ? ALIGN(__tls_end, __tls_align) + __tls_tail_extra_size : __tls_end) - __tls_base );
+	PROVIDE( __tls_size_align = (__tls_size + __tls_align - 1) & ~(__tls_align - 1));
+	PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
+	PROVIDE( __or1k_tls_tcb_offset = MAX(16, __tls_align) );
+	PROVIDE( __sh32_tls_tcb_offset = MAX(8, __tls_align) );
+	PROVIDE( __x86_tls_tcb = ALIGN(__tls_end, __tls_align) );
+	PROVIDE( __x86_tls_tcb_offset = __x86_tls_tcb - __tls_base );
+
+	/*
+	 * Unlike ld.lld, ld.bfd does not advance the location counter for
+	 * .tbss, but we actually need memory allocated for .tbss as we use
+	 * it for the initial TLS storage.
+	 * Create special section here just to make room.
+	 */
+        /* For ld.bfd: 
+        .tbss_space (NOLOAD) : {
+		. = ADDR(.tbss);
+		. = . + SIZEOF(.tbss);
+	} >ram AT>ram :ram
+	*/
+	.bss (NOLOAD) : {
+		/*
+		 * For the x86-32 and x86-64, we must further allocate extra
+		 * space for the thread control block -- at a minimum, the
+		 * TCB needs to contain a pointer to itself
+		 * (https://akkadia.org/drepper/tls.pdf).  Unlike the
+		 * PowerPC case, the x86 TCB appears after the thread local
+		 * variables.
+		 * On the x86, the precise procedure to set the TCB pointer
+		 * depends on the operating system.  The system library
+		 * should implement a __set_tcb() function to set this
+		 * pointer (similar to OpenBSD's, https://man.openbsd.org/
+		 *__get_tcb.2).  __set_tcb() will be called by _set_tls().
+		 */
+		. = ALIGN(__tls_align);
+		PROVIDE( __tls_tail_extra_start = . );
+		KEEP (*(.tls_tail_extra .tls_tail_extra.*))
+		PROVIDE( __tls_tail_extra_end = . );
+
+		PROVIDE( __non_tls_bss_start = . );
+		*(.sbss* )
+		*(.gnu.linkonce.sb.*)
+		*(.bss .bss.* )
+		*(.gnu.linkonce.b.*)
+		*(COMMON)
+
+		/* Align the heap */
+		. = ALIGN(8);
+		__bss_end = .;
+	} >ram AT>ram :ram
+	PROVIDE( __tls_tail_extra_size = __tls_tail_extra_end - __tls_tail_extra_start );
+	PROVIDE( __end = __bss_end );
+	_end = __bss_end;
+	PROVIDE( end = __bss_end );
+	PROVIDE( __bss_size = __bss_end - __bss_start );
+
+	/* Make the rest of memory available for heap storage */
+	PROVIDE (__heap_start = __end);
+	PROVIDE (__heap_end = __stack - (DEFINED(__stack_size) ? __stack_size : 4K));
+	PROVIDE (__heap_size = __heap_end - __heap_start);
+
+        /* Allow a minimum heap size to be specified */
+        .heap (NOLOAD) : {
+                . += (DEFINED(__heap_size_min) ? __heap_size_min : 0);
+        } >ram :ram
+
+	/* Define a stack region to make sure it fits in memory */
+	.stack (NOLOAD) : {
+		. += (DEFINED(__stack_size) ? __stack_size : 4K);
+	} >ram :ram
+
+	/* Throw away C++ exception handling information */
+
+	/*
+
+	/DISCARD/ : {
+		*(.note .note.*)
+		*(.eh_frame .eh_frame.*)
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		*(.ARM.exidx*)
+	}
+
+	*/
+
+	/* Stabs debugging sections.  */
+	.stab          0 : { *(.stab) }
+	.stabstr       0 : { *(.stabstr) }
+	.stab.excl     0 : { *(.stab.excl) }
+	.stab.exclstr  0 : { *(.stab.exclstr) }
+	.stab.index    0 : { *(.stab.index) }
+	.stab.indexstr 0 : { *(.stab.indexstr) }
+	.comment       0 : { *(.comment) }
+	.gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+	/* DWARF debug sections.
+	   Symbols in the DWARF debugging sections are relative to the beginning
+	   of the section so we begin them at 0.  */
+	/* DWARF 1.  */
+	.debug          0 : { *(.debug) }
+	.line           0 : { *(.line) }
+	/* GNU DWARF 1 extensions.  */
+	.debug_srcinfo  0 : { *(.debug_srcinfo) }
+	.debug_sfnames  0 : { *(.debug_sfnames) }
+	/* DWARF 1.1 and DWARF 2.  */
+	.debug_aranges  0 : { *(.debug_aranges) }
+	.debug_pubnames 0 : { *(.debug_pubnames) }
+	/* DWARF 2.  */
+	.debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+	.debug_abbrev   0 : { *(.debug_abbrev) }
+	.debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+	.debug_frame    0 : { *(.debug_frame) }
+	.debug_str      0 : { *(.debug_str) }
+	.debug_loc      0 : { *(.debug_loc) }
+	.debug_macinfo  0 : { *(.debug_macinfo) }
+	/* SGI/MIPS DWARF 2 extensions.  */
+	.debug_weaknames 0 : { *(.debug_weaknames) }
+	.debug_funcnames 0 : { *(.debug_funcnames) }
+	.debug_typenames 0 : { *(.debug_typenames) }
+	.debug_varnames  0 : { *(.debug_varnames) }
+	/* DWARF 3.  */
+	.debug_pubtypes 0 : { *(.debug_pubtypes) }
+	.debug_ranges   0 : { *(.debug_ranges) }
+	/* DWARF 5.  */
+	.debug_addr     0 : { *(.debug_addr) }
+	.debug_line_str 0 : { *(.debug_line_str) }
+	.debug_loclists 0 : { *(.debug_loclists) }
+	.debug_macro    0 : { *(.debug_macro) }
+	.debug_names    0 : { *(.debug_names) }
+	.debug_rnglists 0 : { *(.debug_rnglists) }
+	.debug_str_offsets 0 : { *(.debug_str_offsets) }
+	.debug_sup      0 : { *(.debug_sup) }
+	.gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+
+    /* ATfE:begin */
+    PROVIDE (__llvm_libc_heap_limit = __heap_end); 
+    /* ATfE:end */
 }
-
-ASSERT( __data_size == __data_source_size, "ERROR: .data/.tdata flash size does not match RAM size");
-
+/*
+ * Check that sections that are copied from flash to RAM have matching
+ * padding, so that a single memcpy() of __data_size copies the correct bytes.
+ */
+ASSERT( __data_size == __data_source_size,
+	"ERROR: .data/.tdata flash size does not match RAM size");


### PR DESCRIPTION
Update llvmlibc.ld to match picolibc.ld to simplify migration:
- Update the bootcode to use the same section name as picolibc (.text.init.enter) to simplify migration.
- Keep the old name (.vectors) for compatibility with upstream bootcode used in testing.
- Update the linker script template from latest picolibcpp.ld
- Remove -lcrt0-semihost from the llvmlibc test command line since upstream bootcode is used there.
- Highlight in the docs that LLVM libc linker script is licensed under a different license compared to LLVM libc itself.