### PR TITLE
[ATfE] Replace %T substitution

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/llvm-libc++-picolibc.cfg.in
+++ b/arm-software/embedded/arm-runtimes/test-support/llvm-libc++-picolibc.cfg.in
@@ -31,7 +31,7 @@ config.substitutions.append(('%{link_flags}',
     ' %{libc-extra-link-flags}'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T -- '
+    '%{executor} --execdir %{temp} -- '
 ))
 
 # Long tests are prohibitively slow when run via emulation.

--- a/arm-software/embedded/arm-runtimes/test-support/llvm-libc++abi-picolibc.cfg.in
+++ b/arm-software/embedded/arm-runtimes/test-support/llvm-libc++abi-picolibc.cfg.in
@@ -23,7 +23,7 @@ config.substitutions.append(('%{link_flags}',
     ' %{libc-extra-link-flags}'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T -- '
+    '%{executor} --execdir %{temp} -- '
 ))
 
 import os, site

--- a/arm-software/embedded/arm-runtimes/test-support/llvm-libunwind-picolibc.cfg.in
+++ b/arm-software/embedded/arm-runtimes/test-support/llvm-libunwind-picolibc.cfg.in
@@ -36,7 +36,7 @@ config.substitutions.append(('%{link_flags}',
     ' %{libc-extra-link-flags}'
 ))
 config.substitutions.append(('%{exec}',
-    '%{executor} --execdir %T -- '
+    '%{executor} --execdir %{temp} -- '
 ))
 
 import os, site


### PR DESCRIPTION
Support for the `%T` temp dir substitution is being removed from lit. The libc++ testing format is instead introducing `%{temp}` to replace it, and the downstream test configurations need updating to match.

For reference, see:

https://github.com/llvm/llvm-project/pull/160026
https://github.com/llvm/llvm-project/pull/162323