### PR TITLE
[ATfE] Remove absolute build directory path from libraries

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -17,6 +17,7 @@ project(arm-runtimes)
 set(TOOLCHAIN_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..)
 # Root directory of the llvm-project source.
 set(llvmproject_src_dir ${TOOLCHAIN_SOURCE_DIR}/../..)
+get_filename_component(llvmproject_src_dir_abs "${llvmproject_src_dir}" ABSOLUTE)
 
 # CMake arguments are loaded from the JSON file depending on which C
 # library is used, so this must be set before the JSON is processed.
@@ -99,6 +100,7 @@ set(ENABLE_LIBC_TESTS ${ENABLE_LIBC_TESTS_def} CACHE BOOL "Enable libc tests (pi
 set(ENABLE_COMPILER_RT_TESTS ${ENABLE_COMPILER_RT_TESTS_def} CACHE BOOL "Enable compiler-rt tests.")
 set(ENABLE_LIBCXX_TESTS ${ENABLE_LIBCXX_TESTS_def} CACHE BOOL "Enable libcxx tests.")
 set(LLVM_BINARY_DIR "" CACHE PATH "Path to LLVM toolchain root to build libraries with")
+option(LLVM_USE_RELATIVE_PATHS_IN_FILES "Use relative paths in sources and debug info" ON)
 
 set(PROJECT_PREFIX "subproj" CACHE STRING "Directory to build subprojects in.")
 set(VARIANT_BUILD_ID "${VARIANT}" CACHE STRING "Name to use to identify build directories." )
@@ -231,6 +233,12 @@ set(compile_arch_flags "--target=${target_triple} ${COMPILE_FLAGS} --sysroot ${T
 # Compiling the libraries benefits from some extra optimization
 # flags, and requires a sysroot or include folder for LLVM libc build.
 set(lib_compile_flags "${compile_arch_flags} -ffunction-sections -fdata-sections -fno-ident")
+if(LLVM_USE_RELATIVE_PATHS_IN_FILES)
+    get_filename_component(project_prefix_abs "${PROJECT_PREFIX}" ABSOLUTE BASE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+    set(lib_compile_flags
+        "${lib_compile_flags} -ffile-prefix-map=${project_prefix_abs}/= -ffile-prefix-map=${CMAKE_CURRENT_BINARY_DIR}/= -ffile-prefix-map=${llvmproject_src_dir_abs}/="
+    )
+endif()
 
 # Generic target names for the C library.
 # Declare these now, since compiler-rt requires the 'install' dependency.
@@ -869,6 +877,7 @@ if(C_LIBRARY STREQUAL llvmlibc)
         -DRAM_SIZE=${RAM_SIZE}
         -DSTACK_SIZE=${STACK_SIZE}
         -DLLVMLIBC_SUPPORT_ENABLE_DUMMYPACKEYS=${enable_dummypackeys}
+        -DLLVM_USE_RELATIVE_PATHS_IN_FILES=${LLVM_USE_RELATIVE_PATHS_IN_FILES}
         STEP_TARGETS build install
         USES_TERMINAL_CONFIGURE TRUE
         USES_TERMINAL_BUILD TRUE

--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -100,7 +100,7 @@ set(ENABLE_LIBC_TESTS ${ENABLE_LIBC_TESTS_def} CACHE BOOL "Enable libc tests (pi
 set(ENABLE_COMPILER_RT_TESTS ${ENABLE_COMPILER_RT_TESTS_def} CACHE BOOL "Enable compiler-rt tests.")
 set(ENABLE_LIBCXX_TESTS ${ENABLE_LIBCXX_TESTS_def} CACHE BOOL "Enable libcxx tests.")
 set(LLVM_BINARY_DIR "" CACHE PATH "Path to LLVM toolchain root to build libraries with")
-option(LLVM_USE_RELATIVE_PATHS_IN_FILES "Use relative paths in sources and debug info" ON)
+option(LLVM_USE_RELATIVE_PATHS_IN_MACROS "Use relative paths in macro expansions" ON)
 
 set(PROJECT_PREFIX "subproj" CACHE STRING "Directory to build subprojects in.")
 set(VARIANT_BUILD_ID "${VARIANT}" CACHE STRING "Name to use to identify build directories." )
@@ -233,10 +233,10 @@ set(compile_arch_flags "--target=${target_triple} ${COMPILE_FLAGS} --sysroot ${T
 # Compiling the libraries benefits from some extra optimization
 # flags, and requires a sysroot or include folder for LLVM libc build.
 set(lib_compile_flags "${compile_arch_flags} -ffunction-sections -fdata-sections -fno-ident")
-if(LLVM_USE_RELATIVE_PATHS_IN_FILES)
+if(LLVM_USE_RELATIVE_PATHS_IN_MACROS)
     get_filename_component(project_prefix_abs "${PROJECT_PREFIX}" ABSOLUTE BASE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
     set(lib_compile_flags
-        "${lib_compile_flags} -ffile-prefix-map=${project_prefix_abs}/= -ffile-prefix-map=${CMAKE_CURRENT_BINARY_DIR}/= -ffile-prefix-map=${llvmproject_src_dir_abs}/="
+        "${lib_compile_flags} -fmacro-prefix-map=${project_prefix_abs}/= -fmacro-prefix-map=${CMAKE_CURRENT_BINARY_DIR}/= -fmacro-prefix-map=${llvmproject_src_dir_abs}/="
     )
 endif()
 
@@ -877,7 +877,7 @@ if(C_LIBRARY STREQUAL llvmlibc)
         -DRAM_SIZE=${RAM_SIZE}
         -DSTACK_SIZE=${STACK_SIZE}
         -DLLVMLIBC_SUPPORT_ENABLE_DUMMYPACKEYS=${enable_dummypackeys}
-        -DLLVM_USE_RELATIVE_PATHS_IN_FILES=${LLVM_USE_RELATIVE_PATHS_IN_FILES}
+        -DLLVM_USE_RELATIVE_PATHS_IN_MACROS=${LLVM_USE_RELATIVE_PATHS_IN_MACROS}
         STEP_TARGETS build install
         USES_TERMINAL_CONFIGURE TRUE
         USES_TERMINAL_BUILD TRUE

--- a/arm-software/embedded/llvmlibc-support/CMakeLists.txt
+++ b/arm-software/embedded/llvmlibc-support/CMakeLists.txt
@@ -26,6 +26,17 @@
 cmake_minimum_required(VERSION 3.20.0)
 project(llvmlibc-support LANGUAGES C CXX ASM)
 
+set(LLVM_SOURCE_PREFIX "" CACHE STRING "Use prefix for sources")
+option(LLVM_USE_RELATIVE_PATHS_IN_FILES "Use relative paths in sources and debug info" OFF)
+
+if(LLVM_USE_RELATIVE_PATHS_IN_FILES)
+    file(RELATIVE_PATH relative_root "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
+    add_compile_options(
+        "$<$<COMPILE_LANGUAGE:C,CXX,ASM>:-ffile-prefix-map=${CMAKE_BINARY_DIR}=${relative_root}>"
+        "$<$<COMPILE_LANGUAGE:C,CXX,ASM>:-ffile-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}/=${LLVM_SOURCE_PREFIX}>"
+    )
+endif()
+
 option(
     LLVMLIBC_SUPPORT_ENABLE_DUMMYPACKEYS
     "Build the opt-in dummy PAC key helper library for M-profile PACBTI testing."

--- a/arm-software/embedded/llvmlibc-support/CMakeLists.txt
+++ b/arm-software/embedded/llvmlibc-support/CMakeLists.txt
@@ -26,14 +26,13 @@
 cmake_minimum_required(VERSION 3.20.0)
 project(llvmlibc-support LANGUAGES C CXX ASM)
 
-set(LLVM_SOURCE_PREFIX "" CACHE STRING "Use prefix for sources")
 option(LLVM_USE_RELATIVE_PATHS_IN_MACROS "Use relative paths in macro expansions" OFF)
 
 if(LLVM_USE_RELATIVE_PATHS_IN_MACROS)
     file(RELATIVE_PATH relative_root "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
     add_compile_options(
         "$<$<COMPILE_LANGUAGE:C,CXX,ASM>:-fmacro-prefix-map=${CMAKE_BINARY_DIR}=${relative_root}>"
-        "$<$<COMPILE_LANGUAGE:C,CXX,ASM>:-fmacro-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}/=${LLVM_SOURCE_PREFIX}>"
+        "$<$<COMPILE_LANGUAGE:C,CXX,ASM>:-fmacro-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}/=>"
     )
 endif()
 

--- a/arm-software/embedded/llvmlibc-support/CMakeLists.txt
+++ b/arm-software/embedded/llvmlibc-support/CMakeLists.txt
@@ -27,13 +27,13 @@ cmake_minimum_required(VERSION 3.20.0)
 project(llvmlibc-support LANGUAGES C CXX ASM)
 
 set(LLVM_SOURCE_PREFIX "" CACHE STRING "Use prefix for sources")
-option(LLVM_USE_RELATIVE_PATHS_IN_FILES "Use relative paths in sources and debug info" OFF)
+option(LLVM_USE_RELATIVE_PATHS_IN_MACROS "Use relative paths in macro expansions" OFF)
 
-if(LLVM_USE_RELATIVE_PATHS_IN_FILES)
+if(LLVM_USE_RELATIVE_PATHS_IN_MACROS)
     file(RELATIVE_PATH relative_root "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
     add_compile_options(
-        "$<$<COMPILE_LANGUAGE:C,CXX,ASM>:-ffile-prefix-map=${CMAKE_BINARY_DIR}=${relative_root}>"
-        "$<$<COMPILE_LANGUAGE:C,CXX,ASM>:-ffile-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}/=${LLVM_SOURCE_PREFIX}>"
+        "$<$<COMPILE_LANGUAGE:C,CXX,ASM>:-fmacro-prefix-map=${CMAKE_BINARY_DIR}=${relative_root}>"
+        "$<$<COMPILE_LANGUAGE:C,CXX,ASM>:-fmacro-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}/=${LLVM_SOURCE_PREFIX}>"
     )
 endif()
 


### PR DESCRIPTION
Some library files use macros like `__FILE__` which add the absolute build directory path to the binary. To make the builds more reproducible and easier to compare (especially for FuSa purposes) this patch reuses LLVM option LLVM_USE_RELATIVE_PATHS_IN_FILES to remove the absolute paths.

LLVM options itself does not apply to libraries, thus a local implementation for it is needed.