### PR TITLE
Stop triggering 23.x automerge after upstream sync

### DIFF
--- a/.github/workflows/automerge_23x.yml
+++ b/.github/workflows/automerge_23x.yml
@@ -3,10 +3,6 @@
 # branch of the arm/arm-toolchain repository.
 name: (arm-toolchain) Automerge (23.x)
 on:
-  workflow_run:
-    workflows: ["(arm-toolchain) Sync from Upstream LLVM"]
-    types:
-      - completed
   workflow_dispatch:
     inputs:
       target-commit:


### PR DESCRIPTION
As upstream LLVM 23 approaches release, the automatic trigger for automerging to the `release/arm-software/23.x` branch should be stopped so that the downstream release branch can be manually merged up to the release tag, but no further.