### PR TITLE
[ATfE] Remove __LLVM_LIBC__ define workaround for libcxx

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -941,7 +941,7 @@ if(ENABLE_CXX_LIBS)
             -DLIBCXX_ENABLE_RTTI=${ENABLE_RTTI}
             -DRUNTIMES_USE_LIBC=llvm-libc
             )
-            set(lib_compile_flags "${lib_compile_flags} -D_LIBCPP_PRINT=1 -D__LLVM_LIBC__=1")
+            set(lib_compile_flags "${lib_compile_flags} -D_LIBCPP_PRINT=1")
     elseif(C_LIBRARY MATCHES "^newlib")
         set(cxxlibs_extra_cmake_options
             -DLIBCXXABI_ENABLE_THREADS=OFF


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/174967 RUNTIMES_USE_LIBC=llvm-libc option provides all necessary defines for libcxx to work with LLVM libc.