### PR TITLE
Fix Mingw-w64 build

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -1001,6 +1001,8 @@ if(LLVM_TOOLCHAIN_CROSS_BUILD_MINGW)
         -DLLVM_ENABLE_PROJECTS=${LLVM_ENABLE_PROJECTS_comma}
         -DLLVM_TABLEGEN=${LLVM_BINARY_DIR}/bin/llvm-tblgen${CMAKE_EXECUTABLE_SUFFIX}
         -DLLVM_TARGETS_TO_BUILD=${LLVM_TARGETS_TO_BUILD_comma}
+        -DLLVM_EXTERNAL_PROJECTS=elf2bin
+        -DLLVM_EXTERNAL_ELF2BIN_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../shared/elf2bin
         BUILD_COMMAND "" # Let the install command build whatever it needs
         INSTALL_COMMAND "${CMAKE_COMMAND}" --build <BINARY_DIR> --target install-distribution
         USES_TERMINAL_CONFIGURE TRUE

--- a/arm-software/embedded/docs/building-from-source.md
+++ b/arm-software/embedded/docs/building-from-source.md
@@ -123,7 +123,7 @@ ninja package-llvm-toolchain
 The Arm Toolchain for Embedded can be cross-compiled to run on Windows.
 The compilation itself still happens on Linux. In addition to the prerequisites
 mentioned in the [Installing prerequisites](#installing-prerequisites) section
-you will also need a Mingw-w64 toolchain based on GCC 7.1.0 or above installed.
+you will also need a Mingw-w64 toolchain based on GCC 13 or above installed.
 For example, to install it on Ubuntu Linux use the following command:
 ```
 # apt-get install mingw-w64


### PR DESCRIPTION
Fix Mingw-w64 build by adding missing elf2bin external project to Mingw-w64 build of LLVM Project.

Update the minimal version requirement, Ubuntu 24.04 version of Mingw-w64 is required to build LLVM now: afunix.h is reported missing in Ubuntu 22.04 version.