### PR TITLE
[ATfL] Do not query for the branch name

### DIFF
--- a/arm-software/linux/build.sh
+++ b/arm-software/linux/build.sh
@@ -38,12 +38,11 @@ LLVM_VERSION_MAJOR=$(cat ${SOURCES_DIR}/cmake/Modules/LLVMVersion.cmake | grep -
 LLVM_VERSION_MINOR=$(cat ${SOURCES_DIR}/cmake/Modules/LLVMVersion.cmake | grep -i set | grep LLVM_VERSION_MINOR | grep -o '[0-9]\+')
 LLVM_VERSION_PATCH=$(cat ${SOURCES_DIR}/cmake/Modules/LLVMVersion.cmake | grep -i set | grep LLVM_VERSION_PATCH | grep -o '[0-9]\+')
 TOOLCHAIN_VERSION="${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}"
-ATFL_GIT_BRANCH="$(git -C "${BASE_DIR}" branch --show-current)"
-if [[ "${ATFL_GIT_BRANCH}" == "arm-software" ]]
+ATFL_VERSION=${ATFL_VERSION:-"${TOOLCHAIN_VERSION}"}
+if [[ "${ATFL_VERSION}" == "0.0" ]]
 then
   TOOLCHAIN_VERSION="0.0"
 fi
-ATFL_VERSION=${ATFL_VERSION:-"${TOOLCHAIN_VERSION}"}
 OS_NAME=${OS_NAME:-"linux"}
 TAR_NAME=${TAR_NAME:-"atfl-${ATFL_VERSION}-${OS_NAME}-`uname -m`.tar.gz"}
 ATFL_ASSERTIONS=${ATFL_ASSERTIONS:-"ON"}


### PR DESCRIPTION
Since we rarely build from the top of a branch, we should not query for its name when deciding about a version name or about anything else.