### PR TITLE
Remove xfails for LLVMAENG-6364 which is now fixed.

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/xfails.py
+++ b/arm-software/embedded/arm-runtimes/test-support/xfails.py
@@ -1003,30 +1003,6 @@ def main():
             description="wrong lane indices for SIMD mask on BE target (LLVMAENG-6202)",
         ),
         XFail(
-            name="ldexp/scalbn FP rounding",
-            testnames=[
-                "src/math/libc.test.src.math.ldexp_test.__hermetic__.__build__",
-                "src/math/libc.test.src.math.ldexpl_test.__hermetic__.__build__",
-                "src/math/smoke/libc.test.src.math.smoke.ldexp_test.__hermetic__.__build__",
-                "src/math/smoke/libc.test.src.math.smoke.ldexpl_test.__hermetic__.__build__",
-                "src/math/smoke/libc.test.src.math.smoke.scalbln_test.__hermetic__.__build__",
-                "src/math/smoke/libc.test.src.math.smoke.scalblnl_test.__hermetic__.__build__",
-                "src/math/smoke/libc.test.src.math.smoke.scalbn_test.__hermetic__.__build__",
-                "src/math/smoke/libc.test.src.math.smoke.scalbnl_test.__hermetic__.__build__",
-            ],
-            result=NewResult.XFAILED,
-            project="llvmlibc",
-            variants=[
-                "armebv7m_hard_fpv4_sp_d16_exn_rtti_size",
-                "armebv7m_hard_fpv4_sp_d16_size",
-                "armebv7m_soft_fpv4_sp_d16_exn_rtti_size",
-                "armebv7m_soft_fpv4_sp_d16_size",
-                "armebv7m_soft_nofp_exn_rtti_size",
-                "armebv7m_soft_nofp_size",
-            ],
-            description="ldexp/scalbn Floating point rounding failures on BE Variants (LLVMAENG-6364)",
-        ),
-        XFail(
             name="variadic vector type arguments",
             testnames=[
                 "src/__support/libc.test.src.__support.arg_list_test.__hermetic__.__build__",


### PR DESCRIPTION
The fix is commit 099b1f6aeec8058: the tests of ldexp and scalbn were failing because they compared the results of those functions against the result of using `__divdf3` for the equivalent calculation, and the latter was wrong, due to an underflow-handling bug in `__divdf3` fixed in that commit.