### PR TITLE
Revert "Use _LIBCPP_LIBC_NEWLIB instead of _NEWLIB_VERSION"

### DIFF
--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -192,7 +192,7 @@ typedef basic_fstream<wchar_t> wfstream;
 #  include <__config>
 
 // Downstream issue: #375 (Enable fstream independently of filesystem)
-#  if _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION || defined(_LIBCPP_LIBC_NEWLIB)
+#  if _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION || defined(_NEWLIB_VERSION)
 
 #    include <__algorithm/max.h>
 #    include <__assert>

--- a/libcxx/src/ios.instantiations.cpp
+++ b/libcxx/src/ios.instantiations.cpp
@@ -38,7 +38,7 @@ template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ostringstream<char
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_istringstream<char>;
 
 // Downstream issue: #375 (Enable fstream independently of filesystem)
-#if _LIBCPP_HAS_FILESYSTEM || defined(_LIBCPP_LIBC_NEWLIB)
+#if _LIBCPP_HAS_FILESYSTEM || defined(_NEWLIB_VERSION)
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ifstream<char>;
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ofstream<char>;
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_filebuf<char>;

--- a/libcxx/src/ostream.cpp
+++ b/libcxx/src/ostream.cpp
@@ -9,7 +9,7 @@
 #include <__config>
 
 // Downstream issue: #375 (Enable fstream independently of filesystem)
-#if _LIBCPP_HAS_FILESYSTEM || defined(_LIBCPP_LIBC_NEWLIB)
+#if _LIBCPP_HAS_FILESYSTEM || defined(_NEWLIB_VERSION)
 #  include <fstream>
 #endif
 #include <ostream>

--- a/libcxx/test/support/platform_support.h
+++ b/libcxx/test/support/platform_support.h
@@ -41,7 +41,7 @@
 #   include <fcntl.h> // _O_EXCL, ...
 #   include <sys/stat.h> // _S_IREAD, ...
 // Downstream issue: #375 (Enable fstream independently of filesystem)
-#elif defined(_LIBCPP_LIBC_NEWLIB)
+#elif defined(_NEWLIB_VERSION)
 // No need to include extra headers for the get_temp_file_name() implementation
 // below: tmpnam() is defined in <stdio.h>
 #elif __has_include(<unistd.h>)
@@ -75,7 +75,7 @@ inline std::string get_temp_file_name() {
     abort();
   }
 // Downstream issue: #375 (Enable fstream independently of filesystem)
-#elif defined(_LIBCPP_LIBC_NEWLIB)
+#elif defined(_NEWLIB_VERSION)
   char tmp_name[L_tmpnam];
   char *ret = tmpnam(tmp_name);
   if (ret == NULL) {


### PR DESCRIPTION
This reverts commit 0e0a681fd692ba3e05897ad7f25807e472eea1e0.

I have verified that after applying this revert I can build ATfL successfully again.

Downstream issue: #375