### PR TITLE
[ATfE] Remove stale libc++ lit cmake-bridge config load.

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/llvm-libc++-embedded.cfg.in
+++ b/arm-software/embedded/arm-runtimes/test-support/llvm-libc++-embedded.cfg.in
@@ -1,8 +1,6 @@
 # This testing configuration handles running the test suite against LLVM's libc++
 # using a static library.
 
-lit_config.load_config(config, '@CMAKE_CURRENT_BINARY_DIR@/cmake-bridge.cfg')
-
 config.name = 'libc++-@RUNTIME_VARIANT_NAME@'
 
 config.substitutions.append(('%{libc-include}', '@CMAKE_INSTALL_PREFIX@/include'))


### PR DESCRIPTION
Remove the stale `cmake-bridge.cfg` load from the ATfE libc++ embedded lit configuration.

Upstream llvm-project PR https://github.com/llvm/llvm-project/pull/209638 changed libc++ test configuration generation. As a result, `cmake-bridge.cfg` is no longer generated for libc++ tests.