### PR TITLE
Make use of RUNTIMES_USE_LIBC to build libcxx

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -870,6 +870,7 @@ if(ENABLE_CXX_LIBS)
             -DLIBCXXABI_ENABLE_STATIC_UNWINDER=${ENABLE_EXCEPTIONS}
             -DLIBCXX_ENABLE_EXCEPTIONS=${ENABLE_EXCEPTIONS}
             -DLIBCXX_ENABLE_RTTI=${ENABLE_RTTI}
+            -DRUNTIMES_USE_LIBC=picolibc
         )
         if(ENABLE_LIBCXX_TESTS)
             # Generate xfails for libxx.
@@ -913,6 +914,7 @@ if(ENABLE_CXX_LIBS)
             -DLIBCXXABI_ENABLE_STATIC_UNWINDER=${ENABLE_EXCEPTIONS}
             -DLIBCXX_ENABLE_EXCEPTIONS=${ENABLE_EXCEPTIONS}
             -DLIBCXX_ENABLE_RTTI=${ENABLE_RTTI}
+            -DRUNTIMES_USE_LIBC=llvm-libc
             )
             set(lib_compile_flags "${lib_compile_flags} -D_LIBCPP_PRINT=1")
     elseif(C_LIBRARY MATCHES "^newlib")
@@ -926,6 +928,7 @@ if(ENABLE_CXX_LIBS)
             -DLIBCXXABI_ENABLE_STATIC_UNWINDER=${ENABLE_EXCEPTIONS}
             -DLIBCXX_ENABLE_EXCEPTIONS=${ENABLE_EXCEPTIONS}
             -DLIBCXX_ENABLE_RTTI=${ENABLE_RTTI}
+            -DRUNTIMES_USE_LIBC=newlib
         )
 
         if(C_LIBRARY STREQUAL newlib-nano)


### PR DESCRIPTION
Make use of RUNTIMES_USE_LIBC CMake option to indicate which C library is used to build libcxx.

This option was enabled in https://github.com/llvm/llvm-project/pull/147956/ instead of hardcoded check for corresponding C library header files.