### PR TITLE
[ATfE] Redirect libc abort() to semihosting exit

### DIFF
--- a/arm-software/embedded/llvmlibc-support/semihost/semihost.cpp
+++ b/arm-software/embedded/llvmlibc-support/semihost/semihost.cpp
@@ -26,7 +26,7 @@ void stdio_open(struct __llvm_libc_stdio_cookie *cookie, size_t mode) {
 
 extern "C" {
 
-void semihosting_call_exit(int status) {
+static void semihosting_call_exit(int status) {
 
 #if defined(__ARM_64BIT_STATE) && __ARM_64BIT_STATE
   size_t block[2];


### PR DESCRIPTION
The default libc abort() traps, thus exception handlers under semihosting crash QEMU because of nested exceptions - redirect abort() to semihosting exit instead to cleanly finish execution with QEMU.