### PR TITLE
[ATfE] Add missing dependencies in install_dependencies_macos

### DIFF
--- a/arm-software/embedded/scripts/install_dependencies_macos.sh
+++ b/arm-software/embedded/scripts/install_dependencies_macos.sh
@@ -27,6 +27,8 @@ fi
 # Install required Homebrew packages if not already installed
 REQUIRED_FORMULAE=(
     ccache
+    cmake
+    ninja
     qemu
 )
 MISSING_FORMULAE=()


### PR DESCRIPTION
- We have to explicity install the required packages in self-hosted runners