### PR TITLE
[ATFE] Mark test-pwd as EXCLUDE (POSIX-specific, failing on macOS).

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/xfails.py
+++ b/arm-software/embedded/arm-runtimes/test-support/xfails.py
@@ -387,7 +387,7 @@ def main():
             ],
             result=NewResult.EXCLUDE,
             project="picolibc",
-            description="UID 0 lookup returning Invalid argument on MacOS",
+            description="UID 0 lookup returning Null on MacOS",
         ),
         XFail(
             name="picolibc_sys_seek",


### PR DESCRIPTION
This PR marks the test-pwd test as EXCLUDE.

We are currently observing failures in test-pwd on macOS due to differences in UID 0 lookup behavior (e.g., getpwent/getpwuid returning NULL). The failure appears to be macOS-specific.

However, this test exercises POSIX password database functionality, which is not relevant for our bare-metal targets. Since the test is not meaningful in bare-metal environments and is failing on macOS due to platform-specific behaviour, it is being marked as EXCLUDE across all platforms.