### PR TITLE
[Downstream Change] Update pass for OptimizationLevel changes

### DIFF
--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -2245,7 +2245,7 @@ PassBuilder::buildLTODefaultPipeline(OptimizationLevel Level,
 //  #409
   if (LTOExtraLoopUnroll) {
     LoopPassManager OmaxLPM;
-    OmaxLPM.addPass(LoopFullUnrollPass(Level.getSpeedupLevel(),
+    OmaxLPM.addPass(LoopFullUnrollPass(static_cast<int>(Level),
                                        /*OnlyWhenForced=*/!PTO.LoopUnrolling,
                                        PTO.ForgetAllSCEVInLoopUnroll));
     FPM.addPass(


### PR DESCRIPTION
The upstream commit 5d5dd83a547ea555a8eada2dfd50413c44a3cfe9 replaced OptimizationLevel with a simple enum class, removing the getSpeedupLevel() function. The downstream use of the function can be replaced with a cast.

Downstream issue: #409