### PR TITLE
[ATfE] Apply timeout multiplier to slow picolibc tests

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -537,8 +537,9 @@ if(C_LIBRARY STREQUAL picolibc)
         # Timeout multipliers. The actual timeout value used in testing is:
         # Timeout in seconds (defined in the picolibc's testing specs) x Timeout multiplier
         # In general, tests execute slower with FVPs compared to qemu, but specific tests are
-        # more impacted by the model performance than others due to significant looping. This
-        # timeout is only applied to those tests, via lit.
+        # more impacted by the model performance than others due to significant looping. Running
+        # the tests directly through meson only allows a timeout to be set for all tests, but
+        # using the lit wrapper allows the timeout to be customized per test.
         # Certain variants can also be slower due to the particular model, or specific
         # features enabled, for example:
         # * Armv6m big-endian
@@ -550,7 +551,7 @@ if(C_LIBRARY STREQUAL picolibc)
             else()
                 set(timeout_multiplier 2)
             endif()
-            set(picolibc_timeout_arg --slow-timeout ${timeout_multiplier})
+            set(picolibc_timeout_arg --slow-tests-timeout-multiplier ${timeout_multiplier})
         endif()
 
         # Step target to run the picolibc test via meson.

--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -536,26 +536,28 @@ if(C_LIBRARY STREQUAL picolibc)
 
         # Timeout multipliers. The actual timeout value used in testing is:
         # Timeout in seconds (defined in the picolibc's testing specs) x Timeout multiplier
-        # In general, tests execute slower with FVPs compared to qemu. However certain
-        # variants can also be slower due to features enabled, for example: 
+        # In general, tests execute slower with FVPs compared to qemu, but specific tests are
+        # more impacted by the model performance than others due to significant looping. This
+        # timeout is only applied to those tests, via lit.
+        # Certain variants can also be slower due to the particular model, or specific
+        # features enabled, for example:
         # * Armv6m big-endian
         # * Armv7m big-endian
         # * Armv8.1-M Main PACBTI optimized for code size
         if(TEST_EXECUTOR STREQUAL fvp)
-            if(VARIANT MATCHES "armebv7a")
-                set(timeout_multiplier 3)
+            if(VARIANT MATCHES "^(armebv|^armv8\.1m\.main.*pacret.*size)")
+                set(timeout_multiplier 5)
             else()
                 set(timeout_multiplier 2)
             endif()
-        else()
-            set(timeout_multiplier 1)
+            set(picolibc_timeout_arg --slow-timeout ${timeout_multiplier})
         endif()
 
         # Step target to run the picolibc test via meson.
         ExternalProject_Add_Step(
             picolibc
             check-meson
-            COMMAND ${MESON_EXECUTABLE} test -C <BINARY_DIR> --no-rebuild -t ${timeout_multiplier}
+            COMMAND ${MESON_EXECUTABLE} test -C <BINARY_DIR> --no-rebuild
             USES_TERMINAL TRUE
             EXCLUDE_FROM_MAIN TRUE
             ALWAYS TRUE
@@ -573,7 +575,7 @@ if(C_LIBRARY STREQUAL picolibc)
                 --build <BINARY_DIR>
                 --output ${picolibc_lit_dir}
                 --name picolibc-${variant_xml_name}
-                --timeout-multiplier ${timeout_multiplier}
+                ${picolibc_timeout_arg}
             USES_TERMINAL TRUE
             EXCLUDE_FROM_MAIN TRUE
             DEPENDEES compile-tests

--- a/arm-software/embedded/arm-runtimes/test-support/gen-picolibc-lit-tests.py
+++ b/arm-software/embedded/arm-runtimes/test-support/gen-picolibc-lit-tests.py
@@ -45,7 +45,14 @@ def main():
         help="Name to give the lit suite.",
     )
     arg_parser.add_argument(
-        "--timeout-multiplier", type=float, help="Timeout multiplier (float)."
+        "--timeout-multiplier",
+        type=float,
+        help="Global timeout multiplier, applied to all tests (float).",
+    )
+    arg_parser.add_argument(
+        "--slow-timeout",
+        type=float,
+        help="Timeout multiplier for slow tests only (float).",
     )
 
     args = arg_parser.parse_args()
@@ -62,6 +69,19 @@ def main():
         text=True,
     )
 
+    # List of tests that are known to take longer to run.
+    slow_testnames = [
+        "test-long-double",
+        "test-long-double",
+        "test-long-long-float",
+        "test-long-long-int",
+        "test-long-long-long",
+        "test-long-long",
+        "test-memchr",
+        "test-memmem",
+        "test-memset",
+    ]
+
     for line in p.stdout.splitlines():
         # Meson lists tests in the format of
         # [SUBPROJECT]:[PATH] / [TESTNAME]
@@ -77,7 +97,13 @@ def main():
             # Invoke meson to run the test.
             # Set --logbase so that each has a unique log name.
             cmd = f"# RUN: {args.meson} test -C {args.build} {testname} --logbase {testname} --no-rebuild"
-            if args.timeout_multiplier and args.timeout_multiplier != 1:
+            if (
+                testname in slow_testnames
+                and args.slow_timeout
+                and args.slow_timeout != 1
+            ):
+                cmd += f" -t {args.slow_timeout}"
+            elif args.timeout_multiplier and args.timeout_multiplier != 1:
                 cmd += f" -t {args.timeout_multiplier}"
             f.write(f"{cmd}\n")
 

--- a/arm-software/embedded/arm-runtimes/test-support/gen-picolibc-lit-tests.py
+++ b/arm-software/embedded/arm-runtimes/test-support/gen-picolibc-lit-tests.py
@@ -45,12 +45,12 @@ def main():
         help="Name to give the lit suite.",
     )
     arg_parser.add_argument(
-        "--timeout-multiplier",
+        "--global-timeout-multiplier",
         type=float,
         help="Global timeout multiplier, applied to all tests (float).",
     )
     arg_parser.add_argument(
-        "--slow-timeout",
+        "--slow-tests-timeout-multiplier",
         type=float,
         help="Timeout multiplier for slow tests only (float).",
     )
@@ -99,12 +99,12 @@ def main():
             cmd = f"# RUN: {args.meson} test -C {args.build} {testname} --logbase {testname} --no-rebuild"
             if (
                 testname in slow_testnames
-                and args.slow_timeout
-                and args.slow_timeout != 1
+                and args.slow_tests_timeout_multiplier
+                and args.slow_tests_timeout_multiplier != 1
             ):
-                cmd += f" -t {args.slow_timeout}"
-            elif args.timeout_multiplier and args.timeout_multiplier != 1:
-                cmd += f" -t {args.timeout_multiplier}"
+                cmd += f" -t {args.slow_tests_timeout_multiplier}"
+            elif args.global_timeout_multiplier and args.global_timeout_multiplier != 1:
+                cmd += f" -t {args.global_timeout_multiplier}"
             f.write(f"{cmd}\n")
 
     # Simple lit config to run the tests.


### PR DESCRIPTION
Certain picolibc tests take significantly longer to run than others, due to the test running through a lot of loops combined with a lower execution speed of the model. Most tests complete in seconds, but some can take minutes.

Rather than set an excessively long timeout for all tests, this patch specifies a longer timeout for the tests observed to take the longest (variations on test-long and test-mem), on the variants observed to have slower performing models (arm v6/v7 big endian and v8.1m main PACBTI optimized for code size).

Running the tests through meson usually only allows a timeout multiplier to be set for all tests, however since ATfE has a lit wrapper around the tests to invoke meson individually for each test, each test can instead have its own multiplier. This has been split off into it's own option in the lit generator script: one option for a global multiplier and another specifically for the slow tests. The CMake target for running the tests directly through meson cannot support both, but this target is not the default and was only retained for diagnostics.