### PR TITLE
[ATFE] Update LLVM libc++ patch to align with upstream changes in __config

### DIFF
--- a/arm-software/embedded/patches/llvm-project/0001-Define-_LIBCPP_HAS_C8RTOMB_MBRTOC8.patch
+++ b/arm-software/embedded/patches/llvm-project/0001-Define-_LIBCPP_HAS_C8RTOMB_MBRTOC8.patch
@@ -1,6 +1,6 @@
-From 9011c0e821d5b1563dc2dc6370f29c529e55f41f Mon Sep 17 00:00:00 2001
-From: Victor Campos <victor.campos@arm.com>
-Date: Thu, 31 Oct 2024 09:58:34 +0000
+From 3f847ac6d71dbe36ddbda74c200f9cccb47bfb42 Mon Sep 17 00:00:00 2001
+From: Simi Pallipurath <simi.pallipurath@arm.com>
+Date: Wed, 26 Nov 2025 09:26:52 +0000
 Subject: Define _LIBCPP_HAS_C8RTOMB_MBRTOC8
 
 LLVM libcxx does not define the `char8_t` related functions, instead
@@ -19,14 +19,14 @@ time to implement a proper solution, one needs to create logic to detect
 the picolibc version and define the macro accordingly. The macros that
 govern picolibc version are in `picolibc.h`.
 ---
- libcxx/include/__config | 17 ++---------------
- 1 file changed, 2 insertions(+), 15 deletions(-)
+ libcxx/include/__config | 13 ++-----------
+ 1 file changed, 2 insertions(+), 11 deletions(-)
 
 diff --git a/libcxx/include/__config b/libcxx/include/__config
-index 1cf80a46686a..615433869a4e 100644
+index e758acfa870a..e8b9132c323a 100644
 --- a/libcxx/include/__config
 +++ b/libcxx/include/__config
-@@ -1021,21 +1021,8 @@ typedef __char32_t char32_t;
+@@ -820,17 +820,8 @@ typedef __char32_t char32_t;
  // functions is gradually being added to existing C libraries. The conditions
  // below check for known C library versions and conditions under which these
  // functions are declared by the C library.
@@ -36,12 +36,8 @@ index 1cf80a46686a..615433869a4e 100644
 -// the latter depends on internal GNU libc details that are not appropriate
 -// to depend on here, so any declarations present when __cpp_char8_t is not
 -// defined are ignored.
--#  if defined(_LIBCPP_GLIBC_PREREQ)
--#    if _LIBCPP_GLIBC_PREREQ(2, 36) && defined(__cpp_char8_t)
--#      define _LIBCPP_HAS_C8RTOMB_MBRTOC8 1
--#    else
--#      define _LIBCPP_HAS_C8RTOMB_MBRTOC8 0
--#    endif
+-#  if _LIBCPP_GLIBC_PREREQ(2, 36) && defined(__cpp_char8_t)
+-#    define _LIBCPP_HAS_C8RTOMB_MBRTOC8 1
 -#  else
 -#    define _LIBCPP_HAS_C8RTOMB_MBRTOC8 0
 -#  endif
@@ -51,5 +47,5 @@ index 1cf80a46686a..615433869a4e 100644
  // There are a handful of public standard library types that are intended to
  // support CTAD but don't need any explicit deduction guides to do so. This
 -- 
-2.43.0
+2.34.1
 


### PR DESCRIPTION
Upstream LLVM introduced changes in libcxx/include/__config that overlap with the area modified by our patch
0001-Define-_LIBCPP_HAS_C8RTOMB_MBRTOC8.patch. As a result, the patch no longer applied cleanly during git am. This PR updates and rebases the patch to reflect the upstream modifications while preserving its original functionality. No functional change beyond re-aligning with upstream is intended.

Upstream change: https://github.com/llvm/llvm-project/pull/169405