### PR TITLE
[ATfE] Switch to using llvm-lit internal shell

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/gen-picolibc-lit-tests.py
+++ b/arm-software/embedded/arm-runtimes/test-support/gen-picolibc-lit-tests.py
@@ -90,7 +90,7 @@ lit.llvm.initialize(lit_config, config)
 
 config.name = "%CONFIG_NAME%"
 config.suffixes = [".test"]
-config.test_format = lit.formats.ShTest(not lit.llvm.llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest()
 config.test_source_root = os.path.join(os.path.dirname(__file__), "tests")
 """
     with open(os.path.join(args.output, "lit.cfg.py"), "w", encoding="utf-8") as f:

--- a/arm-software/embedded/packagetest/lit.cfg.py
+++ b/arm-software/embedded/packagetest/lit.cfg.py
@@ -11,7 +11,7 @@ from lit.llvm.subst import FindTool, ToolSubst
 # Configuration file for the 'lit' test runner.
 
 config.name = "package"
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest()
 config.suffixes = [".c", ".cpp", ".test"]
 config.excludes = ["CMakeLists.txt", "README.md"]
 config.test_source_root = os.path.dirname(__file__)

--- a/arm-software/embedded/test/lit.cfg.py
+++ b/arm-software/embedded/test/lit.cfg.py
@@ -9,7 +9,7 @@ from lit.llvm import llvm_config
 # Configuration file for the 'lit' test runner.
 
 config.name = "Arm Toolchain for Embedded"
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest()
 config.suffixes = [".c", ".cpp", ".test"]
 config.excludes = ["CMakeLists.txt"]
 config.test_source_root = os.path.dirname(__file__)


### PR DESCRIPTION
Upstream LLVM is removing support for the lit external shell and has deprecated the `execute_external` argument in `ShTest`.

ATfE currently defaults to using the external shell through the standard LLVM lit configuration. The resulting deprecation warning causes our `lit.cfg` generation step to fail.

Our tests do not depend on any external-shell-specific functionality, so it is safe to switch to the internal shell. This change removes the use of the external shell and has been verified to work without affecting test behaviour.

Refer to:
- [RFC 90951](https://discourse.llvm.org/t/rfc-removal-of-the-lit-external-shell/90951)
- [RFC 80179](https://discourse.llvm.org/t/rfc-enabling-the-lit-internal-shell-by-default/80179)
- Deprecation in upstream PR: [203689](https://github.com/llvm/llvm-project/pull/203689)