### PR TITLE
[ATfE] Remove x bit and #! lines from Python library modules.

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
+++ b/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
 
 import os

--- a/arm-software/embedded/arm-runtimes/test-support/run_qemu.py
+++ b/arm-software/embedded/arm-runtimes/test-support/run_qemu.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2023, Arm Limited and affiliates.
 
 import subprocess


### PR DESCRIPTION
`run_fvp.py` and `run_qemu.py` define functions for other Python code to use, but don't do anything when run by themselves. So it's misleading to have them marked as executable in the filesystem with a `#!` line pointing at the Python interpreter: that tempts a user into running one and finding that it does nothing and won't even respond to --help.

(For example, you might have been looking for lit-exec-fvp.py, which _is_ properly executable, and found this instead. Putting the x bit only on one of those files makes it easier to tell which is which. In particular, a well configured shell will avoid tab-completing it.)