### PR TITLE
[Downstream Change][RFC][BOLT] Enable lite mode by default on AArch64 (#205545)

### DIFF
--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -2460,8 +2460,8 @@ void RewriteInstance::adjustCommandLineOptions() {
   BC->UseCompactAligner = opts::UseCompactAligner;
   BC->X86AlignBranchBoundaryHotOnly = opts::X86AlignBranchBoundaryHotOnly;
 
-  if (BC->isX86() && opts::Lite.getNumOccurrences() == 0 && !opts::StrictMode &&
-      !opts::UseOldText)
+  if ((BC->isX86() || BC->isAArch64()) && opts::Lite.getNumOccurrences() == 0 &&
+      !opts::StrictMode && !opts::UseOldText)
     opts::Lite = true;
 
   if (opts::Lite && opts::UseOldText) {

--- a/bolt/test/AArch64/long-jmp-one-stub.s
+++ b/bolt/test/AArch64/long-jmp-one-stub.s
@@ -6,7 +6,7 @@
 # RUN: %clang %cflags -O0 %t.o -o %t.exe -Wl,-q
 # RUN: link_fdata %s %t.o %t.fdata
 # RUN: llvm-bolt %t.exe -o %t.bolt  \
-# RUN:   --data %t.fdata  | FileCheck %s
+# RUN:   --data %t.fdata --lite=0 | FileCheck %s
 
 # CHECK: BOLT-INFO: Inserted 1 stubs in the hot area and 0 stubs in the cold area. 
 


### PR DESCRIPTION
Cherry-pick from commit b6b9603c7675fff5ec9befacf54391a516fc723c

This is the default on the main branch and will remain so for the next release.

Downstream issue: #995