### PR TITLE
[ATfE] Enable static TLS for LLVM libc

### DIFF
--- a/arm-software/embedded/docs/llvmlibc.md
+++ b/arm-software/embedded/docs/llvmlibc.md
@@ -71,6 +71,8 @@ clang --config=llvmlibc.cfg --target=arm-none-eabi -march=armv7m  -nostartfiles 
 >   * `void _platform_setup_exceptions()`
 >   * `void _platform_setup_memory()`
 >   * `void _platform_setup_arch_extensions()`
+>   * `void _platform_init_data_segments()`
+>   * `void _platform_init_tls()`
 >   * `void _platform_init()`
 >   * `void _platform_debug_putc(int c)`
 >   * `int _platform_get_argv(char *cmdline, int max_cmdline, const char **argv, int max_argv)`
@@ -87,6 +89,7 @@ functions in this order:
 1. `void _platform_setup_memory()`
 1. `void _platform_setup_arch_extensions()`
 1. `void _platform_init_data_segments()`
+1. `void _platform_init_tls()`
 1. `void _platform_init()`
 
 You can override any of these functions in your application to customize.
@@ -108,6 +111,10 @@ a cryptographic key.
   * `__data_size` - the size of the read-write data segment to be copied.
   * `__bss_start` - the address of the start of the BSS region.
   * `__bss_size` - the size of the BSS region to be cleared.
+* `void _platform_init_tls()` - Initialize the initial thread-local storage
+  block for the startup thread. By default, this uses the picolibc-compatible
+  linker script symbols `__tls_first`, `__tls_size`,
+  `__arm32_tls_tcb_offset`, and `__arm64_tls_tcb_offset`.
 * `void _platform_init()` - Any other initialization right before the main
 function is called, for example, setup standard I/O streams.
 

--- a/arm-software/embedded/llvmlibc-support/crt0/CMakeLists.txt
+++ b/arm-software/embedded/llvmlibc-support/crt0/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CRT0_COMMON_SOURCES
   misc.cpp
   system_registers_a.cpp
   system_registers_m.cpp
+  tls.cpp
 )
 
 # crt0 with nohost implementation of platform initialization and finalization

--- a/arm-software/embedded/llvmlibc-support/crt0/bootcode.cpp
+++ b/arm-software/embedded/llvmlibc-support/crt0/bootcode.cpp
@@ -40,6 +40,7 @@ void do_start() {
   _platform_setup_arch_extensions();
 
   _platform_init_data_segments();
+  _platform_init_tls();
 
   __libc_init_array();
   _platform_init();

--- a/arm-software/embedded/llvmlibc-support/crt0/tls.cpp
+++ b/arm-software/embedded/llvmlibc-support/crt0/tls.cpp
@@ -57,6 +57,9 @@ static uintptr_t __llvm_libc_thread_pointer = 0;
 #endif
 
 [[gnu::weak]] void _platform_init_tls() {
+  // Linker defined symbols for TLS must be aligned in the linker script to
+  // meet the ABI requirements, see for an example:
+  // https://github.com/arm/arm-toolchain/blob/arm-software/arm-software/embedded/llvmlibc-support/llvmlibc.ld.in
   if (linker_value(__tls_size) == 0 || linker_value(__tls_first) == 0)
     return;
 

--- a/arm-software/embedded/llvmlibc-support/crt0/tls.cpp
+++ b/arm-software/embedded/llvmlibc-support/crt0/tls.cpp
@@ -1,0 +1,66 @@
+//
+// Copyright (c) 2026, Arm Limited and affiliates.
+//
+// Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM
+// Exceptions. See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+#include <stdint.h>
+
+// TLS symbols defined in the linker script.
+extern "C" {
+[[gnu::weak]] extern char __tls_first[];
+[[gnu::weak]] extern char __tls_size[];
+
+#if defined(__ARM_ARCH_ISA_A64)
+[[gnu::weak]] extern char __arm64_tls_tcb_offset[];
+#elif defined(__arm__)
+[[gnu::weak]] extern char __arm32_tls_tcb_offset[];
+#endif
+} // extern "C"
+
+// Helper functions
+namespace {
+inline uintptr_t linker_value(const void *symbol) {
+  return reinterpret_cast<uintptr_t>(symbol);
+}
+} // namespace
+
+// _set_tls() for compatibility with picolibc and
+// LLVM libc style _platform_init_tls() handler.
+extern "C" {
+#if defined(__ARM_ARCH_ISA_A64)
+[[gnu::weak]] void _set_tls(void *tls) {
+  const uintptr_t tp =
+      reinterpret_cast<uintptr_t>(tls) - linker_value(__arm64_tls_tcb_offset);
+  __asm__ volatile("msr tpidr_el0, %0" : : "r"(tp));
+}
+#elif defined(__arm__)
+// Thread pointer for software TLS implementation.
+static uintptr_t __llvm_libc_thread_pointer = 0;
+
+[[gnu::weak]] void _set_tls(void *tls) {
+  const uintptr_t tp =
+      reinterpret_cast<uintptr_t>(tls) - linker_value(__arm32_tls_tcb_offset);
+  __llvm_libc_thread_pointer = tp;
+#if __ARM_ARCH_PROFILE != 'M' && __ARM_ARCH >= 6
+  __asm__ volatile("mcr p15, 0, %0, c13, c0, 3" : : "r"(tp)); // TPIDRURO
+#endif
+}
+
+[[gnu::weak]] void *__aeabi_read_tp(void) {
+  return reinterpret_cast<void *>(__llvm_libc_thread_pointer);
+}
+#else
+[[gnu::weak]] void _set_tls(void *tls) { (void)tls; }
+#endif
+
+[[gnu::weak]] void _platform_init_tls() {
+  if (linker_value(__tls_size) == 0 || linker_value(__tls_first) == 0)
+    return;
+
+  _set_tls(__tls_first);
+}
+
+} // extern "C"

--- a/arm-software/embedded/llvmlibc-support/platform.h
+++ b/arm-software/embedded/llvmlibc-support/platform.h
@@ -35,6 +35,9 @@ void _platform_setup_arch_extensions(void);
 // Relocate read-write data into its runtime memory and clear the BSS region.
 void _platform_init_data_segments(void);
 
+// Initialize thread-local storage (TLS) for the initial execution context.
+void _platform_init_tls(void);
+
 // Any other initialization right before the main function is called,
 // for example, in semihosting, the standard I/O handles must be opened
 // via the SYS_OPEN operation, and this function is where libsemihost.a does it.


### PR DESCRIPTION
Initialize static TLS in the LLVM libc startup code so TLS-backed libc state is available during language conformance testing. This does not add multithreading support.

Follow picolibc’s TLS layout and linker-script symbols to simplify migration from picolibc to LLVM libc. Also add a weak _platform_init_tls() startup handler so targets can override the default TLS initialization.