### PR TITLE
[ATfL][build] Copying the OpenMP Fortran modules and headers should be more adaptive

### DIFF
--- a/arm-software/linux/build.sh
+++ b/arm-software/linux/build.sh
@@ -459,7 +459,22 @@ package() {
       cp "${LIBRARIES_DIR}/libamath.so" \
           "${ATFL_DIR}/lib/${ATFL_TARGET_TRIPLE}"
     fi
-    cp ${ATFL_DIR}/include/flang/omp* "${ATFL_DIR}/include"
+    if compgen -G "${ATFL_DIR}/include/flang/omp*" >/dev/null; then
+      # Handle the old directory layout
+      cp "${ATFL_DIR}"/include/flang/omp* "${ATFL_DIR}/include"
+    else
+      # Handle the new directory layout
+      cp "${ATFL_DIR}"/lib/clang/*/include/omp* "${ATFL_DIR}/include"
+      cp "${ATFL_DIR}"/lib/clang/*/finclude/flang/"${ATFL_TARGET_TRIPLE}"/omp* "${ATFL_DIR}/include"
+    fi
+    if ! compgen -G "${ATFL_DIR}/include/omp*.h" >/dev/null; then
+      echo "The OpenMP headers could not be copied to ${ATFL_DIR}/include"
+      exit 1
+    fi
+    if ! compgen -G "${ATFL_DIR}/include/omp*.mod" >/dev/null; then
+      echo "The OpenMP Fortran modules could not be copied to ${ATFL_DIR}/include"
+      exit 1
+    fi
     cp "${ATFL_DIR}/share/man/man1/clang.1" "${ATFL_DIR}/share/man/man1/armclang.1"
     sed -i "s/clang /armclang /g" "${ATFL_DIR}/share/man/man1/armclang.1"
     sed -i "s/Bclang/Barmclang/g" "${ATFL_DIR}/share/man/man1/armclang.1"


### PR DESCRIPTION
For the sake of user convenience, we're copying the OpenMP Fortran modules and header files into an easily accessible `include` directory. The most recent upstream changes have spread those files across directories and changed the paths. As the change appears back and forth, we need to be more adaptive here.

This is to address the changes introduced by this upstream PR: https://github.com/llvm/llvm-project/pull/171515