### PR TITLE
[ATfE] Provide clang-scan-deps utility

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -208,6 +208,7 @@ set(BUG_REPORT_URL "https://github.com/arm/arm-toolchain/issues" CACHE STRING ""
 set(LLVM_DISTRIBUTION_COMPONENTS
     clang-resource-headers
     clang
+    clang-scan-deps
     dsymutil
     elf2bin
     lld


### PR DESCRIPTION
Include clang-scan-deps utility into the package to enable C++20 module support.