### PR TITLE
Update ATfL repository installation instructions

### DIFF
--- a/arm-software/linux/docs/Installation.md
+++ b/arm-software/linux/docs/Installation.md
@@ -4,141 +4,176 @@ This section describes how to download and install the Arm Toolchain for Linux.
 
 ### Note
 
-The recommended installation method requires system administrator (`root`)
-assistance. Non-root installation is also possible, see below.
+The system package manager installation method requires system administrator
+(`root`) assistance. To install without `root` privileges, see
+[Non-root installation method](#non-root-installation-method).
 
-## Recommended installation method
+## Recommended installation method using system package manager
 
-The first step is to configure your Linux package manager to be able to fetch
-packages from Arm. You do this step only once.
+You can install and upgrade Arm Toolchain for Linux using Linux system package
+managers and the Arm Toolchains package repositories. Installing the
+`arm-toolchain-for-linux` package also installs the Arm Performance Libraries,
+which are a required dependency.
 
-From the available options, select the packages repository that matches your
-installed Linux distribution. This adds the Arm toolchain repository to the
-package manager:
+### Arm Toolchains Linux package repository signing key change
 
-* Ubuntu 22.04
+Arm has recently reviewed and strengthened its repository management processes.
+As a result, Arm has revoked and replaced the Arm Toolchains repository signing
+key used up to July 2026.
 
-```
-$ curl "https://developer.arm.com/packages/arm-toolchains:ubuntu-22/jammy/Release.key" | sudo gpg --dearmor -o /usr/share/keyrings/obs-oss-arm-com.gpg
+Current installations of Arm Toolchain for Linux continue to work, although
+package manager update or upgrade operations may fail. Existing package users
+must install the latest `arm-toolchains-repository` package for their
+distribution, as shown below.
 
-$ echo "deb [signed-by=/usr/share/keyrings/obs-oss-arm-com.gpg] https://developer.arm.com/packages/arm-toolchains:ubuntu-22/jammy/ ./" | sudo tee /etc/apt/sources.list.d/obs-oss-arm-com.list
+For more information, see the
+[Arm Toolchains repository installation guide](https://learn.arm.com/install-guides/arm-toolchains-repository).
 
-$ sudo apt update
+### Amazon Linux 2023
 
-$ sudo apt install arm-toolchains-transition
-
-$ sudo apt update
-```
-
-* Ubuntu 24.04
-
-```
-$ curl "https://developer.arm.com/packages/arm-toolchains:ubuntu-24/noble/Release.key" | sudo gpg --dearmor -o /usr/share/keyrings/obs-oss-arm-com.gpg
-
-$ echo "deb [signed-by=/usr/share/keyrings/obs-oss-arm-com.gpg] https://developer.arm.com/packages/arm-toolchains:ubuntu-24/noble/ ./" | sudo tee /etc/apt/sources.list.d/obs-oss-arm-com.list
-
-$ sudo apt update
-
-$ sudo apt install arm-toolchains-transition
-
-$ sudo apt update
-```
-
-* Red Hat Enterprise Linux 8
+To configure the Arm Toolchains repository on Amazon Linux 2023:
 
 ```
-$ sudo dnf install 'dnf-command(config-manager)'
-
-$ sudo dnf config-manager -y --add-repo https://developer.arm.com/packages/arm-toolchains:rhel-8/el8/arm-toolchains:rhel-8.repo
-
-$ sudo dnf install arm-toolchains-transition
+$ sudo dnf install https://developer.arm.com/packages/arm-toolchains/amazonlinux/al2023/aarch64/arm-toolchains-repository-2-2.al2023.noarch.rpm
 ```
 
-* Red Hat Enterprise Linux 9
-
-```
-$ sudo dnf install 'dnf-command(config-manager)'
-
-$ sudo dnf config-manager -y --add-repo https://developer.arm.com/packages/arm-toolchains:rhel-9/el9/arm-toolchains:rhel-9.repo
-
-$ sudo dnf install arm-toolchains-transition
-```
-
-* Red Hat Enterprise Linux 10
-
-```
-$ sudo dnf install 'dnf-command(config-manager)'
-
-$ sudo dnf config-manager -y --add-repo https://developer.arm.com/packages/arm-toolchains:rhel-10/el10/arm-toolchains:rhel-10.repo
-
-$ sudo dnf install arm-toolchains-transition
-```
-
-* Amazon Linux 2023
-
-```
-$ sudo dnf install 'dnf-command(config-manager)'
-
-$ sudo dnf config-manager -y --add-repo https://developer.arm.com/packages/arm-toolchains:amzn-2023/al2023/arm-toolchains:amzn-2023.repo
-
-$ sudo dnf install arm-toolchains-transition
-```
-
-* SUSE Linux Enterprise Server 15
-
-```
-$ sudo zypper ar -f https://developer.arm.com/packages/arm-toolchains:sles-15/sl15/arm-toolchains:sles-15.repo
-
-$ sudo zypper install arm-toolchains-transition
-```
-
-* SUSE Linux Enterprise Server 16
-
-```
-$ sudo zypper ar -f https://developer.arm.com/packages/arm-toolchains/sles/sles16/aarch64/arm-toolchains-repository-1-1.sles16.aarch64.rpm
-
-$ sudo zypper --gpg-auto-import-keys --no-gpg-checks refresh --repo arm-toolchains
-```
-
-Select the installation command appropriate for your Linux distribution. This
-installs the Arm Toolchain for Linux, along with the Arm Performance Libraries,
-which is a required dependency:
-
-* Ubuntu systems
-
-```
-$ sudo apt install arm-toolchain-for-linux
-```
-
-* Red Hat Enterprise Linux and Amazon Linux systems
+Install the latest Arm Toolchain for Linux release:
 
 ```
 $ sudo dnf install arm-toolchain-for-linux
 ```
 
-* SUSE Linux Enterprise Server systems
+Upgrade an existing package-manager installation:
 
 ```
-$ sudo zypper install arm-toolchain-for-linux
+$ sudo dnf upgrade arm-toolchain-for-linux
+```
+
+### Red Hat Enterprise Linux 8, 9, and 10
+
+To configure the Arm Toolchains repository on Red Hat Enterprise Linux 8:
+
+```
+$ sudo dnf install https://developer.arm.com/packages/arm-toolchains/arm-toolchains/rhel/el8/aarch64/arm-toolchains-repository-2-2.el8.noarch.rpm
+```
+
+To configure the Arm Toolchains repository on Red Hat Enterprise Linux 9:
+
+```
+$ sudo dnf install https://developer.arm.com/packages/arm-toolchains/arm-toolchains/rhel/el9/aarch64/arm-toolchains-repository-2-2.el9.noarch.rpm
+```
+
+To configure the Arm Toolchains repository on Red Hat Enterprise Linux 10:
+
+```
+$ sudo dnf install https://developer.arm.com/packages/arm-toolchains/arm-toolchains/rhel/el10/aarch64/arm-toolchains-repository-2-2.el10.noarch.rpm
+```
+
+Install the latest Arm Toolchain for Linux release:
+
+```
+$ sudo dnf install arm-toolchain-for-linux
+```
+
+Upgrade an existing package-manager installation:
+
+```
+$ sudo dnf upgrade arm-toolchain-for-linux
+```
+
+### SUSE Linux Enterprise Server 15 and 16
+
+To configure the Arm Toolchains repository on SUSE Linux Enterprise Server 15:
+
+```
+$ sudo rpm -U --nosignature https://developer.arm.com/packages/arm-toolchains/arm-toolchains/arm-toolchains/sles/sles15/aarch64/arm-toolchains-repository-2-2.sles15.noarch.rpm
+```
+
+To configure the Arm Toolchains repository on SUSE Linux Enterprise Server 16:
+
+```
+$ sudo rpm -U --nosignature https://developer.arm.com/packages/arm-toolchains/arm-toolchains/arm-toolchains/sles/sles16/aarch64/arm-toolchains-repository-2-2.sles16.noarch.rpm
+```
+
+Install the latest Arm Toolchain for Linux release:
+
+```
+$ sudo zypper --gpg-auto-import-keys install arm-toolchain-for-linux
+```
+
+Upgrade an existing package-manager installation:
+
+```
+$ sudo zypper up --allow-vendor-change arm-toolchain-for-linux
+```
+
+### Ubuntu Linux 22.04 and 24.04
+
+To configure the Arm Toolchains repository on Ubuntu 22.04:
+
+```
+$ curl -O https://developer.arm.com/packages/arm-toolchains/ubuntu/pool/arm-toolchains-repository_2-2~jammy_all.deb
+$ sudo dpkg -i arm-toolchains-repository_2-2~jammy_all.deb
+$ sudo apt update
+```
+
+To configure the Arm Toolchains repository on Ubuntu 24.04:
+
+```
+$ curl -O https://developer.arm.com/packages/arm-toolchains/ubuntu/pool/arm-toolchains-repository_2-2~noble_all.deb
+$ sudo dpkg -i arm-toolchains-repository_2-2~noble_all.deb
+$ sudo apt update
+```
+
+Install the latest Arm Toolchain for Linux release:
+
+```
+$ sudo apt install arm-toolchain-for-linux
+```
+
+Upgrade an existing package-manager installation:
+
+```
+$ sudo apt upgrade arm-toolchain-for-linux
 ```
 
 ## Non-root installation method
 
-You can install the Arm Toolchain for Linux, along with the Arm Performance
-Libraries in any directory that you wish to specify. For this, the auxiliary
-installation script can be used. This script does not require system
-administrator (`root`) assistance:
+You can install Arm Toolchain for Linux and Arm Performance Libraries in a
+directory you choose without administrator (`root`) assistance by using the
+auxiliary installation script.
+
+First, download the installation script:
+
+```
+$ curl -L -o user_install.sh https://developer.arm.com/-/cdn-downloads/permalink/Arm-Toolchain-for-Linux/Package/user_install.sh
+```
+
+Run the script and specify the installation directory:
+
+```
+$ bash user_install.sh --yes <installation_directory>
+```
+
+The `<installation_directory>` path can be absolute or relative. For example,
+to install into the current directory:
+
+```
+$ bash user_install.sh --yes .
+```
+
+As a convenience, you can also download and run the script in a single command
+using Bash process substitution:
 
 ```
 $ bash <(curl -L https://developer.arm.com/-/cdn-downloads/permalink/Arm-Toolchain-for-Linux/Package/user_install.sh) --yes <installation_directory>
 ```
 
-The `<installation_directory>` path can be either absolute or relative.
-For example, you can invoke a local directory installation:
+For example, to install into the current directory:
 
 ```
 $ bash <(curl -L https://developer.arm.com/-/cdn-downloads/permalink/Arm-Toolchain-for-Linux/Package/user_install.sh) --yes .
 ```
 
-After completion, you can see the `opt` directory tree unpacked into your local
+After completion, the `opt` directory tree is unpacked into the installation
 directory.

--- a/arm-software/linux/docs/Installation.md
+++ b/arm-software/linux/docs/Installation.md
@@ -15,9 +15,9 @@ managers and the Arm Toolchains package repositories. Installing the
 `arm-toolchain-for-linux` package also installs the Arm Performance Libraries,
 which are a required dependency.
 
-### Arm Toolchains Linux package repository signing key change
+### Arm Toolchains Linux package repository signing key change July 2026
 
-Arm has recently reviewed and strengthened its repository management processes.
+Arm regularly reviews and strengthens its repository management processes.
 As a result, Arm has revoked and replaced the Arm Toolchains repository signing
 key used up to July 2026.
 
@@ -54,19 +54,19 @@ $ sudo dnf upgrade arm-toolchain-for-linux
 To configure the Arm Toolchains repository on Red Hat Enterprise Linux 8:
 
 ```
-$ sudo dnf install https://developer.arm.com/packages/arm-toolchains/arm-toolchains/rhel/el8/aarch64/arm-toolchains-repository-2-2.el8.noarch.rpm
+$ sudo dnf install https://developer.arm.com/packages/arm-toolchains/rhel/el8/aarch64/arm-toolchains-repository-2-2.el8.noarch.rpm
 ```
 
 To configure the Arm Toolchains repository on Red Hat Enterprise Linux 9:
 
 ```
-$ sudo dnf install https://developer.arm.com/packages/arm-toolchains/arm-toolchains/rhel/el9/aarch64/arm-toolchains-repository-2-2.el9.noarch.rpm
+$ sudo dnf install https://developer.arm.com/packages/arm-toolchains/rhel/el9/aarch64/arm-toolchains-repository-2-2.el9.noarch.rpm
 ```
 
 To configure the Arm Toolchains repository on Red Hat Enterprise Linux 10:
 
 ```
-$ sudo dnf install https://developer.arm.com/packages/arm-toolchains/arm-toolchains/rhel/el10/aarch64/arm-toolchains-repository-2-2.el10.noarch.rpm
+$ sudo dnf install https://developer.arm.com/packages/arm-toolchains/rhel/el10/aarch64/arm-toolchains-repository-2-2.el10.noarch.rpm
 ```
 
 Install the latest Arm Toolchain for Linux release:
@@ -86,26 +86,27 @@ $ sudo dnf upgrade arm-toolchain-for-linux
 To configure the Arm Toolchains repository on SUSE Linux Enterprise Server 15:
 
 ```
-$ sudo rpm -U --nosignature https://developer.arm.com/packages/arm-toolchains/arm-toolchains/arm-toolchains/sles/sles15/aarch64/arm-toolchains-repository-2-2.sles15.noarch.rpm
+$ sudo rpm -U https://developer.arm.com/packages/arm-toolchains/sles/sles15/aarch64/arm-toolchains-repository-2-2.sles15.noarch.rpm
 ```
 
 To configure the Arm Toolchains repository on SUSE Linux Enterprise Server 16:
 
 ```
-$ sudo rpm -U --nosignature https://developer.arm.com/packages/arm-toolchains/arm-toolchains/arm-toolchains/sles/sles16/aarch64/arm-toolchains-repository-2-2.sles16.noarch.rpm
+$ sudo rpm -U https://developer.arm.com/packages/arm-toolchains/sles/sles16/aarch64/arm-toolchains-repository-2-2.sles16.noarch.rpm
 ```
 
 Install the latest Arm Toolchain for Linux release:
 
 ```
-$ sudo zypper --gpg-auto-import-keys install arm-toolchain-for-linux
+$ sudo zypper install arm-toolchain-for-linux
 ```
 
 Upgrade an existing package-manager installation:
 
 ```
-$ sudo zypper up --allow-vendor-change arm-toolchain-for-linux
+$ sudo zypper up arm-toolchain-for-linux
 ```
+
 
 ### Ubuntu Linux 22.04 and 24.04
 
@@ -162,8 +163,7 @@ to install into the current directory:
 $ bash user_install.sh --yes .
 ```
 
-As a convenience, you can also download and run the script in a single command
-using Bash process substitution:
+For convenience, you can also download and run the script in a single command:
 
 ```
 $ bash <(curl -L https://developer.arm.com/-/cdn-downloads/permalink/Arm-Toolchain-for-Linux/Package/user_install.sh) --yes <installation_directory>
@@ -175,5 +175,4 @@ For example, to install into the current directory:
 $ bash <(curl -L https://developer.arm.com/-/cdn-downloads/permalink/Arm-Toolchain-for-Linux/Package/user_install.sh) --yes .
 ```
 
-After completion, the `opt` directory tree is unpacked into the installation
-directory.
+After completion, the `opt` directory tree is unpacked into the installation directory.


### PR DESCRIPTION
Update the Arm Toolchain for Linux installation documentation to use the current arm-toolchains-repository package flow, add the repository signing key change note, and clarify non-root installation options.