### PR TITLE
[ATfE] Increase more timeouts

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -534,7 +534,7 @@ if(C_LIBRARY STREQUAL picolibc)
         # * Armv7m big-endian
         # * Armv8.1-M Main PACBTI optimized for code size
         if(TEST_EXECUTOR STREQUAL fvp)
-            if(VARIANT MATCHES "armebv7a_soft_nofp")
+            if(VARIANT MATCHES "armebv7a")
                 set(timeout_multiplier 3)
             else()
                 set(timeout_multiplier 2)


### PR DESCRIPTION
In addition to the armebv7a_soft big-endian variants, the armebv7a_hard variants are also simulating slow enough to sometimes hit timeout. This patch broadens the timeout case to include both.