### PR TITLE
Revert "[ATfE] Remove llvm-project downstream patch that defined _LIBCPP_HAS_C8RTOMB_MBRTOC8"

### DIFF
--- a/arm-software/embedded/patches/llvm-project/0001-Define-_LIBCPP_HAS_C8RTOMB_MBRTOC8.patch
+++ b/arm-software/embedded/patches/llvm-project/0001-Define-_LIBCPP_HAS_C8RTOMB_MBRTOC8.patch
@@ -1,0 +1,55 @@
+From 9011c0e821d5b1563dc2dc6370f29c529e55f41f Mon Sep 17 00:00:00 2001
+From: Victor Campos <victor.campos@arm.com>
+Date: Thu, 31 Oct 2024 09:58:34 +0000
+Subject: Define _LIBCPP_HAS_C8RTOMB_MBRTOC8
+
+LLVM libcxx does not define the `char8_t` related functions, instead
+delegating their definitions to the underlying C library.
+
+libcxx defines a macro called `_LIBCPP_HAS_C8RTOMB_MBRTOC8` when it
+infers that the underlying C library provides these functions.
+
+picolibc provides the `char8_t` related functions regardless of the C++
+version used, but this support only landed after version 1.8.8 and, at
+the time of writing, has not made into any released version yet.
+
+This is a temporary fix and should be removed when a picolibc release
+includes the support for `char8_t` and its related functions. When it's
+time to implement a proper solution, one needs to create logic to detect
+the picolibc version and define the macro accordingly. The macros that
+govern picolibc version are in `picolibc.h`.
+---
+ libcxx/include/__config | 17 ++---------------
+ 1 file changed, 2 insertions(+), 15 deletions(-)
+
+diff --git a/libcxx/include/__config b/libcxx/include/__config
+index 1cf80a46686a..615433869a4e 100644
+--- a/libcxx/include/__config
++++ b/libcxx/include/__config
+@@ -1021,21 +1021,8 @@ typedef __char32_t char32_t;
+ // functions is gradually being added to existing C libraries. The conditions
+ // below check for known C library versions and conditions under which these
+ // functions are declared by the C library.
+-//
+-// GNU libc 2.36 and newer declare c8rtomb() and mbrtoc8() in C++ modes if
+-// __cpp_char8_t is defined or if C2X extensions are enabled. Determining
+-// the latter depends on internal GNU libc details that are not appropriate
+-// to depend on here, so any declarations present when __cpp_char8_t is not
+-// defined are ignored.
+-#  if defined(_LIBCPP_GLIBC_PREREQ)
+-#    if _LIBCPP_GLIBC_PREREQ(2, 36) && defined(__cpp_char8_t)
+-#      define _LIBCPP_HAS_C8RTOMB_MBRTOC8 1
+-#    else
+-#      define _LIBCPP_HAS_C8RTOMB_MBRTOC8 0
+-#    endif
+-#  else
+-#    define _LIBCPP_HAS_C8RTOMB_MBRTOC8 0
+-#  endif
++// For picolibc:
++#define _LIBCPP_HAS_C8RTOMB_MBRTOC8 1
+ 
+ // There are a handful of public standard library types that are intended to
+ // support CTAD but don't need any explicit deduction guides to do so. This
+-- 
+2.43.0
+


### PR DESCRIPTION
Reverts arm/arm-toolchain#603

The upstream LLVM patch that made the removal possible has been reverted.