### PR TITLE
[ATfL][build.sh] Continue despite test failures

### DIFF
--- a/arm-software/linux/build.sh
+++ b/arm-software/linux/build.sh
@@ -241,8 +241,10 @@ run_test_command() {
     local log_file="$2"
     shift 2
 
-    LIT_OPTS="${LIT_OPTS} --xunit-xml-output=${xml_output}" \
-        run_command ninja "${NINJA_ARGS[@]}" "$@" 2>&1 | tee -a "${log_file}"
+    if ! LIT_OPTS="${LIT_OPTS} --xunit-xml-output=${xml_output}" \
+        run_command ninja "${NINJA_ARGS[@]}" "$@" 2>&1 | tee -a "${log_file}"; then
+        echo "WARNING: Test command failed, continuing: $*" | tee -a "${log_file}"
+    fi
 }
 
 print_help() {
@@ -550,8 +552,8 @@ check_lit_xml_results() {
         fi
 
         if grep -Eq '<failure([ >])| failures="[1-9][0-9]*"| errors="[1-9][0-9]*"' "${result_file}"; then
-            echo "lit reported failures in: ${result_file}" >&2
-            failed=true
+            # Test failures does not mean abort!
+            echo "WARNING: lit reported failures in: ${result_file}" >&2
         fi
     done
 


### PR DESCRIPTION
It is becoming increasingly common for LLVM test failures to bring down our whole build process resulting in no packages to run against our other test suites.
Therefore consider test failures as soft failures, thus allowing the build to continue till the package creation stage.

A future patch will signal the caller Jenkins job to mark test failures in Amber.