### PR TITLE
[ATfE] Remove LIBC_CONF_TIME_64BIT that was removed in LLVM

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -825,7 +825,6 @@ if(C_LIBRARY STREQUAL llvmlibc)
         ${compiler_launcher_cmake_args}
         ${common_llvmlibc_cmake_args}
         -DLIBC_TARGET_TRIPLE=${target_triple}
-        -DLIBC_CONF_TIME_64BIT=ON
         -DLIBC_CONF_ERRNO_MODE=LIBC_ERRNO_MODE_SHARED
         -DLIBC_CONF_PRINTF_DISABLE_FLOAT=OFF
         -DLIBC_CONF_PRINTF_FLOAT_TO_STR_USE_FLOAT320=ON


### PR DESCRIPTION
This option was removed in https://github.com/llvm/llvm-project/pull/200426 that made 64-bit time_t the default as expected by ATfE.