### PR TITLE
Initialize SME system registers.

### DIFF
--- a/arm-software/embedded/patches/newlib/0002-Initialize-SME-regs.patch
+++ b/arm-software/embedded/patches/newlib/0002-Initialize-SME-regs.patch
@@ -1,0 +1,66 @@
+From 53166afd09c868d1604fa1dc3cff4175041b5b62 Mon Sep 17 00:00:00 2001
+From: Amilendra Kodithuwakku <amilendra.kodithuwakku@arm.com>
+Date: Wed, 28 Jan 2026 07:01:48 +0000
+Subject: [PATCH] Initialize SME system registers.
+
+Check if SME or SME2 is enabled and do the following
+
+1. Clear TPIDR2_EL0 [1]
+The value of TPIDR2_EL0 resets to an architecturally UNKNOWN value
+at warm reset.
+This means we need to clear it manually at startup.
+
+2. Set ESM (bit 12) of the CPTR_EL3 register [2]
+
+3. Initialise SME Streaming SVE Vector length to 2048 bits
+Initialize the SME control register SMCR_EL3 [3] to set the
+effective streaming SVE vector length to the maximum supported
+value of 2048 bits.
+
+[1] https://developer.arm.com/documentation/ddi0601/latest/AArch64-Registers/TPIDR2-EL0--EL0-Read-Write-Software-Thread-ID-Register-2?lang=en
+[2] https://developer.arm.com/documentation/ddi0601/latest/AArch64-Registers/CPTR-EL3--Architectural-Feature-Trap-Register--EL3-?lang=en
+[3] https://developer.arm.com/documentation/ddi0601/latest/AArch64-Registers/SMCR-EL3--SME-Control-Register--EL3-?lang=en
+---
+ libgloss/aarch64/cpu-init/rdimon-aem-el3.S | 26 ++++++++++++++++++++++
+ 1 file changed, 26 insertions(+)
+
+diff --git a/libgloss/aarch64/cpu-init/rdimon-aem-el3.S b/libgloss/aarch64/cpu-init/rdimon-aem-el3.S
+index 0296a8054..21890e4be 100644
+--- a/libgloss/aarch64/cpu-init/rdimon-aem-el3.S
++++ b/libgloss/aarch64/cpu-init/rdimon-aem-el3.S
+@@ -182,6 +182,32 @@ _flat_map:
+        msr     s3_6_c1_c2_0, x1                /* msr  zcr_el3, x1.  */
+        isb
+ .Lnosve:
++       /* Determine if SME (bit 24) or SME2 (bit 25) is available */
++       mrs     x0, id_aa64pfr1_el1
++       tst     x0, 0x3000000
++       b.eq    .Lnosme
++
++       /* set up CPTR_EL3.ESM to 1 */
++       mrs     x1, cptr_el3
++       /* ESM is bit 12 of CPTR_EL3 */
++       orr     x1, x1, 0x1000
++       msr     cptr_el3, x1
++       isb
++
++       /* Clear TPIDR2_EL0 */
++       msr     s3_3_c13_c0_5, xzr
++       isb
++
++       /* Set up SMCR_EL3.LEN and SMCR_EL3.EZT0 */
++       mrs     x1, s3_6_c1_c2_6                /* mrs  x1, smcr_el3 */
++       mov     x2, #0xF
++       bfi     x1, x2, 0, 4                    /* Try to set maximum value supported by the architecture (2048) */
++       lsr     x2, x0, #25
++       bfi     x1, x2, 30, 1                   /* Set EZT0 in SMCR_EL3 (bit 30) when SME2 is available */
++       msr     s3_6_c1_c2_6, x1                /* msr  smcr_el3, x1 */
++       isb
++
++.Lnosme:
+ 	ret
+ #endif
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
Check if SME or SME2 is enabled and do the following

1. Clear TPIDR2_EL0 [1] The value of TPIDR2_EL0 resets to an architecturally UNKNOWN value at warm reset.
This means we need to clear it manually at startup.

2. Set ESM (bit 12) of the CPTR_EL3 register [2]

3. Initialise SME Streaming SVE Vector length to 2048 bits Initialize the SME control register SMCR_EL3 [3] to set the effective streaming SVE vector length to the maximum supported value of 2048 bits.

[1] https://developer.arm.com/documentation/ddi0601/latest/AArch64-Registers/TPIDR2-EL0--EL0-Read-Write-Software-Thread-ID-Register-2?lang=en
[2] https://developer.arm.com/documentation/ddi0601/latest/AArch64-Registers/CPTR-EL3--Architectural-Feature-Trap-Register--EL3-?lang=en
[3] https://developer.arm.com/documentation/ddi0601/latest/AArch64-Registers/SMCR-EL3--SME-Control-Register--EL3-?lang=en