### PR TITLE
Disable automerge for 22.x release branch

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -19,8 +19,6 @@ jobs:
         branches:
           - from_branch: main
             to_branch: arm-software
-          - from_branch: release/22.x
-            to_branch: release/arm-software/22.x
     steps:
       - name: Configure Access Token
         uses: actions/create-github-app-token@v1


### PR DESCRIPTION
- Ensure the arm-toolchain release branch remains stable