### PR TITLE
[patches][picolibc][aarch64] Initialize SME

### DIFF
--- a/arm-software/embedded/patches/picolibc/0004-Add-SME-support-initialization.patch
+++ b/arm-software/embedded/patches/picolibc/0004-Add-SME-support-initialization.patch
@@ -1,0 +1,68 @@
+From 4bbe72b4dc2215e1799f3cff9054e3c8bfff253e Mon Sep 17 00:00:00 2001
+From: Amilendra Kodithuwakku <amilendra.kodithuwakku@arm.com>
+Date: Thu, 29 Jan 2026 16:45:01 +0000
+Subject: [PATCH] [picolibc][SME] Initialize SME during C-runtime
+ initialization (crt0)
+
+Check if SME or SME2 is enabled and do the following
+
+1. Clear TPIDR2_EL0 [1]
+The value of TPIDR2_EL0 resets to an architecturally UNKNOWN value
+at warm reset.
+This means we need to clear it manually at startup.
+
+2. Initialise SME Streaming SVE Vector length to 2048 bits
+Initialize the SME control register SMCR_EL3 [2] to set the
+effective streaming SVE vector length to the maximum supported
+value of 2048 bits.
+
+[1] https://developer.arm.com/documentation/ddi0601/2025-09/AArch64-Registers/TPIDR2-EL0--EL0-Read-Write-Software-Thread-ID-Register-2?lang=en
+[2] https://developer.arm.com/documentation/ddi0601/2025-09/AArch64-Registers/SMCR-EL3--SME-Control-Register--EL3-?lang=en
+---
+ picocrt/machine/aarch64/crt0.S | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/picocrt/machine/aarch64/crt0.S b/picocrt/machine/aarch64/crt0.S
+index 831a57677..4e4dc5942 100644
+--- a/picocrt/machine/aarch64/crt0.S
++++ b/picocrt/machine/aarch64/crt0.S
+@@ -40,6 +40,9 @@
+ 
+ #define MMU_INVALID_FLAGS       0
+ 
++#define FEAT_SME_1      (1LL << 24)
++#define FEAT_SME_2      (1LL << 25)
++
+   .macro start_page_table
+   .section .rodata
+   .global __identity_page_table
+@@ -136,6 +139,26 @@ _start:
+ #endif
+ #endif // __ARM_FP
+ 
++	/* Determine if SME or SME2 is available */
++	mrs     x0, id_aa64pfr1_el1
++	tst     x0, (FEAT_SME_1|FEAT_SME_2)
++	b.eq    .Lnosme
++
++	/* Clear TPIDR2_EL0 */
++	msr     S3_3_C13_C0_5, xzr
++	isb
++
++	/* set up Streaming SVE Vector Length (SVL) in SMCR_EL3 (4 LSB). */
++	mov     x2, #0xF
++
++	/* Try to set the maximum value supported by the architecture (2048). */
++	mrs     x1, s3_6_c1_c2_6 /* mrs  x1, smcr_el3 */
++	bfi     x1, x2, 0, 4
++	msr     s3_6_c1_c2_6, x1 /* msr  smcr_el3, x1 */
++	isb
++
++.Lnosme:
++
+ 	/* Jump into C code */
+ 	bl _cstart
+   .size _start, .-_start
+-- 
+2.34.1
+

--- a/arm-software/embedded/patches/picolibc/0005-add_aarch64_sme_accessible.patch
+++ b/arm-software/embedded/patches/picolibc/0005-add_aarch64_sme_accessible.patch
@@ -1,0 +1,38 @@
+From 328e99571dc59093dd0dfd7a73707abd651f69ad Mon Sep 17 00:00:00 2001
+From: Amilendra Kodithuwakku <amilendra.kodithuwakku@arm.com>
+Date: Thu, 29 Jan 2026 09:19:13 +0000
+Subject: [PATCH] [picolibc][SME] Add implementation of the
+ __aarch64_sme_accessible
+
+compiler-rt relies on the the __aarch64_sme_accessible support
+function to emit SME ABI support routines calls [1].
+__aarch64_sme_accessible returns non-zero when SME support is
+enabled in the underlying hardware.
+
+[1] https://github.com/llvm/llvm-project/commit/2b05fa8f0be7e38f4b4364ea855a3d200ded7480
+---
+ picocrt/machine/aarch64/crt0.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/picocrt/machine/aarch64/crt0.c b/picocrt/machine/aarch64/crt0.c
+index 41b90545f..95d37a323 100644
+--- a/picocrt/machine/aarch64/crt0.c
++++ b/picocrt/machine/aarch64/crt0.c
+@@ -60,6 +60,14 @@ _set_tls(void *tls)
+     __asm__ volatile("msr tpidr_el0, %x0" : : "r"(tls - TP_OFFSET));
+ }
+ 
++int __aarch64_sme_accessible() {
++  int result = 0;
++  __asm__ volatile ("mrs %x[result], id_aa64pfr1_el1" : [result]"=r"(result) :  : );
++  /* Although the ISA reserves BITS 24~27 for SME, at this point of time,
++     only BITS 24 (SME) and 25 (SME + SME2 ZT0 register) have meaning.*/
++  return (result & 0x3000000) != 0;
++}
++
+ #include "../../crt0.h"
+ 
+ /* Defined in crt0.S */
+-- 
+2.34.1
+


### PR DESCRIPTION
These two patches add the following needed for SME support in picolibc

1. If SME or SME2 is enabled,

1.1 Clear TPIDR2_EL0 [1]
The value of TPIDR2_EL0 resets to an architecturally UNKNOWN value at warm reset. This means we need to clear it manually at startup.

1.2 Initialise SME Streaming SVE Vector length to 2048 bits Initialize the SME control register SMCR_EL3 [2] to set the effective streaming SVE vector length to the maximum supported value of 2048 bits.

2. Add implementation of the __aarch64_sme_accessible

compiler-rt relies on the the __aarch64_sme_accessible support function to emit SME ABI support routines calls [3]. __aarch64_sme_accessible returns non-zero when SME support is enabled in the underlying hardware.

[1] https://developer.arm.com/documentation/ddi0601/2025-09/AArch64-Registers/TPIDR2-EL0--EL0-Read-Write-Software-Thread-ID-Register-2?lang=en
[2] https://developer.arm.com/documentation/ddi0601/2025-09/AArch64-Registers/SMCR-EL3--SME-Control-Register--EL3-?lang=en
[3] https://github.com/llvm/llvm-project/commit/2b05fa8f0be7e38f4b4364ea855a3d200ded7480