### PR TITLE
Revert "[ATfL][docs] Keep the changelog in sync with the release branch"

### DIFF
--- a/arm-software/linux/CHANGELOG.md
+++ b/arm-software/linux/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [23.1.0]
 
-- The `armclang` executable binary now optimized with BOLT.
+- The `armclang` and `armflang` executable binaries are now optimized with BOLT.
 
 ## [22.1.0]
 


### PR DESCRIPTION
We will be bolting armflang finally.

This reverts commit c19daed6237d1691f9fe0b11d167105e6bb41877.