### PR TITLE
[ATfE] Reduce memory and CPU pressure on Windows GitHub runners

### DIFF
--- a/arm-software/embedded/scripts/build.ps1
+++ b/arm-software/embedded/scripts/build.ps1
@@ -18,5 +18,5 @@ $buildDir = (Join-Path $repoRoot build)
 mkdir $buildDir
 cd $buildDir
 
-cmake ..\arm-software\embedded -GNinja -DFETCHCONTENT_QUIET=OFF -DENABLE_QEMU_TESTING=OFF
-ninja package-llvm-toolchain
+cmake ..\arm-software\embedded -GNinja -DFETCHCONTENT_QUIET=OFF -DENABLE_QEMU_TESTING=OFF -DLLVM_PARALLEL_LINK_JOBS=2
+ninja -j 48 package-llvm-toolchain


### PR DESCRIPTION
- Limit Ninja parallelism to 48 parallel build jobs to mitigate resource exhaustion
- Limit LLVM parallel link jobs to 2