### PR TITLE
[ATfE] Add QEMU tracing option

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/lit-exec-qemu.py
+++ b/arm-software/embedded/arm-runtimes/test-support/lit-exec-qemu.py
@@ -57,6 +57,12 @@ def main():
         help="Print verbose output. This may affect test result, as the output "
         "will be added to the output of the test.",
     )
+    parser.add_argument(
+        "--trace",
+        type=str,
+        default=None,
+        help="File to write execution trace to (slows execution significantly)",
+    )
     parser.add_argument("image", help="image file to execute")
     parser.add_argument(
         "arguments",
@@ -75,6 +81,7 @@ def main():
         args.timeout,
         args.execdir,
         args.verbose,
+        args.trace,
     )
     sys.exit(ret_code)
 

--- a/arm-software/embedded/arm-runtimes/test-support/picolibc-test-wrapper.py
+++ b/arm-software/embedded/arm-runtimes/test-support/picolibc-test-wrapper.py
@@ -26,6 +26,7 @@ def run(args):
             None,
             pathlib.Path.cwd(),
             args.verbose,
+            args.trace,
         )
     else:
         return run_fvp(
@@ -77,6 +78,12 @@ def main():
     parser.add_argument(
         "--tarmac",
         help="file to wrote tarmac trace to (FVP only)",
+    )
+    parser.add_argument(
+        "--trace",
+        type=str,
+        default=None,
+        help="File to write execution trace to (QEMU only)",
     )
     parser.add_argument(
         "--verbose",

--- a/arm-software/embedded/arm-runtimes/test-support/run_qemu.py
+++ b/arm-software/embedded/arm-runtimes/test-support/run_qemu.py
@@ -16,6 +16,7 @@ def run_qemu(
     timeout,
     working_directory,
     verbose,
+    trace,
 ):
     """Execute the program using QEMU and return the subprocess return code."""
     qemu_params = ["-M", qemu_machine]
@@ -43,6 +44,13 @@ def run_qemu(
         qemu_params += ["-kernel", image]
     else:
         qemu_params += ["-device", f"loader,file={image},cpu-num=0"]
+
+    # Enable tracing: disassembly, CPU state, interrupts and guest errors like
+    # invalid instructions. One instruction at a time.
+    if trace:
+        qemu_params += ["-singlestep"]
+        qemu_params += ["-d", "in_asm,nochain,cpu,int,guest_errors"]
+        qemu_params += ["-D", trace]
 
     command = [qemu_command] + qemu_params
 


### PR DESCRIPTION
Add command line option to QEMU execution wrappers to enable execution tracing: per instruction disassembly and CPU state.