### PR TITLE
[ATfL]: Allow sudo for Ubuntu 2404 Github runner

### DIFF
--- a/.github/workflows/atfl_nightly_build_and_test.yml
+++ b/.github/workflows/atfl_nightly_build_and_test.yml
@@ -23,8 +23,10 @@ jobs:
   build-and-test-toolchain:
     name: Build ${{ matrix.build_script }} for ${{ matrix.target_os }} on ${{ matrix.runner }}
     runs-on: ${{ matrix.runner }}
-    # Ensure the workflow only runs on the arm-toolchain repository and not on forks
-    if: github.repository == 'arm/arm-toolchain'
+
+    # Allow manual runs on Fork for testing, and
+    # scheduled runs only on arm/arm-toolchain
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'arm/arm-toolchain'
 
     strategy:
       fail-fast: false  # Prevents one job failure from cancelling all

--- a/arm-software/linux/scripts/install_dependencies_ubuntu.sh
+++ b/arm-software/linux/scripts/install_dependencies_ubuntu.sh
@@ -9,8 +9,20 @@
 
 set -euo pipefail
 
-apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+if [ "$(id -u)" -eq 0 ]; then
+    echo "root privileges are present"
+    SUDO=""
+else
+    echo "root privileges are not present"
+    command -v sudo >/dev/null 2>&1 || {
+        echo "sudo is required but not installed"
+        exit 1
+    }
+    SUDO="sudo"
+fi
+
+$SUDO apt-get update
+DEBIAN_FRONTEND=noninteractive $SUDO apt-get install -y --no-install-recommends \
     bash \
     binutils-dev \
     build-essential \
@@ -42,6 +54,5 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     zlib1g-dev
 
 # Install fpm
-gem install --no-document fpm
-
-rm -rf /var/lib/apt/lists/*
+$SUDO gem install --no-document fpm
+$SUDO rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
[ATfL]: Allow sudo for Ubuntu 2404 Github runner

We are moving ATfL Github Action from Ubuntu 22.04 Github Runner to Ubuntu 24.04 Github Runner. This PR enables sudo permissions for the workflow, if needed.