### PR TITLE
Revert "[ATfL][build.sh] Try if the use of the lld linker still needs to be forced"

### DIFF
--- a/arm-software/linux/build.sh
+++ b/arm-software/linux/build.sh
@@ -356,8 +356,8 @@ print_forced_cmake_flags_cache() {
 }
 
 bootstrap_compiler_default_config() {
-    rm -f "${BUILD_DIR}"/bootstrap_compiler/bin/clang.cfg
-    rm -f "${BUILD_DIR}"/bootstrap_compiler/bin/clang++.cfg
+    echo "-fuse-ld=lld" >"${BUILD_DIR}"/bootstrap_compiler/bin/clang.cfg
+    echo "-fuse-ld=lld" >"${BUILD_DIR}"/bootstrap_compiler/bin/clang++.cfg
 }
 
 bootstrap_compiler_build() {


### PR DESCRIPTION
Our RHEL-8 builds are failing without the `-fuse-ld=lld` workaround.
This may get fixed by an upstream PR under review (see https://github.com/arm/arm-toolchain/pull/1048#issuecomment-5636729253) but that may take some time so revert arm/arm-toolchain#1042 until then so that we get our builds green. 