### PR TITLE
Revert "[ATfL][build.sh] Do not optimize with PGO for this release..."

### DIFF
--- a/arm-software/linux/build.sh
+++ b/arm-software/linux/build.sh
@@ -497,7 +497,8 @@ product_build() {
     } > flags.cmake
 
     run_command cmake "${CMAKE_ARGS[@]}" -G Ninja "${SOURCES_DIR}/llvm" \
-        -C "${SOURCES_DIR}/flang/cmake/caches/BOLT.cmake" \
+        -DPGO_BUILD_CONFIGURATION="${cmake_caches}/BOLT.cmake" \
+        -C "${SOURCES_DIR}/flang/cmake/caches/BOLT-PGO.cmake" \
         -C flags.cmake \
         -DBUILD_SHARED_LIBS=False \
         -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
- wrong CMake cache used (original instead of locally generated)
- it fails with assertion anyway when doing BOLT without PGO

This reverts commit 368b1d683b48e1315023191bc04d5768b9e827fe.