### PR TITLE
[automerge.py] Print git's error message when it fails.

### DIFF
--- a/arm-software/ci/automerge.py
+++ b/arm-software/ci/automerge.py
@@ -48,9 +48,13 @@ class Git:
     def run_cmd(self, args: list[str], check: bool = True) -> str:
         git_cmd = ["git", "-C", str(self.repo_path)] + args
         logger.debug("Running git command: %s", git_cmd)
-        git_process = subprocess.run(
-            git_cmd, check=check, capture_output=True, text=True
-        )
+        try:
+            git_process = subprocess.run(
+                git_cmd, check=check, capture_output=True, text=True
+            )
+        except subprocess.CalledProcessError as e:
+            logger.debug("Stdout:\n%s\nStderr:\n%s", e.output, e.stderr)
+            raise
         logger.debug("Stdout:\n%s\nStderr:\n%s", git_process.stdout, git_process.stderr)
         return git_process.stdout
 


### PR DESCRIPTION
The default dump of `subprocess.CalledProcessError` only prints the exit status. But when git exits with status 1, it generally printed a message explaining the problem in more detail. That message currently isn't getting as far as our log files.

The process's output is _available_ in the `CalledProcessError`; it just isn't printed by default. Now we print it before letting the exception propagate.