### PR TITLE
Install psutil for ATfE test dependencies

### DIFF
--- a/arm-software/embedded/scripts/install_dependencies.ps1
+++ b/arm-software/embedded/scripts/install_dependencies.ps1
@@ -7,4 +7,4 @@
 
 # Upgrade pip and install meson
 python -m pip install --upgrade pip
-python -m pip install meson==1.2.3 pyyaml==6.0.3
+python -m pip install meson==1.2.3 psutil==7.2.2 pyyaml==6.0.3

--- a/arm-software/embedded/scripts/install_dependencies.sh
+++ b/arm-software/embedded/scripts/install_dependencies.sh
@@ -20,7 +20,7 @@ sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 
 # Upgrade pip and install dependencies
 python3 -m pip install --upgrade pip
-python3 -m pip install --user cmake==4.3.0 meson==1.2.3 ruff==0.8.6
+python3 -m pip install --user cmake==4.3.0 meson==1.2.3 psutil==7.2.2 ruff==0.8.6
 
 export PATH="${HOME}/.local/bin:${PATH}"
 cmake --version

--- a/arm-software/embedded/scripts/install_dependencies_macos.sh
+++ b/arm-software/embedded/scripts/install_dependencies_macos.sh
@@ -54,6 +54,6 @@ fi
 
 # Upgrade pip and install Python tooling inside the virtual environment
 python -m pip install --upgrade pip
-python -m pip install cmake==4.3.0 meson==1.2.3 pyyaml==6.0.3 ruff==0.8.6
+python -m pip install cmake==4.3.0 meson==1.2.3 psutil==7.2.2 pyyaml==6.0.3 ruff==0.8.6
 
 cmake --version


### PR DESCRIPTION
Install psutil for ATfE test dependencies

- Lit needs psutil to enforce per-test timeouts and terminate child processes. 
- Add it to the ATfE dependency installers so hung tests hopefully fail with a timeout instead of blocking the test stage indefinitely.