### PR TITLE
[ATfE] Use target specific directory for llvmlibc includes

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -774,11 +774,11 @@ if(C_LIBRARY STREQUAL llvmlibc)
             -E copy_directory
             <INSTALL_DIR>/lib/${target_triple}
             "${TEMP_LIB_DIR}/lib"
-        # And copy the include directory, which is already arranged right.
+        # Also copy the includes from their target-specific subdirectory.
         COMMAND
             ${CMAKE_COMMAND}
             -E copy_directory
-            <INSTALL_DIR>/include
+            <INSTALL_DIR>/include/${target_triple}
             "${TEMP_LIB_DIR}/include"
     )
 


### PR DESCRIPTION
After an upstream change, the LLVM_ENABLE_PER_TARGET_RUNTIME_DIR option now applies to the include directory when building LLVM libc. The install rules for the build have been updated to copy includes from the new target specific subdirectory, which is already done for the lib directory.