### PR TITLE
Do not use RUNTIMES_USE_LIBC=llvm-libc yet

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -908,7 +908,7 @@ if(ENABLE_CXX_LIBS)
             -DLIBCXXABI_ENABLE_STATIC_UNWINDER=${ENABLE_EXCEPTIONS}
             -DLIBCXX_ENABLE_EXCEPTIONS=${ENABLE_EXCEPTIONS}
             -DLIBCXX_ENABLE_RTTI=${ENABLE_RTTI}
-            -DRUNTIMES_USE_LIBC=llvm-libc
+            -DRUNTIMES_USE_LIBC=system # llvm-libc logic in HandleLibC.cmake is not compatible with ATfE now
             )
             set(lib_compile_flags "${lib_compile_flags} -D_LIBCPP_PRINT=1")
     elseif(C_LIBRARY MATCHES "^newlib")


### PR DESCRIPTION
Fix up for https://github.com/arm/arm-toolchain/pull/623: RUNTIMES_USE_LIBC=llvm-libc has special handling in https://github.com/llvm/llvm-project/blob/8feb6762ba9fb83f8e13ef9486c3b743e1b5cfa7/runtimes/cmake/Modules/HandleLibC.cmake#L26 that breaks ATfE build by adding -nostdlibc option.

Keep using the default system option for now, llvm-libc handling needs further investigation.