### PR TITLE
[ATfE] Lock picolibc to a fixed commit

### DIFF
--- a/arm-software/embedded/versions.json
+++ b/arm-software/embedded/versions.json
@@ -8,8 +8,8 @@
   "repos": {
     "picolibc": {
       "url": "https://github.com/picolibc/picolibc.git",
-      "tagType": "branch",
-      "tag": "main"
+      "tagType": "commithash",
+      "tag": "9626fb83b8214e1da94987a471c7a4e2c0397db9"
     },
     "newlib": {
       "url": "https://github.com/RTEMS/sourceware-mirror-newlib-cygwin.git",


### PR DESCRIPTION
The latest changes in picolibc cause build failures when attempting to compile the tests on certain variants. In order to unblock builds while this is investigated, the picolibc commit can be fixed to an earlier, working version.