### PR TITLE
Revert "[ATfE] Add xfails for a crash in llvm-libc Float128 tests."

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/xfails.py
+++ b/arm-software/embedded/arm-runtimes/test-support/xfails.py
@@ -935,23 +935,6 @@ def main():
             ],
             description="Clang ARM AAPCS mislowers variadic vector type arguments (LLVMAENG-6240)",
         ),
-        XFail(
-            name="Crash on Float128 to integer conversion",
-            testnames=[
-                "src/__support/FPUtil/libc.test.src.__support.FPUtil.float128_test.__hermetic__.__build__",
-            ],
-            result=NewResult.XFAILED,
-            project="llvmlibc",
-            variants=[
-                "armv7m_hard_fpv5_d16_exn_rtti_unaligned_size",
-                "armv7m_hard_fpv5_d16_unaligned_size",
-                "armv8m.main_hard_fp_exn_rtti_unaligned_size",
-                "armv8m.main_hard_fp_unaligned_size",
-                "armv8m.main_soft_nofp_exn_rtti_unaligned_size",
-                "armv8m.main_soft_nofp_unaligned_size",
-            ],
-            description="Float128 conversion to integer performs an out-of-bounds array access (LLVMAENG-6784)",
-        ),
     ]
 
     tests_to_xfail = []


### PR DESCRIPTION
This reverts commit 9fed2ae6e612f1628a70fb9e5bbed82d23d63561 (and its followup fix 6b9b76d48eee6dd2c24bf1b168990ec3766c91f8).

Upstream PR https://github.com/llvm/llvm-project/pull/211593 has fixed the test failure.