### PR TITLE
[ATfE] Ensure xfail files exist for check targets

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -375,7 +375,11 @@ add_subdirectory(
 
 add_dependencies(check-all check-elf2bin)
 
-# Generate a xfail/xfail-not list before running the tests.
+# Ensure the list files exist for anything reading LLVM_LIT_ARGS.
+file(TOUCH ${llvm_xfails_file_path})
+file(TOUCH ${llvm_xfails_not_file_path})
+
+# Update the xfail/xfail-not list before running the tests.
 add_custom_target(
     llvm-xfail-files
     COMMAND ${Python3_EXECUTABLE}


### PR DESCRIPTION
The LLVM_LIT_ARGS option is used by all LLVM projects using lit, not just clang. However the xfail list is currently only populated before running the clang tests, since only clang tests need including in the list.

For now, create a dummy blank file to prevent a file not found error when running certain check targets before check-clang.