### PR TITLE
[ATfE] Only run library tests on Linux

### DIFF
--- a/.github/workflows/atfe_nightly_build_and_test.yml
+++ b/.github/workflows/atfe_nightly_build_and_test.yml
@@ -50,7 +50,7 @@ jobs:
             runner: ah-windows_2022-c7a_24x-200
 
           - build_script: build.sh
-            test_script: test.sh
+            test_script: test_package_only.sh
             install_script: install_dependencies_macos.sh
             target_os: macOS-arm64
             runner: mini-github-m4-01

--- a/arm-software/embedded/scripts/test_package_only.sh
+++ b/arm-software/embedded/scripts/test_package_only.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2025, Arm Limited and affiliates.
+# Copyright (c) 2025-2026, Arm Limited and affiliates.
 # Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/arm-software/embedded/scripts/test_package_only.sh
+++ b/arm-software/embedded/scripts/test_package_only.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# A bash script to run the tests from the Arm Toolchain for Embedded.
+
+# The script assumes a successful build of the toolchain exists in the 'build'
+# directory inside the repository tree.
+
+set -ex
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
+
+# If a test fails, lit will ordinarily return a non-zero result,
+# which prevents further testing. Setting the --ignore-fail option
+# will cause testing to continue, so that CI systems can get a
+# full set of results.
+# The lit test suites do not generate xml results by default.
+# This can be enabled with the --xunit-xml-output option. The file
+# written will be relative to the individual suite's build directly,
+# so the same name can be used for all files for consistency.
+export LIT_OPTS="--ignore-fail --xunit-xml-output=lit_results.junit.xml"
+
+# Run all relevant test targets using Ninja.
+cd "${REPO_ROOT}"/build
+ninja check-all
+ninja check-package-llvm-toolchain


### PR DESCRIPTION
The qemu version used on MacOS runners is a different version to Linux, which leads to libc test failures on certain unaligned variants. Until the versions can be kept consistant and/or Linux updated, library tests will only be run on Linux.