### PR TITLE
[ATfE] Fix invalid register error `ELR_hyp` in exception handling on Armv7-A

### DIFF
--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions_7a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions_7a.h
@@ -35,13 +35,8 @@ static bool is_in_hyp_mode() {
   return mode_bits == 0x1A;
 }
 
-#define GET_LR_VALUE_INTO(var)                                                 \
-  do {                                                                         \
-    if (is_in_hyp_mode())                                                      \
-      var = read_elr_hyp();                                                    \
-    else                                                                       \
-      var = (uint32_t)__builtin_return_address(0);                             \
-  } while (0)
+#define GET_LR_VALUE()                                                         \
+  (is_in_hyp_mode() ? read_elr_hyp() : (uintptr_t)__builtin_return_address(0))
 
 EXFN_ATTR void handle_reset() {
   print_str("CPU Exception: Reset\n");
@@ -49,8 +44,7 @@ EXFN_ATTR void handle_reset() {
 }
 
 EXFN_ATTR void handle_undefined() {
-  uintptr_t lr_val;
-  GET_LR_VALUE_INTO(lr_val);
+  uintptr_t lr_val = GET_LR_VALUE();
   print_str("CPU Exception: Undefined Instruction\n");
   print_str("  PC = ");
   print_hex(lr_val);
@@ -68,9 +62,7 @@ EXFN_ATTR void handle_undefined() {
 EXFN_ATTR void handle_svc_hyp_smc() {
   print_str("CPU Exception: SVC, HVC or SMC\n");
   print_str("  PC = ");
-  uintptr_t lr_val;
-  GET_LR_VALUE_INTO(lr_val);
-  print_hex(lr_val);
+  print_hex(GET_LR_VALUE());
   print_str("\n");
   abort();
 }
@@ -78,9 +70,7 @@ EXFN_ATTR void handle_svc_hyp_smc() {
 EXFN_ATTR void handle_prefetch_abort() {
   print_str("CPU Exception: Prefetch Abort\n");
   print_str("  PC = ");
-  uintptr_t lr_val;
-  GET_LR_VALUE_INTO(lr_val);
-  print_hex(lr_val);
+  print_hex(GET_LR_VALUE());
   print_str("\n");
   print_str("  IFSR = 0x%08x\n");
   print_str("  IFAR = 0x%08x\n");
@@ -90,9 +80,7 @@ EXFN_ATTR void handle_prefetch_abort() {
 EXFN_ATTR void handle_data_abort() {
   print_str("CPU Exception: Data Abort\n");
   print_str("  PC = ");
-  uintptr_t lr_val;
-  GET_LR_VALUE_INTO(lr_val);
-  print_hex(lr_val);
+  print_hex(GET_LR_VALUE());
   print_str("\n");
   print_str("  DFSR = 0x%08x\n");
   print_str("  DFAR = 0x%08x\n");
@@ -102,9 +90,7 @@ EXFN_ATTR void handle_data_abort() {
 EXFN_ATTR void handle_hyp_trap() {
   print_str("CPU Exception: Hypervisor Trap\n");
   print_str("  PC = ");
-  uintptr_t lr_val;
-  GET_LR_VALUE_INTO(lr_val);
-  print_hex(lr_val);
+  print_hex(GET_LR_VALUE());
   print_str("\n");
   print_str("  HSR = 0x%08x\n");
   abort();
@@ -113,9 +99,7 @@ EXFN_ATTR void handle_hyp_trap() {
 EXFN_ATTR void handle_irq() {
   print_str("CPU Exception: IRQ\n");
   print_str("  PC = ");
-  uintptr_t lr_val;
-  GET_LR_VALUE_INTO(lr_val);
-  print_hex(lr_val);
+  print_hex(GET_LR_VALUE());
   print_str("\n");
   abort();
 }
@@ -123,9 +107,7 @@ EXFN_ATTR void handle_irq() {
 EXFN_ATTR void handle_fiq() {
   print_str("CPU Exception: FIQ\n");
   print_str("  PC = ");
-  uintptr_t lr_val;
-  GET_LR_VALUE_INTO(lr_val);
-  print_hex(lr_val);
+  print_hex(GET_LR_VALUE());
   print_str("\n");
   abort();
 }


### PR DESCRIPTION
The exception handling functions print out the value of the link register for logging purposes. The problem with this is in reading the `ELR_hyp` register.

This register is only accessible if the processor is in Hypervisor mode. This mode is always available on Armv8-A, but it is optional on Armv7-A, conditioned on the presence of the Virtualization Extension. Attempts to read/write to this register on the latter, if the Virtualization Extension is not in, cause a compiler error, and possibly a fault at runtime if it hadn't been caught by the compiler.

This patch fixes this by reading from the correct link register depending on the configuration. If the processor is not in Hypervisor mode, the code must read from `LR` instead of `ELR_hyp`.

In one of the handlers, the instruction pointed by the link register is printed out. In Thumb mode, the link register might contain an address that is not 4-byte aligned, therefore the load that retrieves the instruction is now done 2 bytes at a time to avoid misaligned access. We could have code that selectively loads either 4 bytes at once or 2 times 2 bytes depending on the ISA state, but it doesn't seem worth it.