### PR TITLE
[ATfE] Fix bad merge in semihosting after cherry-picks

### DIFF
--- a/arm-software/embedded/llvmlibc-support/semihost/semihost.cpp
+++ b/arm-software/embedded/llvmlibc-support/semihost/semihost.cpp
@@ -25,7 +25,7 @@ void stdio_open(struct __llvm_libc_stdio_cookie *cookie, size_t mode) {
 
 extern "C" {
 
-void __llvm_libc_exit(int status) {
+static void semihosting_call_exit(int status) {
 
 #if defined(__ARM_64BIT_STATE) && __ARM_64BIT_STATE
   size_t block[2];


### PR DESCRIPTION
There were multiple cherry-picks from arm-software with a conflict that was resolved with an issue in semihosting_call_exit declaration.