### PR TITLE
[ATfE] Use 64-bit registers for cache info on AArch64

### DIFF
--- a/arm-software/embedded/llvmlibc-support/crt0/memory_a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/memory_a.h
@@ -36,6 +36,13 @@ void invalidate_cache() {
   __dmb(0xf);
 
   // Invalidate caches
+#if defined(__ARM_ARCH_ISA_A64)
+  bool use64BitCCSIDR = ID_AA64MMFR2.CCIDX;
+#else
+  bool use64BitCCSIDR = false;
+  // TODO: Add support for CCSIDR2
+#endif
+
   unsigned coherence = CLIDR.LoC;
   for (unsigned level = 0; level < coherence; ++level) {
     // We only need to invalidate if we have a data cache at this level
@@ -47,8 +54,10 @@ void invalidate_cache() {
 
       // Clean and invalidate by set/way
       unsigned int log2_line_size = CCSIDR.LineSize + 4;
-      unsigned int sets = CCSIDR.NumSets + 1;
-      unsigned int ways = CCSIDR.Associativity + 1;
+      unsigned int sets =
+          (use64BitCCSIDR ? CCSIDR.NumSets64 : CCSIDR.NumSets) + 1;
+      unsigned int ways =
+          (use64BitCCSIDR ? CCSIDR.Associativity64 : CCSIDR.Associativity) + 1;
       unsigned way_offset = __builtin_clz(ways); // 32-log2(number of ways)
       for (int set = 0; set < sets; ++set) {
         for (int way = 0; way < ways; ++way) {

--- a/arm-software/embedded/llvmlibc-support/crt0/system_registers_a.cpp
+++ b/arm-software/embedded/llvmlibc-support/crt0/system_registers_a.cpp
@@ -22,6 +22,7 @@ DACR_Class DACR;
 CPACR_Class CPACR;
 PMCCFILTR_Class PMCCFILTR;
 ID_DFR0_Class ID_DFR0;
+ID_AA64MMFR2_Class ID_AA64MMFR2;
 SysReg<SysRegName::VBAR> VBAR;
 SysReg<SysRegName::ESR> ESR;
 SysReg<SysRegName::ELR> ELR;

--- a/arm-software/embedded/llvmlibc-support/crt0/system_registers_a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/system_registers_a.h
@@ -39,7 +39,8 @@ namespace sysreg {
   REGNAME(APDBKeyLo, "NO_REGISTER")                                            \
   REGNAME(APDBKeyHi, "NO_REGISTER")                                            \
   REGNAME(APGAKeyLo, "NO_REGISTER")                                            \
-  REGNAME(APGAKeyHi, "NO_REGISTER")
+  REGNAME(APGAKeyHi, "NO_REGISTER")                                            \
+  REGNAME(ID_AA64MMFR2, "p15:3:c0:c7:2")
 
 // Registers that (in AArch64) have both an EL2 and an EL3 version. When these
 // are accessed we choose the appropriate version based on CurrentEL.
@@ -200,6 +201,8 @@ public:
   Field<0, 2> LineSize;
   Field<3, 12> Associativity;
   Field<13, 27> NumSets;
+  Field<3, 23> Associativity64;
+  Field<32, 55> NumSets64;
 };
 
 class CPTR_Class : public SysReg<SysRegName::CPTR> {
@@ -273,6 +276,11 @@ public:
   Field<28, 31> TraceFilt;
 };
 
+class ID_AA64MMFR2_Class : public SysReg<SysRegName::ID_AA64MMFR2> {
+public:
+  Field<20, 23> CCIDX;
+};
+
 extern SCTLR_Class SCTLR;
 extern CLIDR_Class CLIDR;
 extern CCSIDR_Class CCSIDR;
@@ -282,6 +290,7 @@ extern DACR_Class DACR;
 extern CPACR_Class CPACR;
 extern PMCCFILTR_Class PMCCFILTR;
 extern ID_DFR0_Class ID_DFR0;
+extern ID_AA64MMFR2_Class ID_AA64MMFR2;
 extern SysReg<SysRegName::VBAR> VBAR;
 extern SysReg<SysRegName::ESR> ESR;
 extern SysReg<SysRegName::ELR> ELR;


### PR DESCRIPTION
Use 64-bit CCSIDR register on AArch64 with  FEAT_CCIDX implemented. This will provide correct values for number of sets and associativity for cache maintenance operations.

References: https://developer.arm.com/documentation/ddi0601/2025-12/AArch64-Registers/CCSIDR-EL1--Current-Cache-Size-ID-Register?lang=en https://developer.arm.com/documentation/ddi0601/2025-12/AArch64-Registers/ID-AA64MMFR2-EL1--AArch64-Memory-Model-Feature-Register-2?lang=en

The implementation was provided by Vladi Krapp (@VladiKrapp-Arm)