### PR TITLE
[ATfE] Use semihosting WRITEC for debug output

### DIFF
--- a/arm-software/embedded/llvmlibc-support/semihost/semihost.cpp
+++ b/arm-software/embedded/llvmlibc-support/semihost/semihost.cpp
@@ -121,7 +121,7 @@ void _platform_init(void) {
 void _platform_debug_putc(int c) {
   unsigned char ch = (unsigned char)c;
 
-  __llvm_libc_stdio_write(&__llvm_libc_stderr_cookie, (const char *)&ch, 1);
+  semihosting_call(SYS_WRITEC, &ch);
 }
 
 // Provide command line options (argc/argv) for the main function


### PR DESCRIPTION
In _platform_debug_putc(int c) use semihosting WRITEC call directly to be able to output debug information before IO streams are initialized.