### PR TITLE
[ATFE] Move ARM A-profile page table out of flash init section

### DIFF
--- a/arm-software/embedded/llvmlibc-support/crt0/memory_a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/memory_a.h
@@ -92,10 +92,10 @@ void enable_cache() {
 extern "C" [[gnu::weak]] void _platform_setup_memory() {
   invalidate_cache();
 #if __ARM_ARCH_PROFILE == 'A'
-  // Put the page table in the .init section so it doesn't later get
+  // Put the page table in a no-init section so it doesn't later get
   // zero-initialized.
   static_assert(sizeof(unsigned long) == PAGE_TABLE_ENTRY_SIZE);
-  [[gnu::section(".init"), gnu::aligned(PAGE_TABLE_ALIGNMENT)]]
+  [[gnu::section(".noinit.page_table"), gnu::aligned(PAGE_TABLE_ALIGNMENT)]]
   static volatile unsigned long pagetable[PAGE_TABLE_ENTRY_COUNT];
   setup_mmu(pagetable, get_stackheap_start(), get_stackheap_end());
 #endif

--- a/arm-software/embedded/llvmlibc-support/llvmlibc.ld.in
+++ b/arm-software/embedded/llvmlibc-support/llvmlibc.ld.in
@@ -267,6 +267,10 @@ SECTIONS
 	PROVIDE( __data_size = __data_end - __data_start );
 	PROVIDE( __data_source_size = __data_source_end - __data_source );
 
+	.noinit.page_table (NOLOAD) : {
+		KEEP (*(.noinit.page_table .noinit.page_table.*))
+	} >ram AT>ram :ram
+
 	.tbss (NOLOAD) : {
 		*(.tbss .tbss.* .gnu.linkonce.tb.*)
 		*(.tcommon)

--- a/arm-software/embedded/llvmlibc-support/llvmlibc.ld.in
+++ b/arm-software/embedded/llvmlibc-support/llvmlibc.ld.in
@@ -267,9 +267,13 @@ SECTIONS
 	PROVIDE( __data_size = __data_end - __data_start );
 	PROVIDE( __data_source_size = __data_source_end - __data_source );
 
+	/* ATfE:begin */
+        /* Page tables are initialized before .bss is cleared, so keep them
+	 * outside the zero-initialized sections. */
 	.noinit.page_table (NOLOAD) : {
 		KEEP (*(.noinit.page_table .noinit.page_table.*))
 	} >ram AT>ram :ram
+	/* ATfE:end */
 
 	.tbss (NOLOAD) : {
 		*(.tbss .tbss.* .gnu.linkonce.tb.*)


### PR DESCRIPTION
This updates the llvmlibc startup and linker support so the ARM A-profile MMU page table is placed in a dedicated no-init RAM section instead of .init.

Changes:

  - Places the startup page table in .noinit.page_table.
  - Adds a NOLOAD linker section for .noinit.page_table, kept in RAM.
  - Preserves the existing goal of avoiding zero-initialization while preventing the page table from being treated as flash/init content.

Reason: When linking with the LLVM libc boot code, the  boot-stage code size exceeds the currently allocated boot_flash memory region after MMU initialization and related early boot setup are included. This results in linker failures such as:

`ld.lld: error: section '.boot_flash' will not fit in region 'boot_flash': overflowed by 6020 bytes`