### PR TITLE
[ATfE] Increase armebv7a_hard timeout again

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -534,7 +534,9 @@ if(C_LIBRARY STREQUAL picolibc)
         # * Armv7m big-endian
         # * Armv8.1-M Main PACBTI optimized for code size
         if(TEST_EXECUTOR STREQUAL fvp)
-            if(VARIANT MATCHES "armebv7a")
+            if(VARIANT MATCHES "armebv7a_hard")
+                set(timeout_multiplier 5)
+            elseif(VARIANT MATCHES "armebv7a_soft")
                 set(timeout_multiplier 3)
             else()
                 set(timeout_multiplier 2)


### PR DESCRIPTION
The armebv7a_hard variant can be even slower than armebv7a_soft, so may need an high timeout multiplier.