### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/atfe_nightly_build_and_test.yml
+++ b/.github/workflows/atfe_nightly_build_and_test.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Dependencies
         run: ./arm-software/embedded/scripts/${{ matrix.install_script }}
@@ -115,7 +115,7 @@ jobs:
           if ($LASTEXITCODE) { exit $LASTEXITCODE } # Propagate failure
 
       - name: Upload logs as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: logs-${{ matrix.build_script }}-${{ matrix.target_os }}
@@ -124,14 +124,14 @@ jobs:
             test.log
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results-${{ matrix.build_script }}-${{ matrix.target_os }}
           path: build/**/lit_results.junit.xml
 
       - name: Upload built packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: success()
         with:
           name: ATfE-packages-${{ matrix.build_script }}-${{ matrix.target_os }}

--- a/.github/workflows/atfe_post_merge.yml
+++ b/.github/workflows/atfe_post_merge.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Dependencies
         run: ./arm-software/embedded/scripts/install_dependencies.sh

--- a/.github/workflows/atfe_pre_merge.yml
+++ b/.github/workflows/atfe_pre_merge.yml
@@ -56,14 +56,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Checks out the merge commit for the PR
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       # Restore ccache cache from previous runs
       - name: Restore ccache cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.CCACHE_DIR }}
           # key for a cache entry

--- a/.github/workflows/atfl_nightly_build_and_test.yml
+++ b/.github/workflows/atfl_nightly_build_and_test.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Add ~/.local/bin to PATH
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
@@ -147,7 +147,7 @@ jobs:
           find arm-software/linux/output -maxdepth 3 -type f \( -name '*.tar.gz' -o -name '*.deb' \) | sort
 
       - name: Upload build log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ always() && !env.ACT }}
         with:
           name: build-log-${{ matrix.target_os }}
@@ -155,7 +155,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload built packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ success() && !env.ACT }}
         with:
           name: atfl-${{ matrix.build_script }}-${{ matrix.target_os }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,13 +23,13 @@ jobs:
             to_branch: release/arm-software/22.x
     steps:
       - name: Configure Access Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         id: generate-token
         with:
           app-id: ${{ secrets.SYNC_APP_ID }}
           private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ matrix.branches.to_branch }}
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/check_downstream_changes.yml
+++ b/.github/workflows/check_downstream_changes.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Check Script
         run: python3 arm-software/ci/check_downstream_changes.py --repo ${{ github.repository }} --pr ${{ github.event.pull_request.number }}

--- a/.github/workflows/sync_from_upstream.yml
+++ b/.github/workflows/sync_from_upstream.yml
@@ -17,13 +17,13 @@ jobs:
       UPSTREAM_REMOTE: https://github.com/llvm/llvm-project.git
     steps:
       - name: Configure Access Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         id: generate-token
         with:
           app-id: ${{ secrets.SYNC_APP_ID }}
           private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ matrix.branch }}
           token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Node.js 20 actions are being deprecated, so update the following actions to new versions that support Node.js 24:

* actions/cache@v5
* actions/checkout@v6
* actions/create-github-app-token@v3
* actions/upload-artifact@v7