### PR TITLE
[ATfE]: Update XFAIL file for fix in exp10m1f_test

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/xfails.py
+++ b/arm-software/embedded/arm-runtimes/test-support/xfails.py
@@ -1149,7 +1149,6 @@ def main():
         XFail(
             name="Untriaged llvmlibc xfails 6",
             testnames=[
-                "src/math/smoke/libc.test.src.math.smoke.exp10m1f_test.__hermetic__.__build__",
                 "src/stdlib/libc.test.src.stdlib.malloc_test.__hermetic__.__build__",
             ],
             result=NewResult.XFAILED,


### PR DESCRIPTION
src.math.smoke.exp10m1f_test was previously marked XFAIL due to incorrect handling of exp10m1f(-0) in SKIP_ACCURATE_PASS mode.

Upstream commit 5b6880c71b2c ("[libc][math] Fix exp10m1f(-0) in SKIP_ACCURATE_PASS mode") fixes the issue and passes the test now. Update the XFAIL to reflect the new test status.