### PR TITLE
[ATfE] Add expected output of samples to READMEs

### DIFF
--- a/arm-software/embedded/newlib-samples/src/baremetal-semihosting-newlib/README.md
+++ b/arm-software/embedded/newlib-samples/src/baremetal-semihosting-newlib/README.md
@@ -8,3 +8,8 @@ using `newlib`.
 
 A recent version of QEMU is required to run the sample, because of the
 dependency on details of semihosting implementation in QEMU.
+
+Running the sample using `make run` should print a message:
+```
+Hello World!
+```

--- a/arm-software/embedded/newlib-samples/src/cpp-baremetal-semihosting-newlib/Makefile
+++ b/arm-software/embedded/newlib-samples/src/cpp-baremetal-semihosting-newlib/Makefile
@@ -22,9 +22,9 @@ hello.elf: *.cpp
 %.hex: %.elf
 	$(BIN_PATH)/llvm-objcopy -O ihex $< $@
 
-run: hello.hex
+run: hello.hex hello-exn.hex
 	qemu-system-arm -M mps2-an386 -semihosting -nographic -device loader,file=hello.hex
-	qemu-system-arm -M mps2-an386 -semihosting -nographic -device loader,file=hello-exn.elf
+	qemu-system-arm -M mps2-an386 -semihosting -nographic -device loader,file=hello-exn.hex
 
 debug: hello.hex
 	qemu-system-arm -M mps2-an386 -semihosting -nographic -device loader,file=$< -s -S

--- a/arm-software/embedded/newlib-samples/src/cpp-baremetal-semihosting-newlib/README.md
+++ b/arm-software/embedded/newlib-samples/src/cpp-baremetal-semihosting-newlib/README.md
@@ -9,7 +9,14 @@ to build C++ programs with `newlib`.
 A recent version of QEMU is required to run the sample, because of the
 dependency on details of semihosting implementation in QEMU.
 
-Running the sample using `make run` should print a message:
+Running the sample using `make run` should compile and run two files,
+`hello.hex` and `hello-exn.hex`.
+`hello.hex`, compiled without exceptions, will print a message indicating the
+exception was not caught:
+```
+Hello World!
+```
+Whereas `hello-exn.hex` compiled with exceptions, will catch it:
 ```
 Hello World!
 Exception caught.

--- a/arm-software/embedded/newlib-samples/src/cpp-baremetal-semihosting-newlib/README.md
+++ b/arm-software/embedded/newlib-samples/src/cpp-baremetal-semihosting-newlib/README.md
@@ -8,3 +8,9 @@ to build C++ programs with `newlib`.
 
 A recent version of QEMU is required to run the sample, because of the
 dependency on details of semihosting implementation in QEMU.
+
+Running the sample using `make run` should print a message:
+```
+Hello World!
+Exception caught.
+```

--- a/arm-software/embedded/samples/src/baremetal-semihosting-aarch64/README.md
+++ b/arm-software/embedded/samples/src/baremetal-semihosting-aarch64/README.md
@@ -4,3 +4,8 @@ This sample shows how to use semihosting with
 [QEMU Arm System emulator](https://www.qemu.org/docs/master/system/target-arm.html)
 targeting the
 [Raspberry Pi 3 Model B](https://www.qemu.org/docs/master/system/arm/raspi.html).
+
+Running the sample using `make run` should print a message:
+```
+Hello World!
+```

--- a/arm-software/embedded/samples/src/baremetal-semihosting-fvp/README.md
+++ b/arm-software/embedded/samples/src/baremetal-semihosting-fvp/README.md
@@ -21,3 +21,8 @@ files.
 The sample also downloads and uses ATfE multilib testing Python wrapper scripts
 from ATfE repository to construct the full FVP command line. The actual command
 line is printed before the invocation so that it can be inspected and reused.
+
+Running the sample using `make run` should print a message:
+```
+Hello World!
+```

--- a/arm-software/embedded/samples/src/baremetal-semihosting/README.md
+++ b/arm-software/embedded/samples/src/baremetal-semihosting/README.md
@@ -4,3 +4,10 @@ This sample shows how to use semihosting with
 [QEMU Arm System emulator](https://www.qemu.org/docs/master/system/target-arm.html)
 targeting the
 [micro:bit board model](https://www.qemu.org/2019/05/22/microbit/).
+
+Running the sample using `make run` should print a message followed by the
+first seven significant figures of π:
+```
+Hello World!
+pi = 3.141593
+```

--- a/arm-software/embedded/samples/src/baremetal-uart/README.md
+++ b/arm-software/embedded/samples/src/baremetal-uart/README.md
@@ -5,4 +5,9 @@ This sample shows how to use
 without semihosting targeting the
 [micro:bit board model](https://www.qemu.org/2019/05/22/microbit/).
 
+Running the sample using `make run` should print a message:
+```
+Hello World!
+```
+
 _Note: The sample code hangs at the end of the execution in an infinite loop! Use ``Ctrl-a x`` to terminate._

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-cfi/README.md
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-cfi/README.md
@@ -5,9 +5,24 @@ This sample shows how to use
 sanitizer to detect certain kinds of undefined behavior 
 that can subvert the control flow of C++ code at run-time.
 
-The default target `make build` enables CFI, 
-to see the behavior without CFI use the following commands:
+The default target `make build` enables CFI, so that `make run` will encounter
+a hard fault during execution and display a partial register dump, e.g:
 ```
-make build-no-cfi
-make run
+ARM fault: hardfault
+        R0:   0x00000001
+        R1:   0x20000d3c
+        R2:   0x2000093c
+        R3:   0x00000000
+        R12:  0x00000000
+        LR:   0x00011407
+        PC:   0x000115ec
+        XPSR: 0x01000000
+make: [Makefile:28: run] Error 1 (ignored)
+```
+Running `make build-no-cfi` followed by `make run` will demonstrate the
+behavior without CFI, displaying a message as the undefined behaviour is not
+caught:
+```
+Bad
+C++ CFI sample
 ```

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-cfi/README.md
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-cfi/README.md
@@ -19,6 +19,8 @@ ARM fault: hardfault
         XPSR: 0x01000000
 make: [Makefile:28: run] Error 1 (ignored)
 ```
+_Note: The format of the dump may differ depending on the C library used._
+
 Running `make build-no-cfi` followed by `make run` will demonstrate the
 behavior without CFI, displaying a message as the undefined behaviour is not
 caught:

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-exceptions/README.md
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-exceptions/README.md
@@ -2,3 +2,15 @@
 
 This sample shows and tests that C++ exceptions and corresponding
 library variant selection work correctly.
+
+Running the sample using `make run` should compile and run two files,
+`hello.hex` and `hello-exn.hex`.
+`hello.hex`, compiled without exceptions, will print a message indicating the
+exception was not caught:
+```
+No exceptions.
+```
+Whereas `hello-exn.hex` compiled with exceptions, will catch it:
+```
+Exception caught.
+```

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-kasan/README.md
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-kasan/README.md
@@ -25,6 +25,25 @@ exposed to the C library for data, heap, and stack.
 | 3 | Heap use-after-free through `calloc` and `free` wrapping |
 | 4 | Heap buffer overflow after `realloc` wrapping |
 
+For example:
+```
+C++ KASan shadow-memory sample
+Test 1: automatic stack redzone
+Writing one byte past a stack buffer
+KASAN: invalid store at 0x200037a0, size 0x00000001, offset 0x00000000 (recovered)
+Test 2: heap buffer overflow
+Writing one byte past a malloc allocation
+KASAN: invalid store at 0x20000868, size 0x00000001, offset 0x00000000 (recovered)
+Test 3: heap use-after-free
+Freeing an allocation
+Attempting use-after-free
+KASAN: invalid store at 0x200008a0, size 0x00000001, offset 0x00000000 (recovered)
+Test 4: realloc buffer overflow
+Writing one byte past a resized malloc allocation
+KASAN: invalid store at 0x20000938, size 0x00000001, offset 0x00000000 (recovered)
+All KASan tests completed
+```
+
 ## Customizing the runtime
 
 ### Shadow memory

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-prof/README.md
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-prof/README.md
@@ -4,4 +4,26 @@ This sample shows how to use instrumentation to emit profile data
 and use it to show code coverage.
 
 Use `make run` to build with instrumentation, run and collect the raw profile data,
-then output a visualization of the code coverage.
+then output a visualization of the code coverage, e.g:
+```
+    1|       |/* Copyright (c) 2023-2025, Arm Limited and affiliates.
+    2|       | *
+    3|       | * Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+    4|       | * See https://llvm.org/LICENSE.txt for license information.
+    5|       | * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */
+    6|       |
+    7|       |#include <iostream>
+    8|       |#include <vector>
+    9|       |
+   10|       |int main()
+   11|      1|{
+   12|      1|    std::vector vec {1, 2, 3, 4, 5};
+   13|       |
+   14|      5|    for (auto num: vec) {
+   15|      5|        std::cout << num << " ";
+   16|      5|    }
+   17|      1|    std::cout << std::endl;
+   18|       |
+   19|      1|    return 0;
+   20|      1|}
+```

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-ubsan/README.md
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-ubsan/README.md
@@ -7,10 +7,26 @@ to detect undefined behavior in C++ code at run-time.
 UBSan has two supported modes of operation: trap and minimal runtime, 
 see `Makefile` for the respective command line options.
 
-The default `make build` uses the minimal runtime mode.
-
-Use the following commands to invoke the trap mode:
+The default `make build` uses the minimal runtime mode. Running `make run`
+will then display a message indicating the undefined behavior was
+detected, e.g:
 ```
-make build-trap
-make run
+UBSAN: add-overflow (recovered)
+
+C++ UBSan sample
+```
+Alternatively, `make build-trap` followed by `make run` will instead invoke
+the trap mode, so that the same exits with a hardfault and partial register
+dump, e.g:
+```
+ARM fault: hardfault
+        R0:   0x00000001
+        R1:   0x20000418
+        R2:   0x20000018
+        R3:   0x00000000
+        R12:  0x00000000
+        LR:   0x000031c7
+        PC:   0x00003008
+        XPSR: 0x01000000
+make: *** [Makefile:26: run] Error 1
 ```

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting-ubsan/README.md
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting-ubsan/README.md
@@ -30,3 +30,4 @@ ARM fault: hardfault
         XPSR: 0x01000000
 make: *** [Makefile:26: run] Error 1
 ```
+_Note: The format of the dump may differ depending on the C library used._

--- a/arm-software/embedded/samples/src/cpp-baremetal-semihosting/README.md
+++ b/arm-software/embedded/samples/src/cpp-baremetal-semihosting/README.md
@@ -5,3 +5,8 @@ This sample shows how to use semihosting with
 targeting the
 [micro:bit board model](https://www.qemu.org/2019/05/22/microbit/)
 to build C++ programs.
+
+Running the sample using `make run` should print a sequence of numbers:
+```
+1 2 3 4 5
+```


### PR DESCRIPTION
Some of the samples have quite different behaviour, so it may not be obvious when they are not working correctly, especially when some deliberately exit with a hardfault. Adding the expected output to the README files should make it easier to see when a sample is doing what it is meant to.

This also contains a small fix to the `cpp-baremetal-semihosting-newlib` makefile, since only one of the images was being converted to hex.