### PR TITLE
[ATfE] Remove "pre" version suffix

### DIFF
--- a/arm-software/embedded/CMakeLists.txt
+++ b/arm-software/embedded/CMakeLists.txt
@@ -474,7 +474,6 @@ set(CLANG_TEST_EXTRA_ARGS "@${clang_lit_xfails_path}")
 # Product code 'E' for Embedded.
 # This must be done before the llvm directory is included.
 set(LLVM_TOOLCHAIN_PROJECT_CODE "E")
-set(LLVM_TOOLCHAIN_VERSION_SUFFIX "pre")
 include(${CMAKE_CURRENT_SOURCE_DIR}/../shared/cmake/generate_toolchain_id.cmake)
 
 add_subdirectory(


### PR DESCRIPTION
The pre-release suffix was originally added to differentiate main branch builds from release branch builds. This is no longer necessary, as upstream LLVM now always starts release branches at a minor version number of 1, so that a minor version number of 0 indicates the main branch was used. ATfE follows upstream version numbering, so the tag can be retired.