### PR TITLE
Rename release workflows and correct commands

### DIFF
--- a/.github/workflows/create_arm_release_branch.yml
+++ b/.github/workflows/create_arm_release_branch.yml
@@ -7,7 +7,7 @@
 # The branch should be created at the commit where the upstream branch
 # point was merged on to the arm-software branch.
 
-name: "[arm-toolchain] Create arm-toolchain Release Branch"
+name: "(arm-toolchain) Create arm-toolchain Release Branch"
 on:
   workflow_dispatch:
     inputs:
@@ -42,8 +42,9 @@ jobs:
       - name: Create Branch
         run: |
           llvmbranchpoint=$(git merge-base remotes/llvm/main remotes/llvm/release/${{ inputs.release-version }}.x)
-          armbranchpoint=$(git rev-list --reverse --ancestry-path --min-parents=2 $llvmbranchpoint..arm-software | head -n 1)
-          if echo $armbranchpoint | grep "[0-9a-z]\{40\}"; then
+          echo "release/${{ inputs.release-version }}.x branched at $llvmbranchpoint"
+          armbranchpoint=$(git rev-list --reverse --ancestry-path --min-parents=2 "$llvmbranchpoint"..arm-software | head -n 1)
+          if echo "$armbranchpoint" | grep "[0-9a-z]\{40\}"; then
             echo "Branching release/arm-software/${{ inputs.release-version }}.x at $armbranchpoint"
           else
             echo "Unexpected git rev-list result: $armbranchpoint"

--- a/.github/workflows/create_arm_release_branch.yml
+++ b/.github/workflows/create_arm_release_branch.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ steps.generate-token.outputs.token }}
+          fetch-depth: 0
       - name: Configure Git Identity
         run: |
           git config --local user.name "github-actions[bot]"

--- a/.github/workflows/create_llvm_release_branch.yml
+++ b/.github/workflows/create_llvm_release_branch.yml
@@ -5,7 +5,7 @@
 
 # This workflow creates a branch to mirror an upstream LLVM release branch.
 
-name: "[arm-toolchain] Create LLVM Release Branch"
+name: "(arm-toolchain) Create LLVM Release Branch"
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
The `[` character is sorted after alphabetical ones, so use `(` instead to try to keep the workflows at the top of the list.

Additionally, add missing double quotes to the run commands and increase the fetch depth to fetch all history in order to find the branch points.