### PR TITLE
[ATfE] Implement __arm_sme_state in LLVM libc bootcode

### DIFF
--- a/arm-software/embedded/llvmlibc-support/crt0/CMakeLists.txt
+++ b/arm-software/embedded/llvmlibc-support/crt0/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CRT0_COMMON_SOURCES
   exceptions.cpp
   memory.cpp
   misc.cpp
+  sme_abi.cpp
   system_registers_a.cpp
   system_registers_m.cpp
   tls.cpp

--- a/arm-software/embedded/llvmlibc-support/crt0/misc_a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/misc_a.h
@@ -18,6 +18,35 @@ namespace misc {
 
 using namespace sysreg;
 
+#if defined(__ARM_ARCH_ISA_A64)
+[[clang::always_inline]] inline bool has_sme_or_sme2() {
+  constexpr auto FEAT_SME_1 = 1UL << 24;
+  constexpr auto FEAT_SME_2 = 1UL << 25;
+
+  return (static_cast<unsigned long>(ID_AA64PFR1) & (FEAT_SME_1 | FEAT_SME_2)) != 0;
+}
+
+[[clang::always_inline]] inline void init_sme_state() {
+  if (!has_sme_or_sme2())
+    return;
+
+  // TPIDR2_EL0 resets to an architecturally unknown value, so clear it.
+  asm volatile("msr s3_3_c13_c0_5, xzr\n\tisb" : : : "memory");
+
+  // Try to set the streaming vector length to the architectural maximum.
+  unsigned long smcr;
+  if (__arm_rsr("CurrentEL") == 3 << 2) {
+    asm volatile("mrs %0, s3_6_c1_c2_6" : "=r"(smcr));
+    smcr = (smcr & ~0xfUL) | 0xfUL;
+    asm volatile("msr s3_6_c1_c2_6, %0\n\tisb" : : "r"(smcr) : "memory");
+  } else if (__arm_rsr("CurrentEL") == 2 << 2) {
+    asm volatile("mrs %0, s3_4_c1_c2_6" : "=r"(smcr));
+    smcr = (smcr & ~0xfUL) | 0xfUL;
+    asm volatile("msr s3_4_c1_c2_6, %0\n\tisb" : : "r"(smcr) : "memory");
+  }
+}
+#endif
+
 extern "C" [[gnu::weak]] void _platform_setup_arch_extensions() {
 #ifdef __ARM_FEATURE_PAUTH
   // Set all of the pointer authentication keys to different values. In
@@ -54,6 +83,7 @@ extern "C" [[gnu::weak]] void _platform_setup_arch_extensions() {
   // relevant feature these bits are ignored, so safe to set unconditionally.
   CPTR.EZ = 1;
   CPTR.ESM = 1;
+  init_sme_state();
 #else
   // Enable VFP and SIMD
   __arm_wsr("fpexc", 1 << 30);

--- a/arm-software/embedded/llvmlibc-support/crt0/misc_a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/misc_a.h
@@ -20,10 +20,7 @@ using namespace sysreg;
 
 #if defined(__ARM_ARCH_ISA_A64)
 [[clang::always_inline]] inline bool has_sme_or_sme2() {
-  constexpr auto FEAT_SME_1 = 1UL << 24;
-  constexpr auto FEAT_SME_2 = 1UL << 25;
-
-  return (static_cast<unsigned long>(ID_AA64PFR1) & (FEAT_SME_1 | FEAT_SME_2)) != 0;
+  return ID_AA64PFR1.SME != 0 || ID_AA64PFR1.SME2 != 0;
 }
 
 [[clang::always_inline]] inline void init_sme_state() {
@@ -31,18 +28,16 @@ using namespace sysreg;
     return;
 
   // TPIDR2_EL0 resets to an architecturally unknown value, so clear it.
-  asm volatile("msr s3_3_c13_c0_5, xzr\n\tisb" : : : "memory");
+  TPIDR2 = 0;
+  __isb(0xf);
 
   // Try to set the streaming vector length to the architectural maximum.
-  unsigned long smcr;
-  if (__arm_rsr("CurrentEL") == 3 << 2) {
-    asm volatile("mrs %0, s3_6_c1_c2_6" : "=r"(smcr));
-    smcr = (smcr & ~0xfUL) | 0xfUL;
-    asm volatile("msr s3_6_c1_c2_6, %0\n\tisb" : : "r"(smcr) : "memory");
-  } else if (__arm_rsr("CurrentEL") == 2 << 2) {
-    asm volatile("mrs %0, s3_4_c1_c2_6" : "=r"(smcr));
-    smcr = (smcr & ~0xfUL) | 0xfUL;
-    asm volatile("msr s3_4_c1_c2_6, %0\n\tisb" : : "r"(smcr) : "memory");
+  if (CurrentEL.is(ExceptionLevel::EL3)) {
+    SMCR_EL3.LEN = 0xf;
+    __isb(0xf);
+  } else if (CurrentEL.is(ExceptionLevel::EL2)) {
+    SMCR_EL2.LEN = 0xf;
+    __isb(0xf);
   }
 }
 #endif

--- a/arm-software/embedded/llvmlibc-support/crt0/sme_abi.cpp
+++ b/arm-software/embedded/llvmlibc-support/crt0/sme_abi.cpp
@@ -1,0 +1,37 @@
+//
+// Copyright (c) 2026, Arm Limited and affiliates.
+//
+// Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM
+// Exceptions. See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+#if defined(__ARM_ARCH_ISA_A64)
+
+// Minimal SME ABI support for compiler-rt and LLVM libc users.
+// https://github.com/ARM-software/abi-aa/blob/main/aapcs64/aapcs64.rst#811__arm_sme_state
+asm(
+    ".text\n"
+    ".globl __arm_sme_state\n"
+    ".type __arm_sme_state, %function\n"
+    ".variant_pcs __arm_sme_state\n"
+    "__arm_sme_state:\n"
+    "  mov x0, xzr\n"
+    "  mov x1, xzr\n"
+    "\n"
+    "  /* Check whether SME or SME2 is present. */\n"
+    "  mrs x16, id_aa64pfr1_el1\n"
+    "  tst w16, #0x3000000\n"
+    "  b.eq .L__arm_sme_state_no_sme\n"
+    "\n"
+    "  orr x0, x0, #0xC000000000000000\n"
+    "  /* Read SVCR. */\n"
+    "  mrs x16, s3_3_c4_c2_2\n"
+    "  bfxil x0, x16, #0, #2\n"
+    "  /* Read TPIDR2_EL0. */\n"
+    "  mrs x1, s3_3_c13_c0_5\n"
+    ".L__arm_sme_state_no_sme:\n"
+    "  ret\n"
+    ".size __arm_sme_state, .-__arm_sme_state\n");
+
+#endif

--- a/arm-software/embedded/llvmlibc-support/crt0/sme_abi.cpp
+++ b/arm-software/embedded/llvmlibc-support/crt0/sme_abi.cpp
@@ -8,32 +8,39 @@
 
 #if defined(__ARM_ARCH_ISA_A64)
 
+#include "system_registers_a.h"
+
 // Minimal SME ABI support for compiler-rt and LLVM libc users.
 // https://github.com/ARM-software/abi-aa/blob/main/aapcs64/aapcs64.rst#811__arm_sme_state
 // TODO: Consider caching the state to avoid rechecking id_aa64pfr1_el1
 // when running user workloads.
-asm(
-    ".text\n"
-    ".globl __arm_sme_state\n"
-    ".type __arm_sme_state, %function\n"
-    ".variant_pcs __arm_sme_state\n"
-    "__arm_sme_state:\n"
-    "  mov x0, xzr\n"
-    "  mov x1, xzr\n"
-    "\n"
-    "  /* Check whether SME or SME2 is present. */\n"
-    "  mrs x16, id_aa64pfr1_el1\n"
-    "  tst w16, #0x3000000\n"
-    "  b.eq .L__arm_sme_state_no_sme\n"
-    "\n"
-    "  orr x0, x0, #0xC000000000000000\n"
-    "  /* Read SVCR. */\n"
-    "  mrs x16, s3_3_c4_c2_2\n"
-    "  bfxil x0, x16, #0, #2\n"
-    "  /* Read TPIDR2_EL0. */\n"
-    "  mrs x1, s3_3_c13_c0_5\n"
-    ".L__arm_sme_state_no_sme:\n"
-    "  ret\n"
-    ".size __arm_sme_state, .-__arm_sme_state\n");
+using namespace bootcode::sysreg;
+
+constexpr unsigned long SME_STATE_SUPPORT_MASK = 0xC000000000000000UL;
+constexpr unsigned long SME_STATE_SM_MASK = 0x1;
+constexpr unsigned long SME_STATE_ZA_MASK = 0x2;
+
+struct SmeState {
+  // __arm_sme_state returns its two-word result in registers x0 and x1.
+  unsigned long x0;
+  unsigned long x1;
+};
+
+extern "C" SmeState __arm_sme_state() {
+  SmeState state = {0, 0};
+
+  if (ID_AA64PFR1.SME == 0 && ID_AA64PFR1.SME2 == 0)
+    return state;
+
+  state.x0 = SME_STATE_SUPPORT_MASK;
+  if (SVCR.SM != 0)
+    state.x0 |= SME_STATE_SM_MASK;
+  if (SVCR.ZA != 0)
+    state.x0 |= SME_STATE_ZA_MASK;
+  state.x1 = TPIDR2;
+  return state;
+}
+
+asm(".variant_pcs __arm_sme_state");
 
 #endif

--- a/arm-software/embedded/llvmlibc-support/crt0/sme_abi.cpp
+++ b/arm-software/embedded/llvmlibc-support/crt0/sme_abi.cpp
@@ -10,6 +10,8 @@
 
 // Minimal SME ABI support for compiler-rt and LLVM libc users.
 // https://github.com/ARM-software/abi-aa/blob/main/aapcs64/aapcs64.rst#811__arm_sme_state
+// TODO: Consider caching the state to avoid rechecking id_aa64pfr1_el1
+// when running user workloads.
 asm(
     ".text\n"
     ".globl __arm_sme_state\n"

--- a/arm-software/embedded/llvmlibc-support/crt0/system_registers_a.cpp
+++ b/arm-software/embedded/llvmlibc-support/crt0/system_registers_a.cpp
@@ -13,6 +13,13 @@
 namespace bootcode {
 namespace sysreg {
 
+#ifdef __ARM_ARCH_ISA_A64
+CurrentEL_Class CurrentEL;
+TPIDR2_Class TPIDR2;
+SVCR_Class SVCR;
+SMCR_EL2_Class SMCR_EL2;
+SMCR_EL3_Class SMCR_EL3;
+#endif
 SCTLR_Class SCTLR;
 CLIDR_Class CLIDR;
 CCSIDR_Class CCSIDR;
@@ -22,6 +29,7 @@ DACR_Class DACR;
 CPACR_Class CPACR;
 PMCCFILTR_Class PMCCFILTR;
 ID_DFR0_Class ID_DFR0;
+ID_AA64PFR1_Class ID_AA64PFR1;
 ID_AA64MMFR2_Class ID_AA64MMFR2;
 SysReg<SysRegName::VBAR> VBAR;
 SysReg<SysRegName::ESR> ESR;
@@ -30,7 +38,6 @@ SysReg<SysRegName::FAR> FAR;
 SysReg<SysRegName::CSSELR> CSSELR;
 SysReg<SysRegName::TTBR0> TTBR0;
 SysReg<SysRegName::MAIR> MAIR;
-SysReg<SysRegName::ID_AA64PFR1> ID_AA64PFR1;
 SysReg<SysRegName::TCR> TCR;
 SysReg<SysRegName::APIAKeyLo> APIAKeyLo;
 SysReg<SysRegName::APIAKeyHi> APIAKeyHi;

--- a/arm-software/embedded/llvmlibc-support/crt0/system_registers_a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/system_registers_a.h
@@ -17,6 +17,111 @@
 namespace bootcode {
 namespace sysreg {
 
+#ifdef __ARM_ARCH_ISA_A64
+enum class ExceptionLevel : unsigned long {
+  EL0 = 0,
+  EL1 = 1,
+  EL2 = 2,
+  EL3 = 3,
+};
+
+class CurrentEL_Class : public SysRegBase<CurrentEL_Class> {
+public:
+  [[clang::always_inline]] static unsigned long read() {
+    return __arm_rsr("CurrentEL");
+  }
+
+  Field<2, 3> EL;
+
+  [[clang::always_inline]] ExceptionLevel value() {
+    return static_cast<ExceptionLevel>(static_cast<unsigned long>(EL));
+  }
+
+  [[clang::always_inline]] bool is(ExceptionLevel level) {
+    return value() == level;
+  }
+};
+
+extern CurrentEL_Class CurrentEL;
+
+class TPIDR2_Class : public SysRegBase<TPIDR2_Class> {
+public:
+  [[clang::always_inline]] static unsigned long read() {
+    return __arm_rsr64("s3_3_c13_c0_5");
+  }
+
+  [[clang::always_inline]] static void write(unsigned long val) {
+    __arm_wsr64("s3_3_c13_c0_5", val);
+  }
+
+  [[clang::always_inline]] TPIDR2_Class &operator=(unsigned long val) {
+    write(val);
+    return *this;
+  }
+};
+
+class SVCR_Class : public SysRegBase<SVCR_Class> {
+public:
+  [[clang::always_inline]] static unsigned long read() {
+    return __arm_rsr64("s3_3_c4_c2_2");
+  }
+
+  [[clang::always_inline]] static void write(unsigned long val) {
+    __arm_wsr64("s3_3_c4_c2_2", val);
+  }
+
+  [[clang::always_inline]] SVCR_Class &operator=(unsigned long val) {
+    write(val);
+    return *this;
+  }
+
+  Bit<0> SM;
+  Bit<1> ZA;
+};
+
+extern TPIDR2_Class TPIDR2;
+extern SVCR_Class SVCR;
+
+class SMCR_EL2_Class : public SysRegBase<SMCR_EL2_Class> {
+public:
+  [[clang::always_inline]] static unsigned long read() {
+    return __arm_rsr64("s3_4_c1_c2_6");
+  }
+
+  [[clang::always_inline]] static void write(unsigned long val) {
+    __arm_wsr64("s3_4_c1_c2_6", val);
+  }
+
+  [[clang::always_inline]] SMCR_EL2_Class &operator=(unsigned long val) {
+    write(val);
+    return *this;
+  }
+
+  Field<0, 3> LEN;
+};
+
+class SMCR_EL3_Class : public SysRegBase<SMCR_EL3_Class> {
+public:
+  [[clang::always_inline]] static unsigned long read() {
+    return __arm_rsr64("s3_6_c1_c2_6");
+  }
+
+  [[clang::always_inline]] static void write(unsigned long val) {
+    __arm_wsr64("s3_6_c1_c2_6", val);
+  }
+
+  [[clang::always_inline]] SMCR_EL3_Class &operator=(unsigned long val) {
+    write(val);
+    return *this;
+  }
+
+  Field<0, 3> LEN;
+};
+
+extern SMCR_EL2_Class SMCR_EL2;
+extern SMCR_EL3_Class SMCR_EL3;
+#endif
+
 // Registers that only have an EL0 version.
 #define EL0_REGNAMES REGNAME(PMCCFILTR, "p15:0:c14:c15:7")
 
@@ -107,7 +212,7 @@ EL1_REGNAMES
   template <>                                                                  \
   [[clang::always_inline]] inline unsigned long                          \
   SysReg<SysRegName::X>::read() {                                              \
-    if (__arm_rsr("CurrentEL") == 3 << 2)                                      \
+    if (CurrentEL.is(ExceptionLevel::EL3))                                     \
       return __arm_rsr64(#X "_EL3");                                           \
     else                                                                       \
       return __arm_rsr64(#X "_EL2");                                           \
@@ -115,7 +220,7 @@ EL1_REGNAMES
   template <>                                                                  \
   [[clang::always_inline]] inline void SysReg<SysRegName::X>::write(     \
       unsigned long val) {                                                     \
-    if (__arm_rsr("CurrentEL") == 3 << 2)                                      \
+    if (CurrentEL.is(ExceptionLevel::EL3))                                     \
       __arm_wsr64(#X "_EL3", val);                                             \
     else                                                                       \
       __arm_wsr64(#X "_EL2", val);                                             \
@@ -276,6 +381,12 @@ public:
   Field<28, 31> TraceFilt;
 };
 
+class ID_AA64PFR1_Class : public SysReg<SysRegName::ID_AA64PFR1> {
+public:
+  Bit<24> SME;
+  Bit<25> SME2;
+};
+
 class ID_AA64MMFR2_Class : public SysReg<SysRegName::ID_AA64MMFR2> {
 public:
   Field<20, 23> CCIDX;
@@ -290,6 +401,7 @@ extern DACR_Class DACR;
 extern CPACR_Class CPACR;
 extern PMCCFILTR_Class PMCCFILTR;
 extern ID_DFR0_Class ID_DFR0;
+extern ID_AA64PFR1_Class ID_AA64PFR1;
 extern ID_AA64MMFR2_Class ID_AA64MMFR2;
 extern SysReg<SysRegName::VBAR> VBAR;
 extern SysReg<SysRegName::ESR> ESR;
@@ -298,7 +410,6 @@ extern SysReg<SysRegName::FAR> FAR;
 extern SysReg<SysRegName::CSSELR> CSSELR;
 extern SysReg<SysRegName::TTBR0> TTBR0;
 extern SysReg<SysRegName::MAIR> MAIR;
-extern SysReg<SysRegName::ID_AA64PFR1> ID_AA64PFR1;
 extern SysReg<SysRegName::TCR> TCR;
 extern SysReg<SysRegName::APIAKeyLo> APIAKeyLo;
 extern SysReg<SysRegName::APIAKeyHi> APIAKeyHi;


### PR DESCRIPTION
This adds LLVM libc bootcode support for __arm_sme_state as per https://github.com/ARM-software/abi-aa/blob/main/aapcs64/aapcs64.rst#811__arm_sme_state to match this LLVM change https://github.com/llvm/llvm-project/pull/191434