### PR TITLE
Revert "[ATfL] Make sure rpath is added to the helper programs used by the lit tests (#538)"

### DIFF
--- a/arm-software/linux/build.sh
+++ b/arm-software/linux/build.sh
@@ -155,8 +155,6 @@ abort() {
     ***************
     '
     echo "An error occurred. Exiting..." >&2
-    rm -f "${BUILD_DIR}/bootstrap_compiler/bin/clang.cfg"
-    rm -f "${BUILD_DIR}/bootstrap_compiler/bin/clang++.cfg"
     if ${INTERACTIVE}; then
         cd "${BASE_DIR}"
         bash
@@ -376,11 +374,7 @@ product_build() {
     run_command cmake --install . 2>&1 | tee -a "${LOGS_DIR}/product.txt"
     cp -d ${ATFL_DIR}/lib/clang/*/lib/${ATFL_TARGET_TRIPLE}/libflang_rt* \
         "${ATFL_DIR}/lib/${ATFL_TARGET_TRIPLE}"
-    echo "-Wl,-rpath=${ATFL_DIR}/lib" > ${BUILD_DIR}/bootstrap_compiler/bin/clang.cfg
-    echo "-Wl,-rpath=${ATFL_DIR}/lib" > ${BUILD_DIR}/bootstrap_compiler/bin/clang++.cfg
     run_command ninja ${NINJA_ARGS} check-all | tee -a "${LOGS_DIR}/product.txt"
-    rm "${BUILD_DIR}/bootstrap_compiler/bin/clang.cfg"
-    rm "${BUILD_DIR}/bootstrap_compiler/bin/clang++.cfg"
 }
 
 shared_lib_build() {
@@ -415,13 +409,9 @@ shared_lib_build() {
     cp -d ${ATFL_DIR}.libs/lib/clang/*/lib/${ATFL_TARGET_TRIPLE}/libflang_rt* \
         "${ATFL_DIR}/lib/${ATFL_TARGET_TRIPLE}"
     rm -r "${ATFL_DIR}.libs"
-    echo "-Wl,-rpath=${ATFL_DIR}/lib" > ${BUILD_DIR}/bootstrap_compiler/bin/clang.cfg
-    echo "-Wl,-rpath=${ATFL_DIR}/lib" > ${BUILD_DIR}/bootstrap_compiler/bin/clang++.cfg
     echo '-L<CFGDIR>/../runtimes/runtimes-bins/openmp/runtime/src $-Wl,--push-state $-Wl,--as-needed $-lomp $-ldl $-Wl,--pop-state' >bin/clang.cfg
     echo '-L<CFGDIR>/../runtimes/runtimes-bins/openmp/runtime/src $-Wl,--push-state $-Wl,--as-needed $-lomp $-ldl $-Wl,--pop-state' >bin/clang++.cfg
     run_command ninja ${NINJA_ARGS} check-all | tee -a "${LOGS_DIR}/shared_lib.txt"
-    rm "${BUILD_DIR}/bootstrap_compiler/bin/clang.cfg"
-    rm "${BUILD_DIR}/bootstrap_compiler/bin/clang++.cfg"
 }
 
 package() {


### PR DESCRIPTION
It was a horrible solution to the problem introduced by https://github.com/llvm/llvm-project/pull/158719

It caused unexpected issues while testing on RHEL8.

This reverts commit 0cc7c83e71ff8fc3bd1e517df441ed9579654a93.