### PR TITLE
[ATfE] Fix way_offset in A-profile cache invalidation

### DIFF
--- a/arm-software/embedded/llvmlibc-support/crt0/memory_a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/memory_a.h
@@ -58,7 +58,7 @@ void invalidate_cache() {
           (use64BitCCSIDR ? CCSIDR.NumSets64 : CCSIDR.NumSets) + 1;
       unsigned int ways =
           (use64BitCCSIDR ? CCSIDR.Associativity64 : CCSIDR.Associativity) + 1;
-      unsigned way_offset = __builtin_clz(ways); // 32-log2(number of ways)
+      unsigned way_offset = __builtin_clz(ways - 1); // 32-log2(number of ways)
       for (int set = 0; set < sets; ++set) {
         for (int way = 0; way < ways; ++way) {
           unsigned long val =


### PR DESCRIPTION
In the code the ways variable is set to actual number of ways, e.g. 8.

way_offset is calculated as the number of leading 0s, however 8 requires 4 bits to be encoded while the ways in the loop as encoded into 3 bits as values from 0 to 7.

Thus way_offset should be the number of leading 0s for (ways - 1).

Same logic was just implemented in M-profile version.