### PR TITLE
Reject invalid BF encoding when target is next instruction

### DIFF
--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMAsmBackend.cpp
@@ -882,7 +882,15 @@ unsigned ARMAsmBackend::adjustFixupValue(const MCAssembler &Asm,
       Ctx.reportError(Fixup.getLoc(), FixupDiagnostic);
       return 0;
     }
-    uint32_t out = (((Value - 4) >> 1) & 0xf) << 23;
+
+    int64_t encoded = (Value - 4) >> 1;
+    if (encoded == 0) {
+      Ctx.reportError(Fixup.getLoc(),
+                      "invalid BF encoding: target must not be the next instruction");
+      return 0;
+    }
+
+    uint32_t out = (encoded & 0xf) << 23;
     return swapHalfWords(out, Endian == llvm::endianness::little);
   }
   case ARM::fixup_bf_target:

--- a/llvm/test/MC/ARM/bf-invalid-target.s
+++ b/llvm/test/MC/ARM/bf-invalid-target.s
@@ -1,0 +1,14 @@
+@ RUN: not llvm-mc -triple arm-none-eabi -mcpu=cortex-m55 -filetype=obj %s -o /dev/null 2>&1 | FileCheck %s
+
+.text
+bf label, __myfunc
+label:
+  b __myfunc
+
+.section .text.foo, "ax", %progbits
+.type __myfunc, %function
+.global __myfunc
+__myfunc:
+  nop
+
+@ CHECK: error: invalid BF encoding: target must not be the next instruction


### PR DESCRIPTION
When the BF instruction targets the next immediate label, the encoded branch offset becomes zero. Which caused LLVM to emmit invalid machine code.

Added validation in the fixup_bf_branch path to reject this case and emit an error instead.

Added MC regression test to cover new validation.

Assisted by ChatGPT. Human-verified, debugged, tested and validating by author.

Fixes: LLVMAENG-4768