### PR TITLE
[ATfE] Add rule for second file in newlib sample

### DIFF
--- a/arm-software/embedded/newlib-samples/src/cpp-baremetal-semihosting-newlib/Makefile
+++ b/arm-software/embedded/newlib-samples/src/cpp-baremetal-semihosting-newlib/Makefile
@@ -13,10 +13,12 @@ LD_SCRIPT=-T ../../ldscripts/newlib-cm4.ld
 LIBS=-latomic-fallback
 STARTUP=../../startup/startup_ARMCM4.S
 
-build: hello.elf
+build: hello.elf hello-exn.elf
 
 hello.elf: *.cpp
 	$(BIN_PATH)/clang++ $(TARGET) $(CRT_SEMIHOST_NEWLIB) $(CPP_FLAGS) -g $(LD_SCRIPT) $(LIBS) -nostartfiles -o hello.elf $(STARTUP) $^
+
+hello-exn.elf: *.cpp
 	$(BIN_PATH)/clang++ $(TARGET) $(CRT_SEMIHOST_NEWLIB) -fexceptions -DTEST_EXN -g $(LD_SCRIPT) $(LIBS) -nostartfiles -o hello-exn.elf $(STARTUP) $^
 
 %.hex: %.elf


### PR DESCRIPTION
In the cpp-baremetal-semihosting-newlib sample, the hello-exn.hex rule will not be valid unless hello.elf is built first, since that rule builds both hello.elf and hello-exn.elf. To solve this, hello-exn.elf has been given a separate rule.