### PR TITLE
[ATFE] Mark test-pwd as EXCLUDE (POSIX-specific, failing on macOS). (#725)

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/xfails.py
+++ b/arm-software/embedded/arm-runtimes/test-support/xfails.py
@@ -350,6 +350,15 @@ def main():
             description="More recent picolibc versions do now support char16_t and char32_t",
         ),
         XFail(
+            name="UID 0 lookup",
+            testnames=[
+                "test-pwd.test",
+            ],
+            result=NewResult.EXCLUDE,
+            project="picolibc",
+            description="UID 0 lookup returning Null on MacOS",
+        ),
+        XFail(
             name="picolibc_sys_seek",
             testnames=[
                 "semihost-seek.test",


### PR DESCRIPTION
This PR marks the test-pwd test as EXCLUDE.

We are currently observing failures in test-pwd on macOS due to differences in UID 0 lookup behavior (e.g., getpwent/getpwuid returning NULL). The failure appears to be macOS-specific.

However, this test exercises POSIX password database functionality, which is not relevant for our bare-metal targets. Since the test is not meaningful in bare-metal environments and is failing on macOS due to platform-specific behaviour, it is being marked as EXCLUDE across all platforms.

(cherry picked from commit 8a3055f73cf1a2a471dfd1d106dfbadff099db8d)