### PR TITLE
[ATfE] Remove libcxx from check target

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -1135,7 +1135,7 @@ add_dependencies(
 
 add_custom_target(check-llvm-toolchain)
 add_dependencies(check-llvm-toolchain check-libc)
-add_dependencies(check-llvm-toolchain ${LLVM_TOOLCHAIN_SHARED_CHECK_TARGETS})
+add_dependencies(check-llvm-toolchain check-compiler-rt)
 add_subdirectory(test)
 add_dependencies(check-llvm-toolchain check-llvm-toolchain-lit)
 add_subdirectory(packagetest)


### PR DESCRIPTION
The check-llvm-toolchain target should not run all the runtimes checks, only libc and compiler-rt. The check-llvm-toolchain-runtimes and check-all-llvm-toolchain already exist for extended test targets.