### PR TITLE
[libc++] Provide flag for RUNTIMES_USE_LIBC=llvm-libc (#174967)

### DIFF
--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -777,6 +777,8 @@ if (RUNTIMES_USE_LIBC STREQUAL "picolibc")
   config_define(1 _LIBCPP_LIBC_NEWLIB)
 elseif (RUNTIMES_USE_LIBC STREQUAL "newlib")
   config_define(1 _LIBCPP_LIBC_NEWLIB)
+elseif (RUNTIMES_USE_LIBC STREQUAL "llvm-libc")
+  config_define(1 _LIBCPP_LIBC_LLVM_LIBC)
 endif()
 
 # TODO: Remove in LLVM 21. We're leaving an error to make this fail explicitly.

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -706,7 +706,7 @@ typedef __char32_t char32_t;
 #  endif
 
 #  if defined(__BIONIC__) || defined(__NuttX__) || defined(__Fuchsia__) || defined(__wasi__) ||                        \
-      _LIBCPP_HAS_MUSL_LIBC || defined(__OpenBSD__) || defined(__LLVM_LIBC__)
+      _LIBCPP_HAS_MUSL_LIBC || defined(__OpenBSD__) || _LIBCPP_LIBC_LLVM_LIBC
 #    define _LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE
 #  endif
 

--- a/libcxx/include/__config_site.in
+++ b/libcxx/include/__config_site.in
@@ -45,6 +45,7 @@
 // C libraries
 #cmakedefine01 _LIBCPP_LIBC_PICOLIBC
 #cmakedefine01 _LIBCPP_LIBC_NEWLIB
+#cmakedefine01 _LIBCPP_LIBC_LLVM_LIBC
 
 // __USE_MINGW_ANSI_STDIO gets redefined on MinGW
 #ifdef __clang__

--- a/libcxx/include/__random/binomial_distribution.h
+++ b/libcxx/include/__random/binomial_distribution.h
@@ -98,7 +98,7 @@ public:
 };
 
 // Some libc declares the math functions to be `noexcept`.
-#if _LIBCPP_GLIBC_PREREQ(2, 8) || defined(__LLVM_LIBC__)
+#if _LIBCPP_GLIBC_PREREQ(2, 8) || _LIBCPP_LIBC_LLVM_LIBC
 #  define _LIBCPP_LGAMMA_R_NOEXCEPT _NOEXCEPT
 #else
 #  define _LIBCPP_LGAMMA_R_NOEXCEPT

--- a/libcxx/src/chrono.cpp
+++ b/libcxx/src/chrono.cpp
@@ -31,7 +31,7 @@
 #  include <sys/time.h> // for gettimeofday and timeval
 #endif
 
-#if defined(__LLVM_LIBC__)
+#if _LIBCPP_LIBC_LLVM_LIBC
 #  define _LIBCPP_HAS_TIMESPEC_GET
 #endif
 

--- a/libcxx/src/filesystem/filesystem_clock.cpp
+++ b/libcxx/src/filesystem/filesystem_clock.cpp
@@ -32,7 +32,7 @@
 #  include <sys/time.h> // for gettimeofday and timeval
 #endif
 
-#if defined(__LLVM_LIBC__)
+#if _LIBCPP_LIBC_LLVM_LIBC
 #  define _LIBCPP_HAS_TIMESPEC_GET
 #endif
 

--- a/libcxx/src/include/config_elast.h
+++ b/libcxx/src/include/config_elast.h
@@ -21,7 +21,7 @@
 // where strerror/strerror_r can't handle out-of-range errno values.
 #if defined(ELAST)
 #  define _LIBCPP_ELAST ELAST
-#elif defined(__LLVM_LIBC__)
+#elif _LIBCPP_LIBC_LLVM_LIBC
 // No _LIBCPP_ELAST needed for LLVM libc
 #elif _LIBCPP_LIBC_NEWLIB
 #  define _LIBCPP_ELAST __ELASTERROR


### PR DESCRIPTION
There was no flag added for llvm-libc when picolibc and newlib were provided in https://github.com/llvm/llvm-project/pull/147956 - the missing flag breaks libc++ iostream support now because this check https://github.com/llvm/llvm-project/blob/9a8421fa6191d2e1047e3dc8c72a22fa810f9aee/libcxx/include/__config#L719 fails unless an LLVM libc header is included.
Downstream issue: #690