### PR TITLE
[ATfL] Build bootstrap compiler at O3

### DIFF
--- a/arm-software/linux/build.sh
+++ b/arm-software/linux/build.sh
@@ -508,6 +508,7 @@ product_build() {
         -DLLVM_BUILD_DOCS=ON \
         -DLLVM_ENABLE_SPHINX=ON \
         -DSPHINX_WARNINGS_AS_ERRORS=OFF \
+        -DLLVM_SPHINX_THREADS=1 \
         -DLLVM_ENABLE_PROJECTS="llvm;clang;flang;bolt;lld" \
         -DLLVM_ENABLE_RUNTIMES="compiler-rt;flang-rt;libunwind;openmp" \
         -DRUNTIMES_CMAKE_ARGS="-DCMAKE_CXX_FLAGS=-stdlib++-isystem${ATFL_DIR}/include/c++/v1 -D_LIBCPP_VERBOSE_ABORT_NOT_NOEXCEPT;-DCMAKE_EXE_LINKER_FLAGS=${libs};-DCMAKE_MODULE_LINKER_FLAGS=${libs};-DCMAKE_SHARED_LINKER_FLAGS=${libs}" \

--- a/arm-software/linux/build.sh
+++ b/arm-software/linux/build.sh
@@ -373,9 +373,9 @@ bootstrap_compiler_build() {
         -C flags.cmake \
         -DBUILD_SHARED_LIBS=False \
         -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_ASM_FLAGS_RELEASE="-O2 -DNDEBUG" \
-        -DCMAKE_CXX_FLAGS_RELEASE="-O2 -DNDEBUG" \
-        -DCMAKE_C_FLAGS_RELEASE="-O2 -DNDEBUG" \
+        -DCMAKE_ASM_FLAGS_RELEASE="-O3 -DNDEBUG" \
+        -DCMAKE_CXX_FLAGS_RELEASE="-O3 -DNDEBUG" \
+        -DCMAKE_C_FLAGS_RELEASE="-O3 -DNDEBUG" \
         -DCMAKE_INSTALL_PREFIX="${BUILD_DIR}/bootstrap_compiler" \
         -DLLVM_ENABLE_LLD=OFF \
         -DLLVM_ENABLE_LIBCXX=OFF \


### PR DESCRIPTION
GCC14 + RHEL-10/Ubuntu-24 triggers an LLD unit test failure at `O2` so build the bootstrap stage at `O3 NDEBUG`.