### PR TITLE
[ATfE] Removed unused code

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -275,12 +275,6 @@ Hard-float library with target triple \"${target_triple}\" must end \"-eabihf\""
 endif()
 string(REPLACE "-none-" "-unknown-none-" normalized_target_triple ${target_triple})
 
-# This prevents a test failure due to insufficient available registers.
-# TODO: Which test, can this be fixed upstream?
-if(VARIANT STREQUAL "armv6m_soft_nofp")
-    set(compiler_rt_test_flags "${compiler_rt_test_flags} -fomit-frame-pointer")
-endif()
-
 if(ENABLE_COMPILER_RT_TESTS)
     # Generate xfails for compiler-rt.
     set(compiler_rt_lit_xfails_path "${CMAKE_CURRENT_BINARY_DIR}/${VARIANT}_compiler-rt_lit_xfails.txt")


### PR DESCRIPTION
The `armv6m_soft_nofp` variant has since been renamed, so this code is never executed. There is no similar failure observed in the current tests, so there is no reason to retain this code.