### PR TITLE
Add Clang Core Tools to ATfE distribution (#660)

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -208,6 +208,8 @@ set(BUG_REPORT_URL "https://github.com/arm/arm-toolchain/issues" CACHE STRING ""
 set(LLVM_DISTRIBUTION_COMPONENTS
     clang-resource-headers
     clang
+    clang-check
+    clang-format
     clang-scan-deps
     dsymutil
     elf2bin


### PR DESCRIPTION
Add the [core Clang
tools](https://clang.llvm.org/docs/ClangTools.html#core-clang-tools) to the binary distributions of ATfE.