### PR TITLE
[ATfE] Remove the check preventing FVP testing of LLVM libc

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -843,10 +843,6 @@ if(C_LIBRARY STREQUAL llvmlibc)
     )
 
     if(ENABLE_LIBC_TESTS)
-        if(NOT(TEST_EXECUTOR STREQUAL qemu))
-            message(FATAL_ERROR "LLVM-libc tests are only able to run on QEMU.")
-        endif()
-
         add_custom_target(check-llvmlibc)
         add_dependencies(check-all check-llvmlibc)
 


### PR DESCRIPTION
This check was actual when there was hardcoded QEMU invocation, now LLVM libc testing uses the same wrapper scripts as picolibc thus works with FVPs too.