### PR TITLE
[ATfL] Use BASE_DIR to point at the git repo

### DIFF
--- a/arm-software/linux/build.sh
+++ b/arm-software/linux/build.sh
@@ -38,7 +38,7 @@ LLVM_VERSION_MAJOR=$(cat ${SOURCES_DIR}/cmake/Modules/LLVMVersion.cmake | grep -
 LLVM_VERSION_MINOR=$(cat ${SOURCES_DIR}/cmake/Modules/LLVMVersion.cmake | grep -i set | grep LLVM_VERSION_MINOR | grep -o '[0-9]\+')
 LLVM_VERSION_PATCH=$(cat ${SOURCES_DIR}/cmake/Modules/LLVMVersion.cmake | grep -i set | grep LLVM_VERSION_PATCH | grep -o '[0-9]\+')
 TOOLCHAIN_VERSION="${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}"
-ATFL_GIT_BRANCH=$(git branch --show-current)
+ATFL_GIT_BRANCH="$(git -C "${BASE_DIR}" branch --show-current)"
 if [[ "${ATFL_GIT_BRANCH}" == "arm-software" ]]
 then
   TOOLCHAIN_VERSION="0.0"


### PR DESCRIPTION
This script may be executed from different current directories, BASE_DIR helps to find its git repo (similarly to how it has been done a few lines above).