### PR TITLE
[ATfE] Add more atomics xfails

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/xfails.py
+++ b/arm-software/embedded/arm-runtimes/test-support/xfails.py
@@ -152,6 +152,7 @@ def main():
             name="atomics part 1",
             testnames=[
                 "extensions/libcxx/atomics/atomics.flag/init_bool.pass.cpp",
+                "libcxx/diagnostics/atomic.nodiscard.verify.cpp",
                 "libcxx/thread/thread.stoptoken/intrusive_shared_ptr.pass.cpp",
                 "libcxx/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_from_underaligned_buffer.pass.cpp",
                 "libcxx/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_in_geometric_progression.pass.cpp",
@@ -167,6 +168,7 @@ def main():
                 "std/atomics/atomics.flag/init.pass.cpp",
                 "std/atomics/atomics.flag/test_and_set.pass.cpp",
                 "std/atomics/atomics.general/replace_failure_order.pass.cpp",
+                "std/atomics/atomics.ref/address.pass.cpp",
                 "std/atomics/atomics.ref/ctor.pass.cpp",
                 "std/atomics/atomics.ref/deduction.pass.cpp",
                 "std/atomics/atomics.ref/is_always_lock_free.pass.cpp",


### PR DESCRIPTION
New tests were added by 66416f0d4ccf, two of which:
* libcxx/diagnostics/atomic.nodiscard.verify.cpp
* std/atomics/atomics.ref/address.pass.cpp

fail on the following variants:
* armv4t_exn_rtti_size
* armv4t_size
* armv5te_exn_rtti_size
* armv5te_size
* armv6m_soft_nofp_exn_rtti_size
* armv6m_soft_nofp_size

due to missing/incomplete atomics support. These can be added to the existing list of xfails.