### PR TITLE
[llvmlibc-support] Fix new hard-float PCS error from clang

### DIFF
--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions.cpp
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions.cpp
@@ -15,5 +15,5 @@
 #else
 // ARMv4T
 // TODO: fill in stub functions once we can start testing LLVM-libc
-extern "C" [[gnu::weak]] void _platform_setup_exceptions() {}
+extern "C" [[gnu::weak]] PLATFORM_SETUP_PCS void _platform_setup_exceptions() {}
 #endif

--- a/arm-software/embedded/llvmlibc-support/crt0/exceptions_a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/exceptions_a.h
@@ -29,7 +29,7 @@ extern "C" {
 // Floating-point instructions aren't enabled yet
 [[gnu::target("no-fpregs")]]
 #endif
-[[gnu::weak]] void
+PLATFORM_SETUP_PCS [[gnu::weak]] void
 _platform_setup_exceptions() {
 #if __ARM_ARCH_PROFILE == 'A'
   VBAR = reinterpret_cast<unsigned long>(&vector_table);

--- a/arm-software/embedded/llvmlibc-support/crt0/system_registers_a.h
+++ b/arm-software/embedded/llvmlibc-support/crt0/system_registers_a.h
@@ -11,6 +11,7 @@
 #ifndef BOOTCODE_SYSTEM_REGISTERS_A_H
 #define BOOTCODE_SYSTEM_REGISTERS_A_H
 
+#include "platform_setup_pcs.h"
 #include "system_registers_common.h"
 #include <arm_acle.h>
 
@@ -27,17 +28,17 @@ enum class ExceptionLevel : unsigned long {
 
 class CurrentEL_Class : public SysRegBase<CurrentEL_Class> {
 public:
-  [[clang::always_inline]] static unsigned long read() {
+  [[clang::always_inline]] static PLATFORM_SETUP_PCS unsigned long read() {
     return __arm_rsr("CurrentEL");
   }
 
   Field<2, 3> EL;
 
-  [[clang::always_inline]] ExceptionLevel value() {
+  [[clang::always_inline]] PLATFORM_SETUP_PCS ExceptionLevel value() {
     return static_cast<ExceptionLevel>(static_cast<unsigned long>(EL));
   }
 
-  [[clang::always_inline]] bool is(ExceptionLevel level) {
+  [[clang::always_inline]] PLATFORM_SETUP_PCS bool is(ExceptionLevel level) {
     return value() == level;
   }
 };
@@ -46,15 +47,17 @@ extern CurrentEL_Class CurrentEL;
 
 class TPIDR2_Class : public SysRegBase<TPIDR2_Class> {
 public:
-  [[clang::always_inline]] static unsigned long read() {
+  [[clang::always_inline]] static PLATFORM_SETUP_PCS unsigned long read() {
     return __arm_rsr64("s3_3_c13_c0_5");
   }
 
-  [[clang::always_inline]] static void write(unsigned long val) {
+  [[clang::always_inline]] static PLATFORM_SETUP_PCS void
+  write(unsigned long val) {
     __arm_wsr64("s3_3_c13_c0_5", val);
   }
 
-  [[clang::always_inline]] TPIDR2_Class &operator=(unsigned long val) {
+  [[clang::always_inline]] PLATFORM_SETUP_PCS TPIDR2_Class &
+  operator=(unsigned long val) {
     write(val);
     return *this;
   }
@@ -62,15 +65,17 @@ public:
 
 class SVCR_Class : public SysRegBase<SVCR_Class> {
 public:
-  [[clang::always_inline]] static unsigned long read() {
+  [[clang::always_inline]] static PLATFORM_SETUP_PCS unsigned long read() {
     return __arm_rsr64("s3_3_c4_c2_2");
   }
 
-  [[clang::always_inline]] static void write(unsigned long val) {
+  [[clang::always_inline]] static PLATFORM_SETUP_PCS void
+  write(unsigned long val) {
     __arm_wsr64("s3_3_c4_c2_2", val);
   }
 
-  [[clang::always_inline]] SVCR_Class &operator=(unsigned long val) {
+  [[clang::always_inline]] PLATFORM_SETUP_PCS SVCR_Class &
+  operator=(unsigned long val) {
     write(val);
     return *this;
   }
@@ -84,15 +89,17 @@ extern SVCR_Class SVCR;
 
 class SMCR_EL2_Class : public SysRegBase<SMCR_EL2_Class> {
 public:
-  [[clang::always_inline]] static unsigned long read() {
+  [[clang::always_inline]] static PLATFORM_SETUP_PCS unsigned long read() {
     return __arm_rsr64("s3_4_c1_c2_6");
   }
 
-  [[clang::always_inline]] static void write(unsigned long val) {
+  [[clang::always_inline]] static PLATFORM_SETUP_PCS void
+  write(unsigned long val) {
     __arm_wsr64("s3_4_c1_c2_6", val);
   }
 
-  [[clang::always_inline]] SMCR_EL2_Class &operator=(unsigned long val) {
+  [[clang::always_inline]] PLATFORM_SETUP_PCS SMCR_EL2_Class &
+  operator=(unsigned long val) {
     write(val);
     return *this;
   }
@@ -102,15 +109,17 @@ public:
 
 class SMCR_EL3_Class : public SysRegBase<SMCR_EL3_Class> {
 public:
-  [[clang::always_inline]] static unsigned long read() {
+  [[clang::always_inline]] static PLATFORM_SETUP_PCS unsigned long read() {
     return __arm_rsr64("s3_6_c1_c2_6");
   }
 
-  [[clang::always_inline]] static void write(unsigned long val) {
+  [[clang::always_inline]] static PLATFORM_SETUP_PCS void
+  write(unsigned long val) {
     __arm_wsr64("s3_6_c1_c2_6", val);
   }
 
-  [[clang::always_inline]] SMCR_EL3_Class &operator=(unsigned long val) {
+  [[clang::always_inline]] PLATFORM_SETUP_PCS SMCR_EL3_Class &
+  operator=(unsigned long val) {
     write(val);
     return *this;
   }
@@ -170,9 +179,10 @@ template <SysRegName Name> class SysReg : public SysRegBase<SysReg<Name>> {
 public:
   // The system register read/write intrinsics need a string literal argument,
   // so we have to specialize the read/write functions for each register name.
-  static unsigned long read();
-  static void write(unsigned long val);
-  [[clang::always_inline]] SysReg &operator=(unsigned long val) {
+  static PLATFORM_SETUP_PCS unsigned long read();
+  static PLATFORM_SETUP_PCS void write(unsigned long val);
+  [[clang::always_inline]] PLATFORM_SETUP_PCS SysReg &
+  operator=(unsigned long val) {
     write(val);
     return *this;
   }
@@ -182,13 +192,13 @@ public:
 
 #define REGNAME(X, Y)                                                          \
   template <>                                                                  \
-  [[clang::always_inline]] inline unsigned long                          \
+  [[clang::always_inline]] inline PLATFORM_SETUP_PCS unsigned long             \
   SysReg<SysRegName::X>::read() {                                              \
     return __arm_rsr64(#X "_EL0");                                             \
   }                                                                            \
   template <>                                                                  \
-  [[clang::always_inline]] inline void SysReg<SysRegName::X>::write(     \
-      unsigned long val) {                                                     \
+  [[clang::always_inline]] inline PLATFORM_SETUP_PCS void                      \
+  SysReg<SysRegName::X>::write(unsigned long val) {                            \
     __arm_wsr64(#X "_EL0", val);                                               \
   }
 EL0_REGNAMES
@@ -196,13 +206,13 @@ EL0_REGNAMES
 
 #define REGNAME(X, Y)                                                          \
   template <>                                                                  \
-  [[clang::always_inline]] inline unsigned long                          \
+  [[clang::always_inline]] inline PLATFORM_SETUP_PCS unsigned long             \
   SysReg<SysRegName::X>::read() {                                              \
     return __arm_rsr64(#X "_EL1");                                             \
   }                                                                            \
   template <>                                                                  \
-  [[clang::always_inline]] inline void SysReg<SysRegName::X>::write(     \
-      unsigned long val) {                                                     \
+  [[clang::always_inline]] inline PLATFORM_SETUP_PCS void                      \
+  SysReg<SysRegName::X>::write(unsigned long val) {                            \
     __arm_wsr64(#X "_EL1", val);                                               \
   }
 EL1_REGNAMES
@@ -210,7 +220,7 @@ EL1_REGNAMES
 
 #define REGNAME(X, Y)                                                          \
   template <>                                                                  \
-  [[clang::always_inline]] inline unsigned long                          \
+  [[clang::always_inline]] inline PLATFORM_SETUP_PCS unsigned long             \
   SysReg<SysRegName::X>::read() {                                              \
     if (CurrentEL.is(ExceptionLevel::EL3))                                     \
       return __arm_rsr64(#X "_EL3");                                           \
@@ -218,8 +228,8 @@ EL1_REGNAMES
       return __arm_rsr64(#X "_EL2");                                           \
   }                                                                            \
   template <>                                                                  \
-  [[clang::always_inline]] inline void SysReg<SysRegName::X>::write(     \
-      unsigned long val) {                                                     \
+  [[clang::always_inline]] inline PLATFORM_SETUP_PCS void                      \
+  SysReg<SysRegName::X>::write(unsigned long val) {                            \
     if (CurrentEL.is(ExceptionLevel::EL3))                                     \
       __arm_wsr64(#X "_EL3", val);                                             \
     else                                                                       \
@@ -232,13 +242,13 @@ EL23_REGNAMES
 
 #define REGNAME(X, Y)                                                          \
   template <>                                                                  \
-  [[clang::always_inline]] inline unsigned long                          \
+  [[clang::always_inline]] inline PLATFORM_SETUP_PCS unsigned long             \
   SysReg<SysRegName::X>::read() {                                              \
     return __arm_rsr(Y);                                                       \
   }                                                                            \
   template <>                                                                  \
-  [[clang::always_inline]] inline void SysReg<SysRegName::X>::write(     \
-      unsigned long val) {                                                     \
+  [[clang::always_inline]] inline PLATFORM_SETUP_PCS void                      \
+  SysReg<SysRegName::X>::write(unsigned long val) {                            \
     __arm_wsr(Y, val);                                                         \
   }
 EL0_REGNAMES

--- a/arm-software/embedded/llvmlibc-support/platform.h
+++ b/arm-software/embedded/llvmlibc-support/platform.h
@@ -15,6 +15,8 @@
 #ifndef LLVMET_LLVMLIBC_SUPPORT_PLATFORM_H
 #define LLVMET_LLVMLIBC_SUPPORT_PLATFORM_H
 
+#include "platform_setup_pcs.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -24,7 +26,7 @@ extern "C" {
 // needed, this is where to do it.
 
 // Set up the exceptions table and enable relevant interrupts.
-void _platform_setup_exceptions(void);
+PLATFORM_SETUP_PCS void _platform_setup_exceptions(void);
 
 // Set up the Memory Management Unit and caches.
 void _platform_setup_memory(void);

--- a/arm-software/embedded/llvmlibc-support/platform_setup_pcs.h
+++ b/arm-software/embedded/llvmlibc-support/platform_setup_pcs.h
@@ -1,0 +1,21 @@
+//
+// Copyright (c) 2026, Arm Limited and affiliates.
+//
+// Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+// Tiny header file to define the PCS modifier required for functions run
+// before startup code enables the FPU.
+
+#ifndef LLVMET_LLVMLIBC_SUPPORT_PLATFORM_SETUP_PCS_H
+#define LLVMET_LLVMLIBC_SUPPORT_PLATFORM_SETUP_PCS_H
+
+#ifndef __ARM_ARCH_ISA_A64
+#define PLATFORM_SETUP_PCS __attribute__((pcs("aapcs")))
+#else
+#define PLATFORM_SETUP_PCS
+#endif
+
+#endif // LLVMET_LLVMLIBC_SUPPORT_PLATFORM_SETUP_PCS_H


### PR DESCRIPTION
Commit b834b9eb8349dab has added a new diagnostic in clang, faulting any function definition which formally has the hard-float PCS but is compiled in a mode where the FP registers are unavailable. Calls _to_ such a function without the FP registers available are also faulted. This applies even if the function's type uses no floating-point registers anyway (e.g. `void f(void)`), and also even if the function is marked `[[clang::always_inline]]`.

The new diagnostic therefore affects our early setup function `_platform_setup_exceptions()`, which is marked
`[[gnu::target("no-fpregs")]]` because it runs before the FPU is enabled. It also affects the write to the VBAR register inside that function, because that's really the `operator=` method of a C++ class wrapping the system register. I've marked all those system register wrappers as soft-float, rather than trying to find just the one that caused the immediate problem.