### PR TITLE
[ATFE] Use force unrolling of small aarch64 loops

### DIFF
--- a/arm-software/embedded/Omax.cfg
+++ b/arm-software/embedded/Omax.cfg
@@ -9,4 +9,5 @@
 -mllvm -enable-loop-flatten \
 -mllvm -enable-unroll-and-jam \
 -mllvm -enable-inline-memcpy-ld-st \
--mllvm -enable-loop-versioning-licm
+-mllvm -enable-loop-versioning-licm \
+-mllvm -aarch64-force-unroll-threshold=12


### PR DESCRIPTION
This improves performance on several embedded benchmark suites.