### PR TITLE
[ATfE] Set version number in VERSION.txt

### DIFF
--- a/arm-software/embedded/cmake/VERSION.txt.in
+++ b/arm-software/embedded/cmake/VERSION.txt.in
@@ -1,4 +1,4 @@
-Arm Toolchain for Embedded ${armtoolchain_VERSION}
+Arm Toolchain for Embedded ${ArmToolchainForEmbedded_VERSION}
 
 Sources:
 * arm-toolchain: https://github.com/arm/arm-toolchain (commit ${armtoolchain_COMMIT})


### PR DESCRIPTION
The script generating the VERSION.txt used the incorrect variable name, so the version number was missing from the file.

The version can be found in the ArmToolchainForEmbedded_VERSION variable, which is autogenerated by the project command. This was correctly being passed down to the script generating the VERSION.txt file, however the file template referenced a different variable name that didn't exist.