### PR TITLE
[ATfE] Fix llvmlibc C++ sample crash by increasing the stack

### DIFF
--- a/arm-software/embedded/llvmlibc-samples/ldscripts/llvmlibc-microbit.ld
+++ b/arm-software/embedded/llvmlibc-samples/ldscripts/llvmlibc-microbit.ld
@@ -4,6 +4,6 @@ __flash = 0x00003000;       /* starting address of the remaining flash */
 __flash_size = 0x3d000;     /* length of the remaining flash */
 __ram = 0x20000000;         /* starting address of RAM bank 0 */
 __ram_size = 0x4000;        /* length of RAM bank 0 */
-__stack_size = 512;
+__stack_size = 0x400;       /* 1 KB of stack */
 
 INCLUDE llvmlibc.ld

--- a/arm-software/embedded/samples/ldscripts/microbit.ld
+++ b/arm-software/embedded/samples/ldscripts/microbit.ld
@@ -4,6 +4,6 @@ __flash = 0x00003000;       /* starting address of the remaining flash */
 __flash_size = 0x3d000;     /* length of the remaining flash */
 __ram = 0x20000000;         /* starting address of RAM bank 0 */
 __ram_size = 0x4000;        /* length of RAM bank 0 */
-__stack_size = 512;
+__stack_size = 0x400;       /* 1 KB of stack */
 
 INCLUDE picolibcpp.ld


### PR DESCRIPTION
Fix llvmlibc C++ sample crash by increasing the stack size and align the picolibc sample linker script to use the same.