### PR TITLE
[ATfE] Rename xfail after test name change

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/xfails.py
+++ b/arm-software/embedded/arm-runtimes/test-support/xfails.py
@@ -354,7 +354,7 @@ def main():
             testnames=[
                 "semihost-seek.test",
                 "test-fread-fwrite.test",
-                "posix-io.test",
+                "test-posix-io.test",
             ],
             result=NewResult.XFAILED,
             project="picolibc",


### PR DESCRIPTION
The picolibc posix-io test was recently renamed to test-posix-io so the downstream xfail needs renaming also.