### PR TITLE
[ATfE] Mark __stack declaration as extern "C"

### DIFF
--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions_m.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions_m.h
@@ -132,7 +132,7 @@ EXFN_ATTR void __exception_handler() { abort(); }
 // has to be 128-byte aligned, however an implementation can require more bits
 // to be zero and cortex-m23 can require up to 10, so 1024-byte align the vector
 // table.
-[[gnu::weak]] extern char __stack;
+extern "C" [[gnu::weak]] extern char __stack;
 using vtable_t = void (*)(void);
 [[gnu::section(".text.init.enter"), gnu::aligned(1024)]]
 const vtable_t vector_table[] = {

--- a/arm-software/embedded/llvmlibc-support/crt0/memory_common.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/memory_common.h
@@ -11,7 +11,7 @@
 #ifndef BOOTCODE_MEMORY_COMMON_H
 #define BOOTCODE_MEMORY_COMMON_H
 
-[[gnu::weak]] extern char __stack;
+extern "C" [[gnu::weak]] extern char __stack;
 [[gnu::weak]] extern char __heap_start;
 
 namespace bootcode {


### PR DESCRIPTION
The declaration is inside a C++ namespace, thus needs to be explicitly extern "C" to avoid name mangling. Further, all declarations of __start need to be updated to match.