### PR TITLE
[ATfE] Enable ATfE downstream libc++ fstream support for LLVM libc

### DIFF
--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -192,7 +192,7 @@ typedef basic_fstream<wchar_t> wfstream;
 #  include <__config>
 
 // Downstream issue: #375 (Enable fstream independently of filesystem)
-#  if _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION || _LIBCPP_LIBC_NEWLIB
+#  if _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION || _LIBCPP_LIBC_NEWLIB || _LIBCPP_LIBC_LLVM_LIBC
 
 #    include <__algorithm/max.h>
 #    include <__assert>
@@ -250,6 +250,8 @@ public:
   using native_handle_type = void*; // HANDLE
 #      elif __has_include(<unistd.h>)
   using native_handle_type = int; // POSIX file descriptor
+#      elif _LIBCPP_LIBC_LLVM_LIBC
+  using native_handle_type = FILE*;
 #      else
 #        error "Provide a native file handle!"
 #      endif
@@ -286,6 +288,8 @@ public:
     return std::__filebuf_windows_native_handle(__file_);
 #      elif __has_include(<unistd.h>)
     return fileno(__file_);
+#      elif _LIBCPP_LIBC_LLVM_LIBC
+    return __file_;
 #      else
 #        error "Provide a way to determine the file native handle!"
 #      endif
@@ -1668,7 +1672,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  endif // _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
+#  endif // _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION || _LIBCPP_LIBC_NEWLIB || _LIBCPP_LIBC_LLVM_LIBC
 
 #endif // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)
 

--- a/libcxx/src/ios.instantiations.cpp
+++ b/libcxx/src/ios.instantiations.cpp
@@ -58,7 +58,7 @@ template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ostringstream<char
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_istringstream<char>;
 
 // Downstream issue: #375 (Enable fstream independently of filesystem)
-#if _LIBCPP_HAS_FILESYSTEM || _LIBCPP_LIBC_NEWLIB
+#if _LIBCPP_HAS_FILESYSTEM || _LIBCPP_LIBC_NEWLIB || _LIBCPP_LIBC_LLVM_LIBC
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ifstream<char>;
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ofstream<char>;
 template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_filebuf<char>;


### PR DESCRIPTION
This depends on new LLVM libc embedding API and ATfE semihosting implementation for it.

Downstream issue: #375