### PR TITLE
Enable sync and automerging on 23.x branches

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -19,8 +19,8 @@ jobs:
         branches:
           - from_branch: main
             to_branch: arm-software
-          - from_branch: release/22.x
-            to_branch: release/arm-software/22.x
+          - from_branch: release/23.x
+            to_branch: release/arm-software/23.x
     steps:
       - name: Configure Access Token
         uses: actions/create-github-app-token@v3

--- a/.github/workflows/sync_from_upstream.yml
+++ b/.github/workflows/sync_from_upstream.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'arm/arm-toolchain'
     strategy:
       matrix:
-        branch: [main, release/22.x]
+        branch: [main, release/23.x]
     env:
       UPSTREAM_REMOTE: https://github.com/llvm/llvm-project.git
     steps:


### PR DESCRIPTION
The `release/23.x` branch has been created to track upstream LLVM's `release/23.x` branch, so the sync workflow can start syncing it with changes. Likewise the `release/arm-software/23.x` branch has been created, which changes can now be merged on to.