### PR TITLE
Allow ATfE get_fvps.sh to use curl as well as wget.

### DIFF
--- a/arm-software/embedded/fvp/get_fvps.sh
+++ b/arm-software/embedded/fvp/get_fvps.sh
@@ -68,13 +68,22 @@ FILENAME_BASE_AEM_A=$(basename "$URL_BASE_AEM_A")
 FILENAME_BASE_AEM_R=$(basename "$URL_BASE_AEM_R")
 FILENAME_CRYPTO=$(basename "$URL_CRYPTO")
 
+if which curl >&/dev/null; then
+    download_to() { curl --retry 5 --no-clobber "$1" -o "$2"; }
+elif which wget >&/dev/null; then
+    download_to() { wget --no-clobber "$1" -O "$2"; }
+else
+    echo "Need one of curl and wget installed to download files" >&2
+    exit 1
+fi
+
 mkdir -p download
 pushd download
 DOWNLOAD_DIR="$(pwd)"
-wget --content-disposition --no-clobber "${URL_CORSTONE_310}"
-wget --content-disposition --no-clobber "${URL_BASE_AEM_A}"
-wget --content-disposition --no-clobber "${URL_BASE_AEM_R}"
-wget --content-disposition --no-clobber "${URL_CRYPTO}"
+download_to "${URL_CORSTONE_310}" "${FILENAME_CORSTONE_310}"
+download_to "${URL_BASE_AEM_A}" "${FILENAME_BASE_AEM_A}"
+download_to "${URL_BASE_AEM_R}" "${FILENAME_BASE_AEM_R}"
+download_to "${URL_CRYPTO}" "${FILENAME_CRYPTO}"
 popd
 
 mkdir -p install


### PR DESCRIPTION
We auto-detect via `which`, and use whichever tool we can find on PATH, with an appropriate command line in each case.

My general impression is that curl seems more 'in fashion', so this change should enable more users to run this script without having to install an extra package specially.

I've also removed the use of `wget --content-disposition` (which saves the file under a name specified by the remote web server), so that instead we specify the output file name explicitly in each download to be the same name that the rest of the script will expect. curl does have an equivalent option (`-J`), but it seems more robust to avoid depending on the web server matching this script at all.

I added the `--retry 5` option in curl because in one of my test downloads, the web server cut off the connection after a couple of Mb. In that situation wget defaults to trying again to download from where the first attempt left off, but curl doesn't unless you tell it to.