### PR TITLE
[ATfE] Increase picolibc test timeouts.

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -534,7 +534,11 @@ if(C_LIBRARY STREQUAL picolibc)
         # * Armv7m big-endian
         # * Armv8.1-M Main PACBTI optimized for code size
         if(TEST_EXECUTOR STREQUAL fvp)
-            set(timeout_multiplier 2)
+            if(VARIANT MATCHES "armebv7a")
+                set(timeout_multiplier 3)
+            else()
+                set(timeout_multiplier 2)
+            endif()
         else()
             set(timeout_multiplier 1)
         endif()


### PR DESCRIPTION
Armebv7a library variants can run slow enough to trigger timeouts in CI. This adjusts
the multiplier higher while the slowdown is investigated.

Timeout was applied on the 22.x branch earlier
https://github.com/arm/arm-toolchain/pull/712.