### PR TITLE
[ATfE] Remove unused code

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -405,19 +405,6 @@ if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL llvmlibc)
       DESTINATION samples
       COMPONENT llvm-toolchain-llvmlibc-configs
     )
-
-    # LLVM libc lacks a configuration for AArch64, but the AArch32 one works
-    # fine. However, setting the configuration for both architectures to the
-    # arm config directory means the baremetal config.json is never loaded,
-    # as it resides in the directory above. To ensure both are used, copy
-    # them to the same location and point libc to that.
-    set(LIBC_CFG_DIR ${CMAKE_BINARY_DIR}/llvmlibc-config)
-    file(COPY
-        ${llvmproject_src_dir}/libc/config/baremetal/config.json
-        ${llvmproject_src_dir}/libc/config/baremetal/arm/.
-        DESTINATION
-        ${LIBC_CFG_DIR}
-    )
 endif()
 
 get_directory_property(LLVM_VERSION_MAJOR DIRECTORY ${llvmproject_src_dir}/llvm DEFINITION LLVM_VERSION_MAJOR)


### PR DESCRIPTION
This code block is left over from when the top-level CMake project handled building llvmlibc. This functionality was moved to the `arm-runtimes` CMake project, and this particular workaround was ultimately removed in commit 502ae48. It is both in the wrong place and unnecessary.