### PR TITLE
[ATfE] Replace call to abort with __llvm_libc_exit in libc startup code

### DIFF
--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions_7a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions_7a.h
@@ -40,7 +40,7 @@ static bool is_in_hyp_mode() {
 
 EXFN_ATTR void handle_reset() {
   print_str("CPU Exception: Reset\n");
-  abort();
+  __llvm_libc_exit(1);
 }
 
 EXFN_ATTR void handle_undefined() {
@@ -56,7 +56,7 @@ EXFN_ATTR void handle_undefined() {
   print_str("  Instruction (second half word) = ");
   print_hex(half_word1);
   print_str("\n");
-  abort();
+  __llvm_libc_exit(1);
 }
 
 EXFN_ATTR void handle_svc_hyp_smc() {
@@ -64,7 +64,7 @@ EXFN_ATTR void handle_svc_hyp_smc() {
   print_str("  PC = ");
   print_hex(GET_LR_VALUE());
   print_str("\n");
-  abort();
+  __llvm_libc_exit(1);
 }
 
 EXFN_ATTR void handle_prefetch_abort() {
@@ -74,7 +74,7 @@ EXFN_ATTR void handle_prefetch_abort() {
   print_str("\n");
   print_str("  IFSR = 0x%08x\n");
   print_str("  IFAR = 0x%08x\n");
-  abort();
+  __llvm_libc_exit(1);
 }
 
 EXFN_ATTR void handle_data_abort() {
@@ -84,7 +84,7 @@ EXFN_ATTR void handle_data_abort() {
   print_str("\n");
   print_str("  DFSR = 0x%08x\n");
   print_str("  DFAR = 0x%08x\n");
-  abort();
+  __llvm_libc_exit(1);
 }
 
 EXFN_ATTR void handle_hyp_trap() {
@@ -93,7 +93,7 @@ EXFN_ATTR void handle_hyp_trap() {
   print_hex(GET_LR_VALUE());
   print_str("\n");
   print_str("  HSR = 0x%08x\n");
-  abort();
+  __llvm_libc_exit(1);
 }
 
 EXFN_ATTR void handle_irq() {
@@ -101,7 +101,7 @@ EXFN_ATTR void handle_irq() {
   print_str("  PC = ");
   print_hex(GET_LR_VALUE());
   print_str("\n");
-  abort();
+  __llvm_libc_exit(1);
 }
 
 EXFN_ATTR void handle_fiq() {
@@ -109,7 +109,7 @@ EXFN_ATTR void handle_fiq() {
   print_str("  PC = ");
   print_hex(GET_LR_VALUE());
   print_str("\n");
-  abort();
+  __llvm_libc_exit(1);
 }
 
 // The AArch32 exception vector table has 8 entries, each of which is 4

--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions_8a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions_8a.h
@@ -198,7 +198,7 @@ EXFN_ATTR void exception_handler() {
   }
 
   // Stop execution
-  abort();
+  __llvm_libc_exit(1);
 }
 
 // The AArch64 exception vector table has 16 entries, each of which is 128

--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions_common.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions_common.h
@@ -70,4 +70,7 @@ EXFN_ATTR inline void print_hex(T val, bool print_leading_zeros = true) {
 } // namespace exceptions
 } // namespace bootcode
 
+// LLVM libc defined platform specific exit handler
+extern "C" [[noreturn]] void __llvm_libc_exit(int status);
+
 #endif // BOOTCODE_EXCEPTIONS_COMMON_H

--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions_m.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions_m.h
@@ -42,7 +42,7 @@ EXFN_ATTR void __print_faulting_instruction(unsigned short *ptr) {
     print_hex(first);
     print_str("\n");
   }
-  abort();
+  __llvm_libc_exit(1);
 }
 
 EXFN_ATTR void __hardfault_handler() {
@@ -126,7 +126,7 @@ EXFN_ATTR void __securefault_handler() {
 extern "C" unsigned int __systick_count = 0;
 EXFN_ATTR void __systick_handler() { __systick_count += 1; }
 
-EXFN_ATTR void __exception_handler() { abort(); }
+EXFN_ATTR void __exception_handler() { __llvm_libc_exit(1); }
 
 // Architecturally the bottom 7 bits of VTOR are zero, meaning the vector table
 // has to be 128-byte aligned, however an implementation can require more bits
@@ -177,7 +177,7 @@ void setup() {
     VTOR = reinterpret_cast<unsigned long>(&vector_table);
     if (VTOR != reinterpret_cast<unsigned long>(&vector_table)) {
       print_str("Bootcode failed to set VTOR\n");
-      abort();
+      __llvm_libc_exit(1);
     }
   }
 

--- a/arm-software/embedded/llvmlibc-support/semihost/semihost.cpp
+++ b/arm-software/embedded/llvmlibc-support/semihost/semihost.cpp
@@ -51,13 +51,6 @@ void __llvm_libc_exit(int status) {
   semihosting_call_exit(status);
 }
 
-void abort() {
-  // Cleanly exit via semihosting
-  // instead of trapping in the default abort() implementation
-  semihosting_call_exit(1);
-  __builtin_unreachable();
-}
-
 struct __llvm_libc_stdio_cookie __llvm_libc_stdin_cookie;
 struct __llvm_libc_stdio_cookie __llvm_libc_stdout_cookie;
 struct __llvm_libc_stdio_cookie __llvm_libc_stderr_cookie;


### PR DESCRIPTION
LLVM libc does not provide a way to redefine abort(), thus the local abort() definition in LLVM libc semihosting has to be removed.

Calls to abort() in LLVM libc crt0 replaced with __llvm_libc_exit() which is the LLVM libc defined platform specific exit handler.

This prevents exception handlers from crashing because of the trap instruction in LLVM libc implementation of abort().