### PR TITLE
[TEP-2098] Revert Windows CI runner to GH hosted

### DIFF
--- a/.github/workflows/atfe_nightly_build_and_test.yml
+++ b/.github/workflows/atfe_nightly_build_and_test.yml
@@ -47,7 +47,7 @@ jobs:
             test_script: ''
             install_script: install_dependencies.ps1
             target_os: Windows-2022-x86_64
-            runner: ah-windows_2022-c7a_24x-200
+            runner: ToolchainGroup_LargeRunner_Windows-x64
 
           - build_script: build.sh
             test_script: test_package_only.sh


### PR DESCRIPTION
Use GH hosted Windows runner whilst infra issues are investigated.