### PR TITLE
[ATfE] Update paths used for packaging test

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -1088,9 +1088,9 @@ if (CPACK_PACKAGE_DIRECTORY)
     cmake_path(ABSOLUTE_PATH CPACK_PACKAGE_DIRECTORY
         BASE_DIRECTORY ${CMAKE_BINARY_DIR}
         OUTPUT_VARIABLE absolute_package_dir)
-        cmake_path(SET package_filepath ${absolute_package_dir}/${PACKAGE_FILE_NAME}${package_filename_extension})
+    set(package_filepath ${absolute_package_dir}/${PACKAGE_FILE_NAME}${package_filename_extension})
 else()
-    cmake_path(SET package_filepath ${CMAKE_BINARY_DIR}/${PACKAGE_FILE_NAME}${package_filename_extension})
+    set(package_filepath ${CMAKE_BINARY_DIR}/${PACKAGE_FILE_NAME}${package_filename_extension})
 endif()
 set(unpack_directory ${CMAKE_CURRENT_BINARY_DIR}/unpack/${PACKAGE_FILE_NAME})
 add_custom_command(

--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -1080,7 +1080,18 @@ else()
     set(cpack_generator TXZ)
     set(package_filename_extension ".tar.xz")
 endif()
-set(package_filepath ${CMAKE_BINARY_DIR}/${PACKAGE_FILE_NAME}${package_filename_extension})
+# CPACK_PACKAGE_DIRECTORY can optionally set the location of the package.
+# If unset, the location will default to CMAKE_BINARY_DIR.
+if (CPACK_PACKAGE_DIRECTORY)
+    # CPACK_PACKAGE_DIRECTORY may or may not be relative, so
+    # resolve it to an absolute path first.
+    cmake_path(ABSOLUTE_PATH CPACK_PACKAGE_DIRECTORY
+        BASE_DIRECTORY ${CMAKE_BINARY_DIR}
+        OUTPUT_VARIABLE absolute_package_dir)
+        cmake_path(SET package_filepath ${absolute_package_dir}/${PACKAGE_FILE_NAME}${package_filename_extension})
+else()
+    cmake_path(SET package_filepath ${CMAKE_BINARY_DIR}/${PACKAGE_FILE_NAME}${package_filename_extension})
+endif()
 set(unpack_directory ${CMAKE_CURRENT_BINARY_DIR}/unpack/${PACKAGE_FILE_NAME})
 add_custom_command(
     OUTPUT ${package_filepath}


### PR DESCRIPTION
The CPACK_PACKAGE_DIRECTORY option can potentially change where the package will be generated. This location is needed to unpack the package for testing, so the unpack target needs to be able to handle this option.