### PR TITLE
[ATfE]: Rename check-libc-lit to check-libc

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -895,7 +895,7 @@ if(C_LIBRARY STREQUAL llvmlibc)
         ExternalProject_Add_Step(
             llvmlibc
             check-lit
-            COMMAND "${CMAKE_COMMAND}" --build <BINARY_DIR> --target check-libc-lit
+            COMMAND "${CMAKE_COMMAND}" --build <BINARY_DIR> --target check-libc
             COMMAND ${Python3_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/test-support/update-xml-suitename.py
             --dir <BINARY_DIR>/libc/test


### PR DESCRIPTION
[ATfE]: Rename check-libc-lit to check-libc, aligning with the changes done in upstream in https://github.com/arm/arm-toolchain/commit/fc9f14e