### PR TITLE
[ATfE] Use fixed picolibc version for 23.x release branch

### DIFF
--- a/arm-software/embedded/versions.json
+++ b/arm-software/embedded/versions.json
@@ -8,8 +8,8 @@
   "repos": {
     "picolibc": {
       "url": "https://github.com/picolibc/picolibc.git",
-      "tagType": "branch",
-      "tag": "main"
+      "tagType": "commithash",
+      "tag": "7971005696aff8bc8244dfce503510705fed1fd7"
     },
     "newlib": {
       "url": "https://github.com/RTEMS/sourceware-mirror-newlib-cygwin.git",


### PR DESCRIPTION
To prevent any breaking changes in the release, use a fixed picolibc commit instead of pulling the latest.