### PR TITLE
Tag workflow names

### DIFF
--- a/.github/workflows/atfe_nightly_build_and_test.yml
+++ b/.github/workflows/atfe_nightly_build_and_test.yml
@@ -12,7 +12,7 @@
 # a matrix strategy. Each build+test pair runs as a separate job,
 # allowing for concurrency and clear traceability of failures.
 
-name: ATfE Nightly Build and Test
+name: (ATfE) Nightly Build and Test
 
 on:
   workflow_dispatch:

--- a/.github/workflows/atfe_post_merge.yml
+++ b/.github/workflows/atfe_post_merge.yml
@@ -12,7 +12,7 @@
 # It builds and tests the Arm Toolchain for Embedded (ATfE) to validate that the
 # merged changes do not introduce regressions and that the build remains stable.
 
-name: ATfE Post-Merge
+name: (ATfE) Post-Merge
 
 on:
   # Trigger when a pull request is closed

--- a/.github/workflows/atfe_pre_merge.yml
+++ b/.github/workflows/atfe_pre_merge.yml
@@ -11,7 +11,7 @@
 # changes do not introduce regressions and that the build remains stable before
 # merging.
 
-name: ATfE Pre-Merge
+name: (ATfE) Pre-Merge
 
 on:
   # Trigger when a pull request is opened, updated, or reopened

--- a/.github/workflows/atfl_nightly_build_and_test.yml
+++ b/.github/workflows/atfl_nightly_build_and_test.yml
@@ -12,7 +12,7 @@
 # a matrix strategy. Each build+test pair runs as a separate job,
 # allowing for concurrency and clear traceability of failures.
 
-name: ATfL Nightly Build and Test
+name: (ATfL) Nightly Build and Test
 
 on:
   workflow_dispatch:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,7 +1,7 @@
 # This workflow executes the automerge python script to automatically merge
 # changes from the `main` branch of upstream LLVM into the `arm-software`
 # branch of the arm/arm-toolchain repository.
-name: Automerge
+name: (arm-toolchain) Automerge
 on:
   workflow_run:
     workflows: [Sync from Upstream LLVM]

--- a/.github/workflows/check_downstream_changes.yml
+++ b/.github/workflows/check_downstream_changes.yml
@@ -11,7 +11,7 @@
 # itself are part of the check.
 # The script requires the GitHub CLI to be available, and authenticated.
 
-name: check-downstream-changes
+name: (arm-toolchain) check-downstream-changes
 
 on:
   # Trigger whenever a pull request is opened or changed.

--- a/.github/workflows/sync_from_upstream.yml
+++ b/.github/workflows/sync_from_upstream.yml
@@ -1,7 +1,7 @@
 # This workflow fetches changes from relevant branches from the
 # llvm/llvm-project repository (upstream) into the corresponding branches
 # in the arm/arm-toolchain repository (downstream), keeping them in sync.
-name: Sync from Upstream LLVM
+name: (arm-toolchain) Sync from Upstream LLVM
 on:
   schedule:
     - cron: '0,30 * * * *'


### PR DESCRIPTION
Adding a tag using round brackets at the start of each workflow name makes it easier to differentiate the arm-toolchain workflows from the disabled LLVM workflows, and sorts them at the top of the actions list.