### PR TITLE
[ATFE] Remove Downstream Change which enables fstream independently of filesystem.

### DIFF
--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -191,8 +191,7 @@ typedef basic_fstream<wchar_t> wfstream;
 #else
 #  include <__config>
 
-// Downstream issue: #375 (Enable fstream independently of filesystem)
-#  if _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION || defined(_NEWLIB_VERSION)
+#  if _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
 
 #    include <__algorithm/max.h>
 #    include <__assert>

--- a/libcxx/src/ios.instantiations.cpp
+++ b/libcxx/src/ios.instantiations.cpp
@@ -37,8 +37,7 @@ template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_stringstream<char>
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ostringstream<char>;
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_istringstream<char>;
 
-// Downstream issue: #375 (Enable fstream independently of filesystem)
-#if _LIBCPP_HAS_FILESYSTEM || defined(_NEWLIB_VERSION)
+#if _LIBCPP_HAS_FILESYSTEM
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ifstream<char>;
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ofstream<char>;
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_filebuf<char>;

--- a/libcxx/src/ostream.cpp
+++ b/libcxx/src/ostream.cpp
@@ -8,8 +8,7 @@
 
 #include <__config>
 
-// Downstream issue: #375 (Enable fstream independently of filesystem)
-#if _LIBCPP_HAS_FILESYSTEM || defined(_NEWLIB_VERSION)
+#if _LIBCPP_HAS_FILESYSTEM
 #  include <fstream>
 #endif
 #include <ostream>

--- a/libcxx/test/std/input.output/file.streams/fstreams/filebuf.members/native_handle.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/filebuf.members/native_handle.pass.cpp
@@ -13,8 +13,6 @@
 // class basic_filebuf;
 
 // native_handle_type native_handle() const noexcept;
-// Downstream issue: #375 (Enable fstream independently of filesystem)
-// UNSUPPORTED: baremetal
 
 #include <cassert>
 #include <fstream>

--- a/libcxx/test/std/input.output/file.streams/fstreams/filebuf.members/open_pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/filebuf.members/open_pointer.pass.cpp
@@ -14,8 +14,6 @@
 // XFAIL: (!c++03 && !c++11 && !c++14 && !c++17 && !c++20) && using-built-library-before-llvm-18
 
 // XFAIL: LIBCXX-AIX-FIXME
-// Downstream issue: #375 (Enable fstream independently of filesystem)
-// UNSUPPORTED: baremetal
 
 #include <fstream>
 #include <cassert>

--- a/libcxx/test/std/input.output/file.streams/fstreams/fstream.cons/pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/fstream.cons/pointer.pass.cpp
@@ -18,9 +18,6 @@
 
 // XFAIL: LIBCXX-AIX-FIXME
 
-// Downstream issue: #375 (Enable fstream independently of filesystem)
-// UNSUPPORTED: baremetal
-
 #include <fstream>
 #include <cassert>
 

--- a/libcxx/test/std/input.output/file.streams/fstreams/fstream.members/native_handle.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/fstream.members/native_handle.pass.cpp
@@ -13,8 +13,6 @@
 // class basic_fstream;
 
 // native_handle_type native_handle() const noexcept;
-// Downstream issue: #375 (Enable fstream independently of filesystem)
-// UNSUPPORTED: baremetal
 
 #include "test_macros.h"
 #include "../native_handle_test_helpers.h"

--- a/libcxx/test/std/input.output/file.streams/fstreams/fstream.members/open_pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/fstream.members/open_pointer.pass.cpp
@@ -17,8 +17,6 @@
 // XFAIL: (!c++03 && !c++11 && !c++14 && !c++17 && !c++20) && using-built-library-before-llvm-18
 
 // XFAIL: LIBCXX-AIX-FIXME
-// Downstream issue: #375 (Enable fstream independently of filesystem)
-// UNSUPPORTED: baremetal
 
 #include <fstream>
 #include <cassert>

--- a/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/native_handle.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/native_handle.pass.cpp
@@ -13,8 +13,6 @@
 // class basic_ifstream;
 
 // native_handle_type native_handle() const noexcept;
-// Downstream issue: #375 (Enable fstream independently of filesystem)
-// UNSUPPORTED: baremetal
 
 #include "test_macros.h"
 #include "../native_handle_test_helpers.h"

--- a/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
@@ -26,9 +26,6 @@
 // meaning it can represent file sizes up to 2GB (2^31 bytes) only.
 //
 // UNSUPPORTED: target=armv7-unknown-linux-gnueabihf
-// Downstream issue: #375 (Enable fstream independently of filesystem)
-// UNSUPPORTED: baremetal
-
 
 #include <fstream>
 #include <iostream>

--- a/libcxx/test/std/input.output/file.streams/fstreams/ofstream.cons/pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ofstream.cons/pointer.pass.cpp
@@ -18,9 +18,6 @@
 
 // XFAIL: LIBCXX-AIX-FIXME
 
-// Downstream issue: #375 (Enable fstream independently of filesystem)
-// UNSUPPORTED: baremetal
-
 #include <fstream>
 #include <cassert>
 #include <ios>

--- a/libcxx/test/std/input.output/file.streams/fstreams/ofstream.members/native_handle.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ofstream.members/native_handle.pass.cpp
@@ -13,8 +13,6 @@
 // class basic_ofstream;
 
 // native_handle_type native_handle() const noexcept;
-// Downstream issue: #375 (Enable fstream independently of filesystem)
-// UNSUPPORTED: baremetal
 
 #include "test_macros.h"
 #include "../native_handle_test_helpers.h"

--- a/libcxx/test/std/input.output/file.streams/fstreams/ofstream.members/open_pointer.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ofstream.members/open_pointer.pass.cpp
@@ -17,8 +17,6 @@
 // XFAIL: (!c++03 && !c++11 && !c++14 && !c++17 && !c++20) && using-built-library-before-llvm-18
 
 // XFAIL: LIBCXX-AIX-FIXME
-// Downstream issue: #375 (Enable fstream independently of filesystem)
-// UNSUPPORTED: baremetal
 
 #include <fstream>
 #include <cassert>

--- a/libcxx/test/std/input.output/file.streams/lit.local.cfg
+++ b/libcxx/test/std/input.output/file.streams/lit.local.cfg
@@ -2,10 +2,6 @@
 if "no-localization" in config.available_features:
     config.unsupported = True
 
-# Downstream issue: #375 (Enable fstream independently of filesystem)
 #if "no-filesystem" in config.available_features:
 #    config.unsupported = True
 
-# Downstream issue: #375 (Enable fstream independently of filesystem)
-if 'none' in config.target_triple:
-    config.available_features.add('baremetal')

--- a/libcxx/test/support/platform_support.h
+++ b/libcxx/test/support/platform_support.h
@@ -40,10 +40,6 @@
 #   include <io.h> // _mktemp_s
 #   include <fcntl.h> // _O_EXCL, ...
 #   include <sys/stat.h> // _S_IREAD, ...
-// Downstream issue: #375 (Enable fstream independently of filesystem)
-#elif defined(_NEWLIB_VERSION)
-// No need to include extra headers for the get_temp_file_name() implementation
-// below: tmpnam() is defined in <stdio.h>
 #elif __has_include(<unistd.h>)
 #  include <unistd.h> // close
 #endif
@@ -74,15 +70,6 @@ inline std::string get_temp_file_name() {
       continue;
     abort();
   }
-// Downstream issue: #375 (Enable fstream independently of filesystem)
-#elif defined(_NEWLIB_VERSION)
-  char tmp_name[L_tmpnam];
-  char *ret = tmpnam(tmp_name);
-  if (ret == NULL) {
-    perror("tmpnam");
-    abort();
-  }
-  return std::string(ret);
 #elif !__has_include(<unistd.h>)
   // Without `unistd.h` we cannot guarantee that the file is unused, however we
   // can simply generate a good guess in the temporary folder and create it.


### PR DESCRIPTION
With the merging of llvm/llvm-project#147956 upstream, the downstream patch is not required anymore.