### PR TITLE
[ATfE] Enable iostream with llvm libc

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -910,7 +910,7 @@ if(ENABLE_CXX_LIBS)
             -DLIBCXX_ENABLE_RTTI=${ENABLE_RTTI}
             -DRUNTIMES_USE_LIBC=system # llvm-libc logic in HandleLibC.cmake is not compatible with ATfE now
             )
-            set(lib_compile_flags "${lib_compile_flags} -D_LIBCPP_PRINT=1 -D_LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE")
+            set(lib_compile_flags "${lib_compile_flags} -D_LIBCPP_PRINT=1 -D__LLVM_LIBC__=1")
     elseif(C_LIBRARY MATCHES "^newlib")
         set(cxxlibs_extra_cmake_options
             -DLIBCXXABI_ENABLE_THREADS=OFF


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/168931 was merged with basic stdio implementation, it is now possible to enable iostream with llvm libc.

_LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE seems to be defined here https://github.com/llvm/llvm-project/blob/7976ac990000a58a7474269a3ca95e16aed8c35b/libcxx/include/__config#L720 with __LLVM_LIBC__ however it is not enough - there may be a cleaner upstream fix for this.