### PR TITLE
Update an xfail for a renamed libc++ test

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/xfails.py
+++ b/arm-software/embedded/arm-runtimes/test-support/xfails.py
@@ -219,7 +219,7 @@ def main():
                 "std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_deallocate.pass.cpp",
                 "std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_from_initial_buffer.pass.cpp",
                 "std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_from_zero_sized_buffer.pass.cpp",
-                "std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_in_geometric_progression.pass.cpp",
+                "std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_mem.pass.cpp",
                 "std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_overaligned_request.pass.cpp",
                 "std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_with_initial_size.pass.cpp",
                 "std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/equality.pass.cpp",


### PR DESCRIPTION
In the `mem.res.monotonic.buffer` test subdirectory, upstream commit c3564b09f7f6c72 renamed `allocate_in_geometric_progression.pass.cpp` to the more generic `allocate_mem.pass.cpp`. We had that test xfailed (along with many others) on older Arm architecture versions, on the grounds that it requires some atomic functions that those architectures don't support. Update the xfail to refer to the new name.