### PR TITLE
[ATfE] Add new atomic tests to xfail

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/xfails.py
+++ b/arm-software/embedded/arm-runtimes/test-support/xfails.py
@@ -294,6 +294,8 @@ def main():
                 "std/atomics/atomics.ref/exchange.pass.cpp",
                 "std/atomics/atomics.ref/fetch_add.pass.cpp",
                 "std/atomics/atomics.ref/fetch_and.pass.cpp",
+                "std/atomics/atomics.ref/fetch_max.pass.cpp"
+                "std/atomics/atomics.ref/fetch_min.pass.cpp"
                 "std/atomics/atomics.ref/fetch_or.pass.cpp",
                 "std/atomics/atomics.ref/fetch_sub.pass.cpp",
                 "std/atomics/atomics.ref/fetch_xor.pass.cpp",
@@ -312,6 +314,10 @@ def main():
                 "std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_add_explicit.pass.cpp",
                 "std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_and.pass.cpp",
                 "std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_and_explicit.pass.cpp",
+                "std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_max.pass.cpp",
+                "std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_max_explicit.pass.cpp",
+                "std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_min.pass.cpp",
+                "std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_min_explicit.pass.cpp",
                 "std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_or.pass.cpp",
                 "std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_or_explicit.pass.cpp",
                 "std/atomics/atomics.types.operations/atomics.types.operations.req/atomic_fetch_sub.pass.cpp",


### PR DESCRIPTION
These new tests fail on architectures that do not support lock free atomics.