### PR TITLE
[ATfE] xfail no-flash version of picolibc test

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/xfails.py
+++ b/arm-software/embedded/arm-runtimes/test-support/xfails.py
@@ -462,6 +462,7 @@ def main():
             name="picolibc_serial_test",
             testnames=[
                 "test-hello-raw.test",
+                "test-hello-raw-no-flash.test",
             ],
             result=NewResult.EXCLUDE,
             project="picolibc",


### PR DESCRIPTION
The test-hello-raw-no-flash picolibc test times out for the same reason as test-hello-raw currently does, since the messaging on the serial port is not currently implemented.