### PR TITLE
Use updated names in workflow triggers

### DIFF
--- a/.github/workflows/atfe_post_merge.yml
+++ b/.github/workflows/atfe_post_merge.yml
@@ -44,7 +44,7 @@ on:
 
   # Trigger after the Automerge workflow completes
   workflow_run:
-    workflows: [Automerge]
+    workflows: ["(arm-toolchain) Automerge"]
     types: [completed]
 
 jobs:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -4,7 +4,7 @@
 name: (arm-toolchain) Automerge
 on:
   workflow_run:
-    workflows: [Sync from Upstream LLVM]
+    workflows: ["(arm-toolchain) Sync from Upstream LLVM"]
     types:
       - completed
   workflow_dispatch:


### PR DESCRIPTION
Some GitHub workflows are triggered by other workflows completing. A couple were still referencing the old names, which were changed in a7b3fcb5. These have been changed to their new versions.