### PR TITLE
[ATfE] Fix libc v7-R no-fpregs attribute build failure

### DIFF
--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions_a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions_a.h
@@ -24,11 +24,12 @@ namespace exceptions {
 
 using namespace sysreg;
 
+extern "C" {
 #ifndef __ARM_ARCH_ISA_A64
 // Floating-point instructions aren't enabled yet
 [[gnu::target("no-fpregs")]]
 #endif
-extern "C" [[gnu::weak]] void
+[[gnu::weak]] void
 _platform_setup_exceptions() {
 #if __ARM_ARCH_PROFILE == 'A'
   VBAR = reinterpret_cast<unsigned long>(&vector_table);
@@ -44,6 +45,7 @@ _platform_setup_exceptions() {
         (reinterpret_cast<unsigned int *>(vector_table))[i];
   }
 #endif
+}
 }
 
 } // namespace exceptions


### PR DESCRIPTION
After the customization handlers were added in https://github.com/arm/arm-toolchain/commit/bc8a58bf986894c20fc668ffc71731c251ee8dcc the optional no-fpregs attribute collided with the extern "C" declaration on the handler - this was fixed by creating an extern "C" block around it.