### PR TITLE
[ATfE] Remove experimental status of llvmlibc

### DIFF
--- a/arm-software/embedded/CHANGELOG.md
+++ b/arm-software/embedded/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 definitions can be overridden by users on platforms without native atomic
 operation support.
 ### Changed
+- LLVM libc support is no longer marked experimental and is considered
+production quality for typical embedded use cases.
+
 ### Deprecated
 - `picolibc` will be superseded with LLVM libc as the default C library in
   ATfE 24. Further in ATfE 25 `picolibc` will be moved out of the main ATfE

--- a/arm-software/embedded/README.md
+++ b/arm-software/embedded/README.md
@@ -104,6 +104,10 @@ Install appropriate latest supported Microsoft Visual C++ Redistributable packag
 > If you are using the toolchain in a shared environment with untrusted input,
 > make sure it is sufficiently sandboxed.
 
+> [!NOTE]
+> See [Using LLVM libc](docs/llvmlibc.md#using-llvm-libc) for details about
+> using LLVM Project standard C library provided with ATfE.
+
 To use the toolchain, on the command line you need to provide the following options:
 * The target triple.
 * The FPU to use.

--- a/arm-software/embedded/docs/llvmlibc.md
+++ b/arm-software/embedded/docs/llvmlibc.md
@@ -1,13 +1,10 @@
-# Experimental LLVM libc support
+# LLVM libc support
 
 Arm Toolchain for Embedded (ATfE) uses
 [`picolibc`](https://github.com/picolibc/picolibc) as the standard C
-library. For experimental and evaluation purposes, you can instead
-choose to use the LLVM project's own C library.
-
-> [!WARNING]
-> `llvmlibc` support in Arm Toolchain for Embedded is
-> an experimental technology preview, with significant limitations.
+library. This will change in a future version to use the [LLVM project's own
+C library](https://libc.llvm.org/) that is now provided with ATfE to facilitate
+the migration.
 
 ## Building the toolchain with LLVM libc
 
@@ -300,10 +297,11 @@ $ LIBC=llvmlibc make build
 
 ## Limitations of LLVM libc in Arm Toolchain for Embedded
 
-At present, this toolchain builds the C++ libraries limited to what is supported
-in conjunction with LLVM libc. For example, file I/O and fstream are not
-available - only console iostream can be used.
+LLVM libc is a production-quality implementation, but it currently provides only
+a subset of the functions defined by the C standard.
+Its coverage is sufficient for typical embedded use cases and continues to grow
+based on user needs and requests.
 
-LLVM libc is a work in
-progress. It is incomplete: not all standard C library functionality
-is provided yet.
+ATfE builds of the C++ libraries are limited to what is supported
+in conjunction with LLVM libc. For example, file I/O and `fstream` are not
+available - only console `iostream` can be used.


### PR DESCRIPTION
Update the LLVM libc doc to remove "experimental" status, clarify the scope, add a more prominent link from the main README.