### PR TITLE
[ATfE] Add a sample for using FVP (#698)

### DIFF
--- a/arm-software/embedded/samples/src/baremetal-semihosting-fvp/Makefile
+++ b/arm-software/embedded/samples/src/baremetal-semihosting-fvp/Makefile
@@ -1,0 +1,96 @@
+#
+# Copyright (c) 2020-2026, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+
+include ../../Makefile.conf
+
+# Needs FVPs installed, see https://github.com/arm/arm-toolchain/blob/arm-software/arm-software/embedded/fvp/get_fvps.sh
+# By default, assume the script is running in ATfE source tree with get_fvps.sh script run to install FVPs
+# in the default location.
+ifndef FVP_INSTALL_DIR
+    FVP_INSTALL_DIR=../../../fvp/install
+endif
+
+# Check if the sample is run from ATfE source tree, thus the files are available
+IN_TREE_FVP_CONFIG_DIR:=../../../fvp/config
+ifneq ($(wildcard $(IN_TREE_FVP_CONFIG_DIR)),)
+    FVP_CONFIG_DIR:=$(IN_TREE_FVP_CONFIG_DIR)
+else
+    FVP_CONFIG_DIR:=.
+endif
+
+IN_TREE_FVP_CONFIG_NAME:=../../../fvp/config/cortex-m85.cfg
+ifneq ($(wildcard $(IN_TREE_FVP_CONFIG_NAME)),)
+    FVP_CONFIG_NAME:=$(IN_TREE_FVP_CONFIG_NAME)
+else
+    FVP_CONFIG_NAME:=cortex-m85.cfg
+endif
+
+IN_TREE_LIT_EXEC_FVP:=../../../arm-runtimes/test-support/lit-exec-fvp.py
+ifneq ($(wildcard $(IN_TREE_LIT_EXEC_FVP)),)
+    LIT_EXEC_FVP:=$(IN_TREE_LIT_EXEC_FVP)
+else
+    LIT_EXEC_FVP:=lit-exec-fvp.py
+endif
+
+IN_TREE_RUN_FVP:=../../../arm-runtimes/test-support/run_fvp.py
+ifneq ($(wildcard $(IN_TREE_RUN_FVP)),)
+    RUN_FVP:=$(IN_TREE_RUN_FVP)
+else
+    RUN_FVP:=run_fvp.py
+endif
+
+# From https://github.com/arm/arm-toolchain/blob/arm-software/arm-software/embedded/arm-multilib/json/variants/armebv6m_soft_nofp_size.json
+# see BOOT_FLASH_ADDRESS, BOOT_FLASH_SIZE, etc properties.
+# For A-profile example, see https://github.com/arm/arm-toolchain/blob/arm-software/arm-software/embedded/arm-multilib/json/variants/aarch64a_be.json
+# For R-profile example, see https://github.com/arm/arm-toolchain/blob/arm-software/arm-software/embedded/arm-multilib/json/variants/aarch64r_be.json
+CORSTONE_FVP_MEMORY_MAP=\
+	-Wl,--defsym=__boot_flash=0x01000000 \
+	-Wl,--defsym=__boot_flash_size=2M \
+	-Wl,--defsym=__flash=0x60000000 \
+	-Wl,--defsym=__flash_size=0x1000000 \
+	-Wl,--defsym=__ram=0x61000000 \
+	-Wl,--defsym=__ram_size=0x1000000 \
+	-Wl,--defsym=__stack_size=4K
+
+build: hello.elf
+
+hello.elf: *.c
+	$(BIN_PATH)/clang $(CFG_FILE) $(MICROBIT_OPTIONS) $(CRT_SEMIHOST) $(MATH_LIB) -g $(CORSTONE_FVP_MEMORY_MAP) -T $(LIBC_LD_FILE) -o hello.elf $^
+
+setup:
+	# Download helper files and scripts to current folder if missing:
+	# - Not available in tree, and
+	# - Not yet downloaded to the current folder.
+	@if [ ! -f $(LIT_EXEC_FVP) ]; then \
+		wget https://raw.githubusercontent.com/arm/arm-toolchain/refs/heads/arm-software/arm-software/embedded/arm-runtimes/test-support/lit-exec-fvp.py; \
+	fi
+	@if [ ! -f $(RUN_FVP) ]; then \
+		wget https://raw.githubusercontent.com/arm/arm-toolchain/refs/heads/arm-software/arm-software/embedded/arm-runtimes/test-support/run_fvp.py; \
+	fi
+	@if [ ! -f $(FVP_CONFIG_NAME) ]; then \
+		wget https://raw.githubusercontent.com/arm/arm-toolchain/refs/heads/arm-software/arm-software/embedded/fvp/config/cortex-m85.cfg; \
+	fi
+
+run: setup hello.elf
+# From https://github.com/arm/arm-toolchain/blob/arm-software/arm-software/embedded/arm-multilib/json/variants/armebv6m_soft_nofp_size.json
+# see FVP_MODEL and FVP_CONFIG properties.
+	python3 $(LIT_EXEC_FVP) --verbose \
+		--fvp-install-dir=$(FVP_INSTALL_DIR) \
+		--fvp-config-dir=$(FVP_CONFIG_DIR) \
+		--fvp-model=corstone-310 \
+		--fvp-config=cortex-m85 \
+		hello.elf
+
+clean:
+	rm -f *.elf
+	rm -f lit-exec-fvp.py
+	rm -f run_fvp.py
+	rm -f cortex-m85.cfg
+	rm -f :semihosting-features
+	rm -fr __pycache__
+
+.PHONY: clean setup run

--- a/arm-software/embedded/samples/src/baremetal-semihosting-fvp/README.md
+++ b/arm-software/embedded/samples/src/baremetal-semihosting-fvp/README.md
@@ -1,0 +1,23 @@
+# Bare-metal semihosting FVP sample
+
+This sample shows how to use semihosting with a
+[Corstone IoT FVP (Fixed Virtual Platform)](https://developer.arm.com/Tools%20and%20Software/Fixed%20Virtual%20Platforms/IoT%20FVPs).
+
+This sample is supported on Linux only. It relies on Corstone-310 FVP to be
+installed, you can use the
+[`get_fvps.sh`](https://github.com/arm/arm-toolchain/blob/arm-software/arm-software/embedded/fvp/get_fvps.sh)
+script from the ATfE repository to install this and other FVPs.
+
+The sample requires the `FVP_INSTALL_DIR` variable to be set in the environment
+or on the make command line, to find the FVP. By default, it assumes that the
+ATfE source tree is checked out and the FVPs are installed using the
+`get_fvps.sh` script above.
+
+The sample makes use of ATfE multilib variants
+[JSON files](https://github.com/arm/arm-toolchain/tree/arm-software/arm-software/embedded/arm-multilib/json/variants)
+to get example settings for the memory map, FVP model and required configuration
+files.
+
+The sample also downloads and uses ATfE multilib testing Python wrapper scripts
+from ATfE repository to construct the full FVP command line. The actual command
+line is printed before the invocation so that it can be inspected and reused.

--- a/arm-software/embedded/samples/src/baremetal-semihosting-fvp/hello.c
+++ b/arm-software/embedded/samples/src/baremetal-semihosting-fvp/hello.c
@@ -1,0 +1,12 @@
+/* Copyright (c) 2020-2026, Arm Limited and affiliates. 
+ *
+ * Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */
+
+#include <stdio.h>
+
+int main(void) {
+  printf("Hello World!\n");
+  return 0;
+}


### PR DESCRIPTION
Add a new sample to show how to build and run a trivial application with an IoT FVP.

This sample downloads and uses wrapper scripts from ATfE repository, which are not provided in the binary package. It needs just a few files, so this seems to be better than requiring users to checkout the whole ATfE tree. It is also easier to see what, out of the whole repository, is actually needed.

The sample assumes required FVP is installed and gives pointers how to do so.