### PR TITLE
Remove explicit version numbers from apt-get command

### DIFF
--- a/arm-software/embedded/scripts/install_dependencies.sh
+++ b/arm-software/embedded/scripts/install_dependencies.sh
@@ -13,7 +13,7 @@ sudo apt-get update && sudo apt-get install -y --no-install-recommends \
     clang \
     ccache \
     cmake \
-    ninja-build=1.10.1-1 \
+    ninja-build \
     python3-pip \
     python3-setuptools \
     qemu-system-arm \


### PR DESCRIPTION
The intention was to ensure we keep running our Github actions CI in a predictable environment containing fixed versions of the packages we use. But it doesn't work out that way, because when Ubuntu issues an update to any of those packages, the older version vanishes from the package repository, and then an apt-get command that insists on the older version will fail to install.

For example, our post-merge CI is failing today because qemu-system-arm has been updated, and 1:6.2+dfsg-2ubuntu6.27 doesn't exist any more.

Instead of updating that to 1:6.2+dfsg-2ubuntu6.28, this patch simply removes all the fixed package versions, so that we'll get whatever version the host Ubuntu distribution is able to provide.

This does mean that a changed version of a package _might_ change the behaviour of our tests. However:

 1. it's unlikely, because most updates within a single Ubuntu LTS release will be minor bug fixes, so the chance of it affecting the semantics of our testing is low

 2. this version of the script _might_ cause a test failure on any given update, but the previous version _definitely_ caused a test failure on _every_ update, when the packages failed to install!