### PR TITLE
[ATFE] Adjust test suite: XFAIL + test exclusion.

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/xfails.py
+++ b/arm-software/embedded/arm-runtimes/test-support/xfails.py
@@ -384,7 +384,7 @@ def main():
             name="picolibc_UID0_lookup",
             testnames=[
                 "test-pwd.test",
-                "test-grp.test"
+                "test-grp.test",
             ],
             result=NewResult.EXCLUDE,
             project="picolibc",
@@ -455,7 +455,7 @@ def main():
             name="picolibc_rateInHz",
             testnames=[
                 "semihost-gettimeofday.test",
-                "test-stat.test"
+                "test-stat.test",
             ],
             result=NewResult.XFAILED,
             project="picolibc",

--- a/arm-software/embedded/arm-runtimes/test-support/xfails.py
+++ b/arm-software/embedded/arm-runtimes/test-support/xfails.py
@@ -381,9 +381,10 @@ def main():
             description="More recent picolibc versions do now support char16_t and char32_t",
         ),
         XFail(
-            name="UID 0 lookup",
+            name="picolibc_UID0_lookup",
             testnames=[
                 "test-pwd.test",
+                "test-grp.test"
             ],
             result=NewResult.EXCLUDE,
             project="picolibc",
@@ -454,6 +455,7 @@ def main():
             name="picolibc_rateInHz",
             testnames=[
                 "semihost-gettimeofday.test",
+                "test-stat.test"
             ],
             result=NewResult.XFAILED,
             project="picolibc",
@@ -483,7 +485,7 @@ def main():
                 "armv8.1m.main_soft_nofp_nomve_pacret_bti_size",
                 "armv8.1m.main_soft_nofp_nomve_pacret_bti_unaligned_size",
             ],
-            description="rateInHz port not connected in Corstone-310 FVP (SDDKW-94045).",
+            description="rateInHz port not connected in Corstone-310 FVP (SDDKW-95688).",
         ),
         XFail(
             name="string push back",


### PR DESCRIPTION
This PR marks the test-grp.test as EXCLUDE.
We are currently observing failures in test-grp on macOS same as test-pwd (https://github.com/arm/arm-toolchain/pull/740) due to differences in UID 0 lookup behavior. The failure appears to be macOS-specific. This test exercises POSIX password database functionality, which is not relevant for our bare-metal targets..

This PR also marks test-stat.test as Xfailed.
This test calls gettimeofday(), which relies on the semihosting tick frequency. This is a known issue of the Corstone-310 FVP version using on ATFE. The test is therefore marked as XFAIL to avoid CI failures.