### PR TITLE
Document C library selection options

### DIFF
--- a/arm-software/embedded/docs/building-from-source.md
+++ b/arm-software/embedded/docs/building-from-source.md
@@ -76,6 +76,10 @@ independent per-library CMake options:
 | `LLVM_TOOLCHAIN_ENABLE_NEWLIB_NANO` | OFF | newlib-nano |
 | `LLVM_TOOLCHAIN_ENABLE_LLVMLIBC` | OFF | LLVM libc |
 
+> **Note:** The default C library may change in a future ATfE version.
+> If your build requires a specific C library, for example picolibc,
+> please enable it explicitly with `-DLLVM_TOOLCHAIN_ENABLE_PICOLIBC=ON`.
+
 Multiple libraries can be enabled simultaneously. For example, to build both
 picolibc and LLVM libc:
 


### PR DESCRIPTION
- Explain how to build ATfE with multiple C libraries 
- Remove trailing whitespaces