### PR TITLE
Tep 1233 garcar02

### DIFF
--- a/arm-software/linux/docs/GettingStarted.md
+++ b/arm-software/linux/docs/GettingStarted.md
@@ -1,10 +1,10 @@
-## Getting Started
+# Getting Started
 
 This document describes how to get started with the already installed Arm
 Toolchain for Linux. Here you will find out how to use it to compile a source
 code into an executable binary.
 
-### Looking at the toolchain
+## Looking at the toolchain
 
 The default installation site of Arm Toolchain For Linux is the
 `/opt/arm/arm-toolchain-for-linux` directory. It contains a complete set of LLVM
@@ -18,7 +18,7 @@ OpenMP runtime). The main tools are as follows:
 Note that the LLVM equivalents of these commands (`clang`, `clang++`, `flang`)
 are also available and functionally identical.
 
-### Configure and load environment modules
+## Configure and load environment modules
 
 After installation, you should be able to invoke any of those commands with
 their absolute paths, e.g.:
@@ -32,19 +32,19 @@ Although fully operable, this is not the most convenient way of using the
 toolchain. Therefore, we recommend using the environment modules. These can be
 installed on most of the existing Linux distributions, as presented below.
 
-#### Ubuntu systems
+### Ubuntu systems
 
 ```
 $ sudo apt install environment-modules
 ```
 
-#### Red Hat Enterprise Linux and Amazon Linux systems
+### Red Hat Enterprise Linux and Amazon Linux systems
 
 ```
 $ sudo dnf install environment-modules
 ```
 
-#### SUSE Linux Enterprise Server systems
+### SUSE Linux Enterprise Server systems
 
 ```
 $ sudo zypper install environment-modules
@@ -53,13 +53,13 @@ $ sudo zypper install environment-modules
 After installing environment modules, you need to execute a profile script which
 matches with your default shell:
 
-#### BASH
+### BASH
 
 ```
 $ source /etc/profile.d/modules.sh
 ```
 
-#### csh or tcsh
+### csh or tcsh
 
 ```
 $ source /etc/profile.d/modules.csh
@@ -98,14 +98,14 @@ $ which armflang
 /opt/arm/arm-toolchain-for-linux/bin/armflang
 ```
 
-### Using the compiler
+## Using the compiler
 
-#### Example 1: Compile and run an example C program
+### Example 1: Compile and run an example C program
 
 Consider a simple program stored in a `.c` file, for example: `hello.c`:
 
 ```
-#include <stdio.h>
+include <stdio.h>
 
 int main()
 {
@@ -129,7 +129,7 @@ $ ./hello
 Hello, World!
 ```
 
-#### Example 2: Compile and run an example Fortran program
+### Example 2: Compile and run an example Fortran program
 
 Consider a simple program stored in a `.f90` file, for example: `hello.f90`:
 
@@ -154,7 +154,7 @@ $ ./hello
  hello world
 ```
 
-### Compile and link C/C++ programs
+## Compile and link C/C++ programs
 
 To generate an executable binary, compile your source file (for example,
 `source.c`) with the `armclang` command:
@@ -191,12 +191,12 @@ $ armclang -c source2.c
 $ armclang -o binary source1.o source2.o
 ```
 
-#### Note
+### Note
 
 For the C/C++ compiler's command line arguments reference visit this page:
 [Clang command line argument reference](https://releases.llvm.org/20.1.0/tools/clang/docs/ClangCommandLineReference.html).
 
-### Compile and link Fortran programs
+## Compile and link Fortran programs
 
 To generate an executable binary, compile your source file (for example,
 `source.f90`) with the `armflang` command:
@@ -239,12 +239,12 @@ $ armclang -c source2.c
 $ armflang -o binary source1.o source2.o
 ```
 
-#### Note
+### Note
 
 For the Fortran compiler's command line arguments reference visit this page:
 [Flang command line argument reference](https://flang.llvm.org/docs/FlangCommandLineReference.html).
 
-### Increase the optimization level
+## Increase the optimization level
 
 To control the optimization level, specify the `-O<level>` option on your
 compile line, and replace `<level>` with one of `0`, `1`, `2` or `3`. The `-O0`
@@ -266,7 +266,7 @@ optimization level, use:
 $ armflang -O3 -o binary source.f90
 ```
 
-#### Note
+### Note
 
 Similarly to other compilers, the Arm Toolchain for Linux C and C++ compilers
 can also be supplied with the `-Ofast` option. This will however result in
@@ -291,7 +291,7 @@ As the warning message states, the effect of applying the `-Ofast` option when
 compiling Fortram programs can be achieved by using the
 `-O3 -ffast-math -fstack-arrays` options instead.
 
-### Compile and optimize using CPU auto-detection
+## Compile and optimize using CPU auto-detection
 
 If you tell the compiler what target CPU your application will run on, it can
 make target-specific optimization decisions. Target-specific optimization
@@ -322,7 +322,7 @@ The `-mcpu` option supports a range of Armv8-A-based Systems-on-Chips (SoCs).
 When `-mcpu` is not specified, by default, `-mcpu=generic` is set, which
 generates  portable output suitable for any Armv8-A-based target.
 
-#### Note
+### Note
 
 * The optimizations that are performed from setting the `-mcpu` option (also
   known as hardware, or CPU, tuning) are independent of the optimizations that
@@ -333,9 +333,9 @@ generates  portable output suitable for any Armv8-A-based target.
   `-mcpu=<target>` where `<target>` is the target processor that you will run
   the application on.
 
-### Fortran Recommendations
+## Fortran Recommendations
 
-#### Who should use Arm Toolchain For Linux
+### Who should use Arm Toolchain For Linux
 
 * Code with modern Fortran features (except coarrays/teams/collectives) will
   work with ATfL.
@@ -346,7 +346,7 @@ generates  portable output suitable for any Armv8-A-based target.
 
 * Applications requiring quadmath support can be compiled with ATfL.
 
-#### Who should not use Arm Toolchain For Linux
+### Who should not use Arm Toolchain For Linux
 
 * Performance is not guaranteed. For users seeking highest performance ATfL is
   not recommended.

--- a/arm-software/linux/docs/Installation.md
+++ b/arm-software/linux/docs/Installation.md
@@ -1,8 +1,8 @@
-## Installation
+# Installation
 
 This document describes how to download and install the Arm Toolchain for Linux.
 
-### Pre-installation step
+## Pre-installation step
 
 The first step is to configure your Linux package manager to be able to fetch
 packages from Arm. This step only needs to be performed once.
@@ -10,7 +10,7 @@ packages from Arm. This step only needs to be performed once.
 From the options below, select the packages repository matching with your
 installed Linux distribution.
 
-#### Ubuntu 22.04
+### Ubuntu 22.04
 
 ```
 $ curl "https://developer.arm.com/packages/arm-toolchains:ubuntu-22/jammy/Release.key" | sudo gpg --dearmor -o /usr/share/keyrings/obs-oss-arm-com.gpg
@@ -20,7 +20,7 @@ $ echo "deb [signed-by=/usr/share/keyrings/obs-oss-arm-com.gpg] https://develope
 $ sudo apt update
 ```
 
-#### Ubuntu 24.04
+### Ubuntu 24.04
 
 ```
 $ curl "https://developer.arm.com/packages/arm-toolchains:ubuntu-24/noble/Release.key" | sudo gpg --dearmor -o /usr/share/keyrings/obs-oss-arm-com.gpg
@@ -30,7 +30,7 @@ $ echo "deb [signed-by=/usr/share/keyrings/obs-oss-arm-com.gpg] https://develope
 $ sudo apt update
 ```
 
-#### Red Hat Entrprise Linux 8
+### Red Hat Entrprise Linux 8
 
 ```
 $ sudo dnf install 'dnf-command(config-manager)'
@@ -38,7 +38,7 @@ $ sudo dnf install 'dnf-command(config-manager)'
 $ sudo dnf config-manager -y --add-repo https://developer.arm.com/packages/arm-toolchains:rhel-8/el8/arm-toolchains:rhel-8.repo
 ```
 
-#### Red Hat Entrprise Linux 9
+### Red Hat Entrprise Linux 9
 
 ```
 $ sudo dnf install 'dnf-command(config-manager)'
@@ -46,7 +46,7 @@ $ sudo dnf install 'dnf-command(config-manager)'
 $ sudo dnf config-manager -y --add-repo https://developer.arm.com/packages/arm-toolchains:rhel-9/el9/arm-toolchains:rhel-9.repo
 ```
 
-#### Amazon Linux 2023
+### Amazon Linux 2023
 
 ```
 $ sudo dnf install 'dnf-command(config-manager)'
@@ -54,31 +54,31 @@ $ sudo dnf install 'dnf-command(config-manager)'
 $ sudo dnf config-manager -y --add-repo https://developer.arm.com/packages/arm-toolchains:amzn-2023/al2023/arm-toolchains:amzn-2023.repo
 ```
 
-#### SUSE Linux Enterprise Server 15
+### SUSE Linux Enterprise Server 15
 
 ```
 $ sudo zypper ar -f https://developer.arm.com/packages/arm-toolchains:sles-15/sl15/arm-toolchains:sles-15.repo
 ```
 
-### Installation step
+## Installation step
 
 Please select the command below appropriate for your Linux distribution. This
 will install Arm Toolchain For Linux, along with Arm Performance Libraries,
 which is a required dependency.
 
-#### Ubuntu systems
+### Ubuntu systems
 
 ```
 $ sudo apt install arm-toolchain-for-linux
 ```
 
-#### Red Hat Enterprise Linux and Amazon Linux systems
+### Red Hat Enterprise Linux and Amazon Linux systems
 
 ```
 $ sudo dnf install arm-toolchain-for-linux
 ```
 
-#### SUSE Linux Enterprise Server systems
+### SUSE Linux Enterprise Server systems
 
 ```
 $ sudo zypper install arm-toolchain-for-linux

--- a/arm-software/linux/docs/PortingFromACfL.md
+++ b/arm-software/linux/docs/PortingFromACfL.md
@@ -1,4 +1,4 @@
-## ACfL to ATfL Porting Guide
+# ACfL to ATfL Porting Guide
 
 This document outlines the key differences between using the Arm Toolchain for
 Linux (ATfL) and the Arm Compiler for Linux (ACfL). It also lists command-line
@@ -11,14 +11,14 @@ the names of these frontends are consistent across both: `armclang` for C,
 
 The quadmath is supported by ATfL, while it was not supported by ACfL.
 
-### Reference Version
+## Reference Version
 
 |Compiler                      |Version|
 |------------------------------|-------|
 |Arm Compiler for Linux (ACfL) |24.10  |
 |Arm Toolchain for Linux (ATfL)|20.0   |
 
-### ArmPL integration
+## ArmPL integration
 
 In ACfL, Arm Performance Libraries (ArmPL) are bundled with the compiler. To
 simplify usage, the `-armpl` flag is provided to automatically include the
@@ -31,17 +31,17 @@ users must manually specify the locations of the headers and libraries using
 `pkg-config`. Detailed instructions are available in the
 [Getting Started](./GettingStarted.md) guide.
 
-#### Note
+### Note
 
 Vector math functions from libamath are accessible without manually specifying
 the libraries.
 
-### C/C++ Frontend
+## C/C++ Frontend
 
 The C/C++ frontend in ATfL is identical to the one used in ACfL. Both are built
 on the Clang frontend from the upstream LLVM project (`llvm-project/clang`).
 
-### Fortran Frontend
+## Fortran Frontend
 
 The Fortran frontend in ATfL is based on the new LLVM Flang project
 (`llvm-project/flang`). This frontend is a modern, from-scratch implementation.
@@ -50,7 +50,7 @@ In contrast, ACfL used the older Classic Flang frontend, available at
 Because ATfL introduces a new Fortran frontend, this document will primarily
 focus on the differences in Fortran support between the two toolchains.
 
-#### Major difference
+### Major difference
 
 |                |Compatibility|
 |----------------|-------------|
@@ -58,7 +58,7 @@ focus on the differences in Fortran support between the two toolchains.
 |Module file     |No           |
 |Array descriptor|No           |
 
-#### Difference in Fortran features
+### Difference in Fortran features
 
 |Feature                   |ACfL                                                                                         |ATfL                                                                                                 |
 |--------------------------|---------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
@@ -71,7 +71,7 @@ focus on the differences in Fortran support between the two toolchains.
 |Recursive functions       |Use `-frecursive`                                                                            |Default                                                                                              |
 |Main function             |Is a library linked at link-time                                                             |Is generated in the object file containing the program statement                                     |
 
-#### Difference in command line flags
+### Difference in command line flags
 
 The following table summarises some of the most commonly used compiler flags in
 gfortran and gives their equivalent in the Arm Fortran compiler:
@@ -84,7 +84,7 @@ gfortran and gives their equivalent in the Arm Fortran compiler:
 |`-r8`             |`-fdefault-real-8`        |Sets the default `KIND` for `REAL` and `COMPLEX` declarations, constants, functions, and intrinsics|
 |`-i8`             |`-fdefault-integer-8`     |Set the default `KIND` for `INTEGER` and `LOGICAL` to 64bit (i.e., `KIND = 8`)                     |
 
-#### Pre-defined macros
+### Pre-defined macros
 
 `armflang` has the following compiler and machine specific predefined processor
 macros:

--- a/arm-software/linux/docs/UsingArmPL.md
+++ b/arm-software/linux/docs/UsingArmPL.md
@@ -1,9 +1,9 @@
-## Using the Arm Performance Libraries
+# Using the Arm Performance Libraries
 
 You can get greater performance from your code if you enable linking to the
 optimized math libraries at compilation time.
 
-### Linking to Arm Performance Libraries
+## Linking to Arm Performance Libraries
 
 To enable you to get the best performance on Arm-based systems, Arm recommends
 linking to Arm Performance Libraries. Arm Performance Libraries provide
@@ -61,7 +61,7 @@ armpl-static-lp64-omp           ArmPL - Arm Performance Libraries
 armpl-static-lp64-seq           ArmPL - Arm Performance Libraries
 ```
 
-#### C/C++ examples
+### C/C++ examples
 
 To link to the OpenMP multi-threaded Arm Performance Libraries with a 64-bit
 integer interface, and include compiler and library optimizations for an
@@ -87,7 +87,7 @@ Neoverse V2-based system, use:
 $ armclang -o binary code_with_math_routines.c -mcpu=neoverse-v2 `pkg-config armpl-dynamic-lp64-seq --cflags --libs`
 ```
 
-#### Fortran examples
+### Fortran examples
 
 To link to the OpenMP multi-threaded Arm Performance Libraries with a 64-bit
 integer interface, and include compiler and library optimizations for an
@@ -113,7 +113,7 @@ Neoverse V1-based system, use:
 $ armflang -o binary code_with_math_routines.f90 -mcpu=neoverse-v1 `pkg-config armpl-dynamic-lp64-seq --cflags --libs`
 ```
 
-#### More information
+### More information
 
 For more information please visit this page:
 [Get started with Arm Performance Libraries (stand-alone Linux version) Version 24.10](https://developer.arm.com/documentation/102620/latest).
@@ -121,7 +121,7 @@ For more information please visit this page:
 To learn more about integrating Arm Performance Libraries with Arm Toolchain For
 Linux please visit [Using Arm Performance Libraries (ArmPL) with ATfL](https://github.com/arm/arm-toolchain/blob/arm-software/arm-software/linux/README.md#using-arm-performance-libraries-armpl-with-atfl).
 
-#### Note
+### Note
 
 The Arm Performance Libraries suite is also the provider of the vectorized math
 routines library (libamath). This is a subset of the libm functions, which makes

--- a/arm-software/linux/docs/UsingBOLT.md
+++ b/arm-software/linux/docs/UsingBOLT.md
@@ -1,4 +1,4 @@
-## How to use BOLT with our toolchain
+# How to use BOLT with our toolchain
 
 BOLT is a post-link optimizer available in ATfL. To benefit from it you can use
 the following tools:
@@ -7,7 +7,7 @@ the following tools:
 * `llvm-bolt-heatmap`
 * `perf2bolt`
 
-### Example optimization of a pathological case
+## Example optimization of a pathological case
 
 To try this example, download and adapt our Telemetry repository. You can do
 that with the following commands:


### PR DESCRIPTION
Reduce markdown heading levels in arm-software/linux/docs, all currently start at level 2