### PR TITLE
[ATfE] Extend the test timeout multipliers to qemu runs

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -578,14 +578,12 @@ if(C_LIBRARY STREQUAL picolibc)
         # * Armv6m big-endian
         # * Armv7m big-endian
         # * Armv8.1-M Main PACBTI optimized for code size
-        if(TEST_EXECUTOR STREQUAL fvp)
-            if(VARIANT MATCHES "^(armebv|^armv8\.1m\.main.*pacret.*size)")
-                set(timeout_multiplier 5)
-            else()
-                set(timeout_multiplier 2)
-            endif()
-            set(picolibc_timeout_arg --slow-tests-timeout-multiplier ${timeout_multiplier})
+        if(VARIANT MATCHES "^(armebv|^armv8\.1m\.main.*pacret.*size)")
+            set(timeout_multiplier 5)
+        else()
+            set(timeout_multiplier 2)
         endif()
+        set(picolibc_timeout_arg --slow-tests-timeout-multiplier ${timeout_multiplier})
 
         # Step target to run the picolibc test via meson.
         ExternalProject_Add_Step(


### PR DESCRIPTION
`test-many-malloc` is a picolibc test that times out in Jenkins even when run with qemu.

The timeout multiplier feature we had so far only worked for variants whose tests ran on FVP.

Since this is the first time we have a test that takes too long with qemu, it's time to have the timeout multipliers work irrespective of the runner used.