### PR TITLE
Revert "Fix Picolibc to a specic commit hash"

### DIFF
--- a/arm-software/embedded/versions.json
+++ b/arm-software/embedded/versions.json
@@ -8,8 +8,8 @@
   "repos": {
     "picolibc": {
       "url": "https://github.com/picolibc/picolibc.git",
-      "tagType": "commithash",
-      "tag": "a742b2d5c5f94ed71458b1f7144e451af597a45b"
+      "tagType": "branch",
+      "tag": "main"
     },
     "newlib": {
       "url": "https://github.com/RTEMS/sourceware-mirror-newlib-cygwin.git",


### PR DESCRIPTION
This reverts commit 0498b10c9f53e9b3e72f1b3e6a9c8e367e31d809.

This change should have been made to the release branch and should not have been pushed to trunk.