### PR TITLE
[ATfE] Fix xfail entry that missed commas

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/xfails.py
+++ b/arm-software/embedded/arm-runtimes/test-support/xfails.py
@@ -294,8 +294,8 @@ def main():
                 "std/atomics/atomics.ref/exchange.pass.cpp",
                 "std/atomics/atomics.ref/fetch_add.pass.cpp",
                 "std/atomics/atomics.ref/fetch_and.pass.cpp",
-                "std/atomics/atomics.ref/fetch_max.pass.cpp"
-                "std/atomics/atomics.ref/fetch_min.pass.cpp"
+                "std/atomics/atomics.ref/fetch_max.pass.cpp",
+                "std/atomics/atomics.ref/fetch_min.pass.cpp",
                 "std/atomics/atomics.ref/fetch_or.pass.cpp",
                 "std/atomics/atomics.ref/fetch_sub.pass.cpp",
                 "std/atomics/atomics.ref/fetch_xor.pass.cpp",


### PR DESCRIPTION
The original xfail PR lacked some commas. The resulting xfail description was still valid Python code hence no error was raised.