### PR TITLE
[ATFE] Run llvmlibc tests against generated sysroot matching final multilib layout.

### DIFF
--- a/arm-software/embedded/arm-multilib/CMakeLists.txt
+++ b/arm-software/embedded/arm-multilib/CMakeLists.txt
@@ -25,6 +25,7 @@ set(ENABLE_VARIANTS "all" CACHE STRING "Semicolon separated list of variants to 
 set(C_LIBRARY "picolibc" CACHE STRING "Which C library to use.")
 set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc newlib newlib-nano llvmlibc)
 set(PROJECT_PREFIX "${CMAKE_BINARY_DIR}/lib-builds" CACHE STRING "Directory to build subprojects in.")
+set(LLVM_LIBC_TEST_SYSROOT "${PROJECT_PREFIX}/test-sysroot" CACHE PATH "Build-tree package-style sysroot for LLVM libc tests.")
 option(
     NUMERICAL_BUILD_NAMES
     "Instead of using the full variant name to label build directories, use an index number. This may help shorten paths."
@@ -120,6 +121,24 @@ add_dependencies(
     check-cxxabi
     check-unwind
 )
+
+if(C_LIBRARY STREQUAL llvmlibc)
+    if(ENABLE_MULTILIB_HEADER_OPTIMISATION)
+        set(LLVM_LIBC_TEST_SYSROOT_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/multilib-optimised")
+    else()
+        set(LLVM_LIBC_TEST_SYSROOT_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/multilib")
+    endif()
+    list(APPEND passthrough_dirs "-DLLVM_LIBC_TEST_SYSROOT=${LLVM_LIBC_TEST_SYSROOT}")
+    add_custom_target(
+        llvmlibc-test-sysroot
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${LLVM_LIBC_TEST_SYSROOT}"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${LLVM_LIBC_TEST_SYSROOT}"
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${LLVM_LIBC_TEST_SYSROOT_SOURCE_DIR}"
+            "${LLVM_LIBC_TEST_SYSROOT}"
+        COMMENT "Generating llvm-libc test sysroot"
+    )
+endif()
 
 if(ENABLE_PARALLEL_LIB_CONFIG OR ENABLE_PARALLEL_LIB_BUILD)
     # Additional targets to build the variant subprojects in parallel.
@@ -247,6 +266,7 @@ foreach(lib_idx RANGE ${lib_count_dec})
                 ${passthrough_dirs}
                 ${additional_cmake_args}
                 -DVARIANT_JSON=${variant_json_file}
+                -DVARIANT_MULTILIB_FLAGS=${variant_multilib_flags}
                 -DC_LIBRARY=${C_LIBRARY}
                 -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                 -DPROJECT_PREFIX=${PROJECT_PREFIX}
@@ -334,6 +354,13 @@ foreach(lib_idx RANGE ${lib_count_dec})
                     ${check_target}
                     runtimes-${variant}-build
                 )
+                if(C_LIBRARY STREQUAL llvmlibc AND check_target STREQUAL check-llvmlibc)
+                    ExternalProject_Add_StepDependencies(
+                        runtimes-${variant}
+                        ${check_target}
+                        llvmlibc-test-sysroot
+                    )
+                endif()
                 add_custom_target(${check_target}-${variant})
                 add_dependencies(${check_target} runtimes-${variant}-${check_target})
                 add_dependencies(${check_target}-${variant} runtimes-${variant}-${check_target})
@@ -431,4 +458,12 @@ if(ENABLE_MULTILIB_HEADER_OPTIMISATION)
         DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/multilib-optimised/"
         DESTINATION .
     )
+endif()
+
+if(C_LIBRARY STREQUAL llvmlibc)
+    if(ENABLE_MULTILIB_HEADER_OPTIMISATION)
+        add_dependencies(llvmlibc-test-sysroot generate-multilib-common-headers)
+    else()
+        add_dependencies(llvmlibc-test-sysroot ${all_runtime_targets} multilib-yaml)
+    endif()
 endif()

--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -59,6 +59,7 @@ endif()
 set(TARGET_ARCH ${TARGET_ARCH_def} CACHE STRING "Architecture being targetted.")
 set(VARIANT ${VARIANT_def} CACHE STRING "Name for the variant, usually architecture + suffix.")
 set(COMPILE_FLAGS ${COMPILE_FLAGS_def} CACHE STRING "Flags required to build the variant.")
+set(VARIANT_MULTILIB_FLAGS "" CACHE STRING "Flags that select this variant in multilib.yaml.")
 set(TEST_EXECUTOR ${TEST_EXECUTOR_def} CACHE STRING "Program used to run tests.")
 set_property(CACHE TEST_EXECUTOR PROPERTY STRINGS fvp qemu)
 set(FVP_MODEL ${FVP_MODEL_def} CACHE STRING "FVP model to use, if FVP is the test executor.")
@@ -100,6 +101,7 @@ set(ENABLE_LIBC_TESTS ${ENABLE_LIBC_TESTS_def} CACHE BOOL "Enable libc tests (pi
 set(ENABLE_COMPILER_RT_TESTS ${ENABLE_COMPILER_RT_TESTS_def} CACHE BOOL "Enable compiler-rt tests.")
 set(ENABLE_LIBCXX_TESTS ${ENABLE_LIBCXX_TESTS_def} CACHE BOOL "Enable libcxx tests.")
 set(LLVM_BINARY_DIR "" CACHE PATH "Path to LLVM toolchain root to build libraries with")
+set(LLVM_LIBC_TEST_SYSROOT "" CACHE PATH "Build-tree package-style sysroot for LLVM libc tests.")
 option(LLVM_USE_RELATIVE_PATHS_IN_MACROS "Use relative paths in macro expansions" ON)
 
 set(PROJECT_PREFIX "subproj" CACHE STRING "Directory to build subprojects in.")
@@ -798,6 +800,18 @@ if(C_LIBRARY STREQUAL llvmlibc)
         -T
         llvmlibc.ld
     )
+    set(llvmlibc_test_compile_options "")
+    if(LLVM_LIBC_TEST_SYSROOT)
+        set(llvmlibc_test_sysroot "--sysroot=${LLVM_LIBC_TEST_SYSROOT}")
+        list(APPEND llvmlibc_test_compile_options ${llvmlibc_test_sysroot})
+        list(APPEND llvmlibc_test_link_options ${llvmlibc_test_sysroot})
+    endif()
+    if(VARIANT_MULTILIB_FLAGS)
+        separate_arguments(llvmlibc_test_multilib_flags NATIVE_COMMAND ${VARIANT_MULTILIB_FLAGS})
+        list(APPEND llvmlibc_test_compile_options ${llvmlibc_test_multilib_flags})
+        list(APPEND llvmlibc_test_link_options ${llvmlibc_test_multilib_flags})
+    endif()
+    list(JOIN llvmlibc_test_compile_options "," llvmlibc_test_compile_options_default)
     if(NOT target_supports_lock_free_atomics)
         list(APPEND llvmlibc_test_link_options -latomic-fallback)
     endif()
@@ -882,6 +896,7 @@ if(C_LIBRARY STREQUAL llvmlibc)
         -DLLVM_ENABLE_RUNTIMES=libc
         -DLLVM_LIBC_ALL_HEADERS=ON
         -DLLVM_LIBC_FULL_BUILD=ON
+        -DLIBC_TEST_COMPILE_OPTIONS_DEFAULT=${llvmlibc_test_compile_options_default}
         -DLIBC_TEST_LINK_OPTIONS_DEFAULT=${llvmlibc_test_link_options_default}
         -DLIBC_TEST_CMD=${test_cmd}
         -DLIBC_TEST_HERMETIC_ONLY=ON


### PR DESCRIPTION
LLVM libc tests now run against a generated build-tree sysroot so tests can be compiled and linked using the same multilib layout that will be installed in the final package.

LLVM libc tests need to resolve headers and libraries through the multilib layout, including the optimised common-header layout when enabled. So the ATFE build system passes --sysroot when compiling and linking these tests. Before this change, that sysroot pointed at the runtimes tmp_install area, which is created as a per-variant temporary install directory. That layout is useful while building each variant, but it does not work in the layered layout where minor variants contain only the payload required for their subarchive and rely on content inherited from base variants. As a result, individual per-variant temporary install directories no longer represent a complete view of the installed sysroot and are not suitable as test environments. Building a dedicated test sysroot lets the tests exercise the generated multilib package structure instead of relying only on per-variant temporary install directories.

This patch:

- Adds LLVM_LIBC_TEST_SYSROOT.
- When C_LIBRARY=llvmlibc, creates a new target: llvmlibc-test-sysroot. 
      -  That target deletes/recreates the test sysroot, copies either:
         - multilib-optimised/ if header optimisation is enabled, or
         - multilib/ otherwise. 
- For LLVM libc tests, the test compile and link options now include: - --sysroot=<LLVM_LIBC_TEST_SYSROOT>. - the variant's multilib flags
- A dependency from LLVM libc check targets to the generated test sysroot