### PR TITLE
[ATfE] Remove picolibc reference to COPYING.NEWLIB

### DIFF
--- a/arm-software/embedded/cmake/THIRD-PARTY-LICENSES.txt.in
+++ b/arm-software/embedded/cmake/THIRD-PARTY-LICENSES.txt.in
@@ -7,6 +7,6 @@ additional or alternate licenses:
  - libc++: third-party-licenses/LIBCXX-LICENSE.txt
  - libc++abi: third-party-licenses/LIBCXXABI-LICENSE.txt
  - libunwind: third-party-licenses/LIBUNWIND-LICENSE.txt
- - Picolibc: third-party-licenses/COPYING.NEWLIB, third-party-licenses/COPYING.picolibc${mingw_runtime_dlls}
+ - Picolibc: third-party-licenses/COPYING.picolibc${mingw_runtime_dlls}
 
 Picolibc licenses refer to its source files. Sources are identified in VERSION.txt.


### PR DESCRIPTION
COPYING.NEWLIB was removed from picolibc in https://github.com/picolibc/picolibc/commit/0174a6f9b5b3f9607aeba868a0bdc38b093b04bc - COPYING.picolibc provides all required information.