### PR TITLE
[ATfE] Avoid overloading | operator in run_fvp script

### DIFF
--- a/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
+++ b/arm-software/embedded/arm-runtimes/test-support/run_fvp.py
@@ -9,6 +9,7 @@ from os import environ
 from os import path
 from dataclasses import dataclass
 from platform import uname
+from typing import Optional
 import shlex
 
 
@@ -18,7 +19,7 @@ class FVP:
     tarmac_plugin: str
     crypto_plugin: str
     cmdline_param: str
-    stderr_param: str | None = None
+    stderr_param: Optional[str] = None
 
 
 MODELS = {


### PR DESCRIPTION
Overloading `|` in this way requires Python 3.10, however LLVM's minimum Python version is still only 3.8.