### PR TITLE
[ATFE] Add XFAIL for targets lacking hardware CAS support for non power of two atomic operations.

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/xfails.py
+++ b/arm-software/embedded/arm-runtimes/test-support/xfails.py
@@ -313,22 +313,22 @@ def main():
                 "armv4t_size",
                 "armv5te_exn_rtti_size",
                 "armv5te_size",
-                "armv6m_soft_nofp_exn_rtti_size"
-                "armv6m_soft_nofp_size"
-                "armv7m_hard_fpv4_sp_d16_exn_rtti_size"
-                "armv7m_hard_fpv4_sp_d16_exn_rtti_unaligned_size"
-                "armv7m_hard_fpv4_sp_d16_size"
-                "armv7m_hard_fpv4_sp_d16_unaligned_size"
-                "armv7m_hard_fpv5_d16_exn_rtti_unaligned_size"
-                "armv7m_hard_fpv5_d16_unaligned_size"
-                "armv7m_soft_fpv4_sp_d16_exn_rtti_size"
-                "armv7m_soft_fpv4_sp_d16_exn_rtti_unaligned_size"
-                "armv7m_soft_fpv4_sp_d16_size"
-                "armv7m_soft_fpv4_sp_d16_unaligned_size"
-                "armv7m_soft_nofp_exn_rtti_size"
-                "armv7m_soft_nofp_exn_rtti_unaligned_size"
-                "armv7m_soft_nofp_size"
-                "armv7m_soft_nofp_unaligned_size"
+                "armv6m_soft_nofp_exn_rtti_size",
+                "armv6m_soft_nofp_size",
+                "armv7m_hard_fpv4_sp_d16_exn_rtti_size",
+                "armv7m_hard_fpv4_sp_d16_exn_rtti_unaligned_size",
+                "armv7m_hard_fpv4_sp_d16_size",
+                "armv7m_hard_fpv4_sp_d16_unaligned_size",
+                "armv7m_hard_fpv5_d16_exn_rtti_unaligned_size",
+                "armv7m_hard_fpv5_d16_unaligned_size",
+                "armv7m_soft_fpv4_sp_d16_exn_rtti_size",
+                "armv7m_soft_fpv4_sp_d16_exn_rtti_unaligned_size",
+                "armv7m_soft_fpv4_sp_d16_size",
+                "armv7m_soft_fpv4_sp_d16_unaligned_size",
+                "armv7m_soft_nofp_exn_rtti_size",
+                "armv7m_soft_nofp_exn_rtti_unaligned_size",
+                "armv7m_soft_nofp_size",
+                "armv7m_soft_nofp_unaligned_size",
             ],
             description="target lacks hardware CAS for non-power-of-two atomic object sizes",
         ),


### PR DESCRIPTION
After updating to LLVM 23, atomics_types_generic.cas_non_power_of_2.pass.cpp started running on several ARM targets where it was previously skipped.

On armv4t, armv5te, and armv6m there is no sufficient hardware atomic instructions to implement atomic inline, and armv7m have some inline atomic capability (up to 4 bytes), the generic load/compare_exchange paths required by this test rely on missing __atomic_* helpers.

Mark this test as XFAIL on these targets to reflect the architectural/runtime limitations.