### PR TITLE
Defend banked SP setup against register allocator

### DIFF
--- a/arm-software/embedded/llvmlibc-support/crt0/misc_a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/misc_a.h
@@ -92,17 +92,25 @@ extern "C" [[gnu::weak]] void _platform_setup_arch_extensions() {
 #if !defined(__ARM_ARCH_ISA_A64) &&                                            \
     !(__ARM_ARCH_PROFILE == 'R' && __ARM_ARCH >= 8)
   // Copy the current sp value to each of the banked copies of sp.
-  __arm_wsr("CPSR_c", 0x11); // FIQ
-  asm volatile("mov sp, %0" : : "r"(__builtin_frame_address(0)));
-  __arm_wsr("CPSR_c", 0x12); // IRQ
-  asm volatile("mov sp, %0" : : "r"(__builtin_frame_address(0)));
-  __arm_wsr("CPSR_c", 0x17); // ABT
-  asm volatile("mov sp, %0" : : "r"(__builtin_frame_address(0)));
-  __arm_wsr("CPSR_c", 0x1B); // UND
-  asm volatile("mov sp, %0" : : "r"(__builtin_frame_address(0)));
-  __arm_wsr("CPSR_c", 0x1F); // SYS
-  asm volatile("mov sp, %0" : : "r"(__builtin_frame_address(0)));
-  __arm_wsr("CPSR_c", 0x13); // SVC
+  asm volatile(
+      "mov r0, sp\n"
+      "mov r1, #0x11\n" // FIQ
+      "msr CPSR_c, r1\n"
+      "mov sp, r0\n"
+      "mov r1, #0x12\n" // IRQ
+      "msr CPSR_c, r1\n"
+      "mov sp, r0\n"
+      "mov r1, #0x17\n" // ABT
+      "msr CPSR_c, r1\n"
+      "mov sp, r0\n"
+      "mov r1, #0x1B\n" // UND
+      "msr CPSR_c, r1\n"
+      "mov sp, r0\n"
+      "mov r1, #0x1F\n" // SYS
+      "msr CPSR_c, r1\n"
+      "mov sp, r0\n"
+      "mov r1, #0x13\n" // return to SVC
+      "msr CPSR_c, r1" : : : "r0", "r1");
 #endif
 }
 


### PR DESCRIPTION
This is the same change in ATfE's startup code that upstream commit 73e1c53474a46a9 made in LLVM libc's, and for the same reason: switching between AArch32 CPU modes swaps out banked registers (at least lr, and r8-r12 too if FIQ mode is involved), and therefore it isn't safe to do it in a context where the compiler might have chosen to allocate important values in those registers.