### PR TITLE
[ATfE] Fix llvmlibc AArch64 sample

### DIFF
--- a/arm-software/embedded/llvmlibc-samples/ldscripts/llvmlibc-raspi3b.ld
+++ b/arm-software/embedded/llvmlibc-samples/ldscripts/llvmlibc-raspi3b.ld
@@ -15,7 +15,7 @@ linker script file should be provided.
 */
 
 __boot_flash = 0x80000; /* Default firmware address for Rapberry Pi 3 */
-__boot_flash_size = 0x2000; /* 8K of space for added page table */
+__boot_flash_size = 0x3000; /* 12K of space for added page table */
 __flash = 0x10000000;
 __flash_size = 0x10000000;
 __ram = 0x20000000;

--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions_8a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions_8a.h
@@ -206,7 +206,7 @@ EXFN_ATTR void exception_handler() {
 // For our purposes, each entry just contains one branch instruction to the
 // exception reporting function, since we never want to resume after an
 // exception.
-[[gnu::naked, gnu::section(".text.init.enter"), gnu::aligned(2048)]]
+[[gnu::naked, gnu::section(".init.vectors"), gnu::aligned(2048)]]
 void vector_table() {
 #define VECTOR_TABLE_ENTRY                                                     \
   asm(".balign 128");                                                          \


### PR DESCRIPTION
Fix llvmlibc AArch64 sample by providing the vector table a name that ensures correct placement following the latest (picolibc based) linker script. Without this, the vector table got before _start.

Increase the size of boot_flash to fit.