### PR TITLE
[ATfE] Use the same timeout multiplier for slow picolibc tests

### DIFF
--- a/arm-software/embedded/arm-runtimes/CMakeLists.txt
+++ b/arm-software/embedded/arm-runtimes/CMakeLists.txt
@@ -578,12 +578,7 @@ if(C_LIBRARY STREQUAL picolibc)
         # * Armv6m big-endian
         # * Armv7m big-endian
         # * Armv8.1-M Main PACBTI optimized for code size
-        if(VARIANT MATCHES "^(armebv|^armv8\.1m\.main.*pacret.*size)")
-            set(timeout_multiplier 5)
-        else()
-            set(timeout_multiplier 2)
-        endif()
-        set(picolibc_timeout_arg --slow-tests-timeout-multiplier ${timeout_multiplier})
+        set(picolibc_timeout_arg --slow-tests-timeout-multiplier 5)
 
         # Step target to run the picolibc test via meson.
         ExternalProject_Add_Step(


### PR DESCRIPTION
The armv7a variant is also slow running the many-malloc test. Rather than continuing to expand the regex customizing timeouts to variants, it is simpler to use the same increased multiplier now that it is specific to the slow tests.