### PR TITLE
[ATfL]: Enable xml test report output for test suite

### DIFF
--- a/arm-software/linux/build.sh
+++ b/arm-software/linux/build.sh
@@ -236,7 +236,7 @@ run_command() {
     "$@"
 }
 
-run_lit_ninja() {
+run_test_command() {
     local xml_output="$1"
     local log_file="$2"
     shift 2
@@ -399,7 +399,7 @@ bootstrap_compiler_build() {
     run_command cmake --install . 2>&1 | tee -a "${LOGS_DIR}/bootstrap_compiler.txt"
     export PATH="${BUILD_DIR}/bootstrap_compiler/bin:${PATH}"
     bootstrap_compiler_default_config
-    run_lit_ninja "${LOGS_DIR}/bootstrap_check_all.xml" "${LOGS_DIR}/bootstrap_compiler.txt" check-all
+    run_test_command "${LOGS_DIR}/bootstrap_check_all.xml" "${LOGS_DIR}/bootstrap_compiler.txt" check-all
 }
 
 libcpp_build() {
@@ -428,8 +428,8 @@ libcpp_build() {
     run_command cmake --build . "${CMAKE_BUILD_ARGS[@]}" 2>&1 | tee -a "${LOGS_DIR}/libcpp.txt"
     run_command cmake --install . 2>&1 | tee -a "${LOGS_DIR}/libcpp.txt"
     export LD_LIBRARY_PATH="${ATFL_DIR}/lib:${ATFL_DIR}/lib/${ATFL_TARGET_TRIPLE}:${LD_LIBRARY_PATH}"
-    run_lit_ninja "${LOGS_DIR}/check_cxx.xml" "${LOGS_DIR}/libcpp.txt" check-cxx
-    run_lit_ninja "${LOGS_DIR}/check_cxxabi.xml" "${LOGS_DIR}/libcpp.txt" check-cxxabi
+    run_test_command "${LOGS_DIR}/check_cxx.xml" "${LOGS_DIR}/libcpp.txt" check-cxx
+    run_test_command "${LOGS_DIR}/check_cxxabi.xml" "${LOGS_DIR}/libcpp.txt" check-cxxabi
 }
 
 product_build() {
@@ -483,7 +483,7 @@ product_build() {
     cp -d "${ATFL_DIR}"/lib/clang/*/lib/"${ATFL_TARGET_TRIPLE}"/libflang_rt* \
         "${ATFL_DIR}/lib/${ATFL_TARGET_TRIPLE}"
     echo "-Wl,-rpath=${ATFL_DIR}/lib" >> "${BUILD_DIR}"/bootstrap_compiler/bin/clang++.cfg
-    run_lit_ninja "${LOGS_DIR}/product_check_all.xml" "${LOGS_DIR}/product.txt" check-all
+    run_test_command "${LOGS_DIR}/product_check_all.xml" "${LOGS_DIR}/product.txt" check-all
 
     bootstrap_compiler_default_config
 }
@@ -526,7 +526,7 @@ static_libomp_build() {
     cp "${ATFL_DIR}".libs/lib/lib*.a \
         "${ATFL_DIR}/lib/${ATFL_TARGET_TRIPLE}"
     rm -r "${ATFL_DIR}.libs"
-    run_lit_ninja "${LOGS_DIR}/check_openmp.xml" "${LOGS_DIR}/static_libomp.txt" check-openmp
+    run_test_command "${LOGS_DIR}/check_openmp.xml" "${LOGS_DIR}/static_libomp.txt" check-openmp
 }
 
 check_lit_xml_results() {
@@ -537,6 +537,8 @@ check_lit_xml_results() {
         "${LOGS_DIR}/check_cxx.xml"
         "${LOGS_DIR}/check_cxxabi.xml"
         "${LOGS_DIR}/product_check_all.xml"
+        # OpenMP tests do not get executed currently
+        # "${LOGS_DIR}/check_openmp.xml"
     )
 
     echo_bold "Checking lit XML test results...."

--- a/arm-software/linux/build.sh
+++ b/arm-software/linux/build.sh
@@ -531,7 +531,6 @@ check_lit_xml_results() {
         "${LOGS_DIR}/check_cxx.xml"
         "${LOGS_DIR}/check_cxxabi.xml"
         "${LOGS_DIR}/product_check_all.xml"
-        "${LOGS_DIR}/check_openmp.xml"
     )
 
     echo_bold "Checking lit XML test results...."

--- a/arm-software/linux/build.sh
+++ b/arm-software/linux/build.sh
@@ -520,8 +520,7 @@ static_libomp_build() {
     cp "${ATFL_DIR}".libs/lib/lib*.a \
         "${ATFL_DIR}/lib/${ATFL_TARGET_TRIPLE}"
     rm -r "${ATFL_DIR}.libs"
-    LIT_OPTS="${LIT_OPTS} --xunit-xml-output=${LOGS_DIR}/check_openmp.xml" \
-        run_command ninja "${NINJA_ARGS[@]}" check-openmp 2>&1 | tee -a "${LOGS_DIR}/static_libomp.txt"
+    run_command ninja "${NINJA_ARGS[@]}" check-openmp 2>&1 | tee -a "${LOGS_DIR}/static_libomp.txt"
 }
 
 check_lit_xml_results() {

--- a/arm-software/linux/build.sh
+++ b/arm-software/linux/build.sh
@@ -390,7 +390,8 @@ bootstrap_compiler_build() {
     run_command cmake --install . 2>&1 | tee -a "${LOGS_DIR}/bootstrap_compiler.txt"
     export PATH="${BUILD_DIR}/bootstrap_compiler/bin:${PATH}"
     bootstrap_compiler_default_config
-    run_command ninja "${NINJA_ARGS[@]}" check-all 2>&1 | tee -a "${LOGS_DIR}/bootstrap_compiler.txt"
+    LIT_OPTS="${LIT_OPTS} --xunit-xml-output=${LOGS_DIR}/bootstrap_check_all.xml" \
+        run_command ninja "${NINJA_ARGS[@]}" check-all 2>&1 | tee -a "${LOGS_DIR}/bootstrap_compiler.txt"
 }
 
 libcpp_build() {
@@ -419,8 +420,10 @@ libcpp_build() {
     run_command cmake --build . "${CMAKE_BUILD_ARGS[@]}" 2>&1 | tee -a "${LOGS_DIR}/libcpp.txt"
     run_command cmake --install . 2>&1 | tee -a "${LOGS_DIR}/libcpp.txt"
     export LD_LIBRARY_PATH="${ATFL_DIR}/lib:${ATFL_DIR}/lib/${ATFL_TARGET_TRIPLE}:${LD_LIBRARY_PATH}"
-    run_command ninja "${NINJA_ARGS[@]}" check-cxx 2>&1 | tee -a "${LOGS_DIR}/libcpp.txt"
-    run_command ninja "${NINJA_ARGS[@]}" check-cxxabi 2>&1 | tee -a "${LOGS_DIR}/libcpp.txt"
+    LIT_OPTS="${LIT_OPTS} --xunit-xml-output=${LOGS_DIR}/check_cxx.xml" \
+        run_command ninja "${NINJA_ARGS[@]}" check-cxx 2>&1 | tee -a "${LOGS_DIR}/libcpp.txt"
+    LIT_OPTS="${LIT_OPTS} --xunit-xml-output=${LOGS_DIR}/check_cxxabi.xml" \
+        run_command ninja "${NINJA_ARGS[@]}" check-cxxabi 2>&1 | tee -a "${LOGS_DIR}/libcpp.txt"
 }
 
 product_build() {
@@ -474,7 +477,8 @@ product_build() {
     cp -d "${ATFL_DIR}"/lib/clang/*/lib/"${ATFL_TARGET_TRIPLE}"/libflang_rt* \
         "${ATFL_DIR}/lib/${ATFL_TARGET_TRIPLE}"
     echo "-Wl,-rpath=${ATFL_DIR}/lib" >> "${BUILD_DIR}"/bootstrap_compiler/bin/clang++.cfg
-    run_command ninja "${NINJA_ARGS[@]}" check-all 2>&1 | tee -a "${LOGS_DIR}/product.txt"
+    LIT_OPTS="${LIT_OPTS} --xunit-xml-output=${LOGS_DIR}/product_check_all.xml" \
+        run_command ninja "${NINJA_ARGS[@]}" check-all 2>&1 | tee -a "${LOGS_DIR}/product.txt"
     bootstrap_compiler_default_config
 }
 
@@ -516,7 +520,39 @@ static_libomp_build() {
     cp "${ATFL_DIR}".libs/lib/lib*.a \
         "${ATFL_DIR}/lib/${ATFL_TARGET_TRIPLE}"
     rm -r "${ATFL_DIR}.libs"
-    run_command ninja "${NINJA_ARGS[@]}" check-openmp 2>&1 | tee -a "${LOGS_DIR}/static_libomp.txt"
+    LIT_OPTS="${LIT_OPTS} --xunit-xml-output=${LOGS_DIR}/check_openmp.xml" \
+        run_command ninja "${NINJA_ARGS[@]}" check-openmp 2>&1 | tee -a "${LOGS_DIR}/static_libomp.txt"
+}
+
+check_lit_xml_results() {
+    local failed=false
+    local result_file
+    local result_files=(
+        "${LOGS_DIR}/bootstrap_check_all.xml"
+        "${LOGS_DIR}/check_cxx.xml"
+        "${LOGS_DIR}/check_cxxabi.xml"
+        "${LOGS_DIR}/product_check_all.xml"
+        "${LOGS_DIR}/check_openmp.xml"
+    )
+
+    echo_bold "Checking lit XML test results...."
+    for result_file in "${result_files[@]}"; do
+        if [[ ! -f "${result_file}" ]]; then
+            echo "Expected lit XML result file was not created: ${result_file}" >&2
+            failed=true
+            continue
+        fi
+
+        if grep -Eq '<failure([ >])| failures="[1-9][0-9]*"| errors="[1-9][0-9]*"' "${result_file}"; then
+            echo "lit reported failures in: ${result_file}" >&2
+            failed=true
+        fi
+    done
+
+    if ${failed}; then
+        return 1
+    fi
+    echo_bold "Checking lit XML test results....done"
 }
 
 package() {
@@ -609,6 +645,7 @@ main() {
         echo_bold "Completed stage: ${stage}."
     done
     echo_bold "Executed build stages."
+    check_lit_xml_results
     echo_bold "Packaging...."
     package
     echo_bold "Packaged."
@@ -689,6 +726,15 @@ make_and_clean_directory() {
 make_and_clean_directory "${BUILD_DIR:?}"
 make_and_clean_directory "${OUTPUT_DIR:?}"
 make_and_clean_directory "${LOGS_DIR:?}"
+
+# If a test fails, lit will ordinarily return a non-zero result,
+# which prevents further testing. Setting the --ignore-fail option
+# will cause testing to continue, so that CI systems can get a
+# full set of results.
+# The lit test suites do not generate xml results by default.
+# This can be enabled with the --xunit-xml-output option.
+# Each check target appends its own --xunit-xml-output path under LOGS_DIR.
+export LIT_OPTS="${LIT_OPTS:+${LIT_OPTS} }--ignore-fail"
 
 main
 trap : 0

--- a/arm-software/linux/build.sh
+++ b/arm-software/linux/build.sh
@@ -678,9 +678,17 @@ then
   exit 1
 fi
 
-mkdir -p "${BUILD_DIR}"
-mkdir -p "${OUTPUT_DIR}"
-mkdir -p "${LOGS_DIR}"
+make_and_clean_directory() {
+    local dir="$1"
+    mkdir -p "${dir}"
+
+    # Initial clean-up of directory contents. Directory itself may be mounted.
+    find "${dir}" -mindepth 1 -maxdepth 1 -depth -exec rm -rf -- {} +
+}
+
+make_and_clean_directory "${BUILD_DIR:?}"
+make_and_clean_directory "${OUTPUT_DIR:?}"
+make_and_clean_directory "${LOGS_DIR:?}"
 
 main
 trap : 0

--- a/arm-software/linux/build.sh
+++ b/arm-software/linux/build.sh
@@ -236,6 +236,15 @@ run_command() {
     "$@"
 }
 
+run_lit_ninja() {
+    local xml_output="$1"
+    local log_file="$2"
+    shift 2
+
+    LIT_OPTS="${LIT_OPTS} --xunit-xml-output=${xml_output}" \
+        run_command ninja "${NINJA_ARGS[@]}" "$@" 2>&1 | tee -a "${log_file}"
+}
+
 print_help() {
     cat <<EOF
 Usage: $0 [OPTIONS]
@@ -390,8 +399,7 @@ bootstrap_compiler_build() {
     run_command cmake --install . 2>&1 | tee -a "${LOGS_DIR}/bootstrap_compiler.txt"
     export PATH="${BUILD_DIR}/bootstrap_compiler/bin:${PATH}"
     bootstrap_compiler_default_config
-    LIT_OPTS="${LIT_OPTS} --xunit-xml-output=${LOGS_DIR}/bootstrap_check_all.xml" \
-        run_command ninja "${NINJA_ARGS[@]}" check-all 2>&1 | tee -a "${LOGS_DIR}/bootstrap_compiler.txt"
+    run_lit_ninja "${LOGS_DIR}/bootstrap_check_all.xml" "${LOGS_DIR}/bootstrap_compiler.txt" check-all
 }
 
 libcpp_build() {
@@ -420,10 +428,8 @@ libcpp_build() {
     run_command cmake --build . "${CMAKE_BUILD_ARGS[@]}" 2>&1 | tee -a "${LOGS_DIR}/libcpp.txt"
     run_command cmake --install . 2>&1 | tee -a "${LOGS_DIR}/libcpp.txt"
     export LD_LIBRARY_PATH="${ATFL_DIR}/lib:${ATFL_DIR}/lib/${ATFL_TARGET_TRIPLE}:${LD_LIBRARY_PATH}"
-    LIT_OPTS="${LIT_OPTS} --xunit-xml-output=${LOGS_DIR}/check_cxx.xml" \
-        run_command ninja "${NINJA_ARGS[@]}" check-cxx 2>&1 | tee -a "${LOGS_DIR}/libcpp.txt"
-    LIT_OPTS="${LIT_OPTS} --xunit-xml-output=${LOGS_DIR}/check_cxxabi.xml" \
-        run_command ninja "${NINJA_ARGS[@]}" check-cxxabi 2>&1 | tee -a "${LOGS_DIR}/libcpp.txt"
+    run_lit_ninja "${LOGS_DIR}/check_cxx.xml" "${LOGS_DIR}/libcpp.txt" check-cxx
+    run_lit_ninja "${LOGS_DIR}/check_cxxabi.xml" "${LOGS_DIR}/libcpp.txt" check-cxxabi
 }
 
 product_build() {
@@ -477,8 +483,8 @@ product_build() {
     cp -d "${ATFL_DIR}"/lib/clang/*/lib/"${ATFL_TARGET_TRIPLE}"/libflang_rt* \
         "${ATFL_DIR}/lib/${ATFL_TARGET_TRIPLE}"
     echo "-Wl,-rpath=${ATFL_DIR}/lib" >> "${BUILD_DIR}"/bootstrap_compiler/bin/clang++.cfg
-    LIT_OPTS="${LIT_OPTS} --xunit-xml-output=${LOGS_DIR}/product_check_all.xml" \
-        run_command ninja "${NINJA_ARGS[@]}" check-all 2>&1 | tee -a "${LOGS_DIR}/product.txt"
+    run_lit_ninja "${LOGS_DIR}/product_check_all.xml" "${LOGS_DIR}/product.txt" check-all
+
     bootstrap_compiler_default_config
 }
 
@@ -520,7 +526,7 @@ static_libomp_build() {
     cp "${ATFL_DIR}".libs/lib/lib*.a \
         "${ATFL_DIR}/lib/${ATFL_TARGET_TRIPLE}"
     rm -r "${ATFL_DIR}.libs"
-    run_command ninja "${NINJA_ARGS[@]}" check-openmp 2>&1 | tee -a "${LOGS_DIR}/static_libomp.txt"
+    run_lit_ninja "${LOGS_DIR}/check_openmp.xml" "${LOGS_DIR}/static_libomp.txt" check-openmp
 }
 
 check_lit_xml_results() {


### PR DESCRIPTION
Also, ensure to continue tests even on test failure.
At end of build and test, add a check to indicate if there is test failure, and appropriately reflect the status in CI pipelines.