### PR TITLE
[ATfE] Use short build names on Windows

### DIFF
--- a/arm-software/embedded/scripts/build.ps1
+++ b/arm-software/embedded/scripts/build.ps1
@@ -18,5 +18,5 @@ $buildDir = (Join-Path $repoRoot build)
 mkdir $buildDir
 cd $buildDir
 
-cmake ..\arm-software\embedded -GNinja -DFETCHCONTENT_QUIET=OFF -DENABLE_QEMU_TESTING=OFF -DLLVM_PARALLEL_LINK_JOBS=2
+cmake ..\arm-software\embedded -GNinja -DFETCHCONTENT_QUIET=OFF -DENABLE_QEMU_TESTING=OFF -DLLVM_PARALLEL_LINK_JOBS=2 -DSHORT_BUILD_PATHS=ON
 ninja -j 48 package-llvm-toolchain


### PR DESCRIPTION
Due to the length of certain library variant names, the internal build paths can get very long, and push the OS limit on Windows. The SHORT_BUILD_PATHS option will avoid this by numerically indexing the variant directories instead of using the full variant name.